### PR TITLE
[Stars] Add raw URL to quickly jump.

### DIFF
--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -158,10 +158,11 @@ class Stars:
         emoji = self.star_emoji(starrers)
         # base = '%s ID: %s' % (msg.channel.mention, msg.id)
 
+        msgUrl = "https://discordapp.com/channels/%s/%s/%s" % (msg.server.id, msg.channel.id, msg.id)
         if starrers > 1:
-            base = '%s **%s** %s ID: %s' % (emoji, starrers, msg.channel.mention, msg.id)
+            base = '%s **%s** %s ID: %s\nJump: %s' % (emoji, starrers, msg.channel.mention, msg.id, msgUrl)
         else:
-            base = '%s %s ID: %s' % (emoji, msg.channel.mention, msg.id)
+            base = '%s %s ID: %s\nJump: %s' % (emoji, msg.channel.mention, msg.id, msgUrl)
 
 
         content = msg.content


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Addresses #97.  Thought it wasn't possible before, but @zapsel proved me wrong.  Quickly jump to starred message with raw URL.  Only thing is that we can't put link in embed, or it opens in a new window, or use `[text](url)` cause it doesn't work outside of embed.  Tested on Windows desktop app, Android app, and iOS app working.
![ShareX-gif](https://user-images.githubusercontent.com/6710854/45261616-ed856a00-b3bb-11e8-82fd-28747be73b37.gif)
