### PR TITLE
[Catgirl] Add id to image so it has a unique id and file extension

### DIFF
--- a/cogs/catgirl.py
+++ b/cogs/catgirl.py
@@ -111,7 +111,7 @@ class Catgirl_beta:
         randCatgirl = random.choice(self.catgirls)
         embed = discord.Embed()
         embed.colour = discord.Colour.red()
-        embed.title = "Catgirl"
+        embed.title = "Catgirl"+randCatgirl[JSON_pixivID]
         embed.url = randCatgirl[JSON_imageURLKey]
         if JSON_isPixiv in randCatgirl and randCatgirl[JSON_isPixiv]:
             source = "[{}]({})".format("Original Source","http://www.pixiv.net/member_illust.php?mode=medium&illust_id="+randCatgirl[JSON_pixivID])


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [X] Enhancement
- [ ] New feature

### Description of the changes
Adds a file extension to catgirl pictures so they can be reposted properly. The ID added to the catgirls also ensures each is unique so catgirls will never be rewritten in case a it isn't automatically renamed.