### PR TITLE
[Heist] Add jailed/dead if player does not succeed.

### DIFF
--- a/cogs/heist.py
+++ b/cogs/heist.py
@@ -810,7 +810,7 @@ class Heist:
                 results.append(good_thing[0].format(player.name))
             else:
                 bad_thing = random.choice(bad_out)
-                dropout_msg = bad_thing[0] + "```\n{0} dropped out of the game.```"
+                dropout_msg = bad_thing[0] + "```\n{0} dropped out of the game " + "({}).```".format(bad_thing[1])
                 self.failure_handler(settings, player, bad_thing[1])
                 settings["Crew"].pop(player.id)
                 bad_out.remove(bad_thing)


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Add jailed/dead if player does not succeed.  Addresses #57.