### PR TITLE
[General] Check words for urban command.

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -278,11 +278,22 @@ class General:
             await self.bot.say("I need the `Embed links` permission "
                                "to send this")
 
-    @commands.command()
-    async def urban(self, *, search_terms : str, definition_number : int=1):
+    @commands.command(pass_context=True)
+    async def urban(self, ctx, *, search_terms : str, definition_number : int=1):
         """Urban Dictionary search
 
         Definition number must be between 1 and 10"""
+        word_filter = self.bot.get_cog("WordFilter")
+        if not word_filter:
+            await self.bot.say("Word Filter is not loaded.  Please load this "
+                               "cog and try again!")
+            return
+
+        if word_filter.containsFilterableWords( ctx.message ):
+            await self.bot.say("You have filtered out words in your query. "
+                               "Please check your query and try again!")
+            return
+
         def encode(s):
             return quote_plus(s, encoding='utf-8', errors='replace')
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -289,7 +289,7 @@ class General:
                                "cog and try again!")
             return
 
-        if word_filter.containsFilterableWords( ctx.message ):
+        if word_filter.containsFilterableWords(ctx.message):
             await self.bot.say("You have filtered out words in your query. "
                                "Please check your query and try again!")
             return


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Addresses #93 for `renurban`.
- Add context to command.
- Couple with WordFilter.
- Check to make sure WordFilter cog is loaded.

Below is a screenshot in action with a commonly filtered word:
![Screenshot](https://user-images.githubusercontent.com/6710854/45198244-7369af80-b21a-11e8-8744-01a5ceafbf17.jpg)
