### PR TITLE
[WordFilter] Blacklist commands

### DIFF
--- a/cogs/spoilers.py
+++ b/cogs/spoilers.py
@@ -98,7 +98,7 @@ class Spoilers: # pylint: disable=too-many-instance-attributes
 
             if (msgId in self.onCooldown.keys() and
                     user.id in self.onCooldown[msgId].keys() and
-                    self.onCooldown[msgId][user.id] > datetime.now):
+                    self.onCooldown[msgId][user.id] > datetime.now()):
                 return
             msg = self.messages[msgId]
             embed = discord.Embed()

--- a/cogs/word_filter.py
+++ b/cogs/word_filter.py
@@ -204,6 +204,51 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
 
         self._updateSettings(self.settings)
 
+    #########################################
+    # COMMANDS - COMMAND BLACKLIST SETTINGS #
+    #########################################
+    @wordFilter.group(name="command", pass_context=True, no_pm=True,
+                      aliases=["cmd"])
+    @checks.mod_or_permissions(manage_messages=True)
+    async def _command(self, ctx):
+        """Blacklist command settings. (help for more info)
+        Settings for controlling filtering on commands.
+        """
+        if str(ctx.invoked_subcommand).lower() == "word_filter command":
+            await send_cmd_help(ctx)
+
+    @_command.command(name="add", pass_context=True, no_pm=True)
+    async def _commandAdd(self, ctx):
+        """Add a command to the blacklist.
+        If the invoked command contains any filtered words, the entire message
+        is filtered and the contents of the message will be sent back to the
+        user via DM.
+        """
+        pass
+
+    @_command.command(name="del", pass_context=True, no_pm=True,
+                      aliases=["delete", "remove"])
+    @checks.mod_or_permissions(manage_messages=True)
+    async def _commandRemove(self, ctx, channelName: str):
+        """Remove a command from the blacklist.
+        The command that is removed from the list will be filtered as normal
+        messages.  That is, if the invoked command contains any filtered words,
+        only the filtered words will be censored and replaced (as opposed to the
+        entire message being deleted).
+        """
+        pass
+
+    @_command.command(name="list", pass_context=True, no_pm=True,
+                      aliases=["ls"])
+    @checks.mod_or_permissions(manage_messages=True)
+    async def _commandList(self, ctx):
+        """List blacklisted commands.
+        If the commands on this list are invoked with any filtered words, the
+        entire message is filtered and the contents of the message will be sent
+        back to the user via DM.
+        """
+        pass
+
     ############################################
     # COMMANDS - CHANNEL WHITELISTING SETTINGS #
     ############################################

--- a/cogs/word_filter.py
+++ b/cogs/word_filter.py
@@ -28,7 +28,8 @@ def checkFileSystem():
             print("Word Filter: Creating folder: {} ...".format(folder))
             os.makedirs(folder)
 
-    files = ["data/word_filter/filter.json",
+    files = ["data/word_filter/command_blacklist",
+             "data/word_filter/filter.json",
              "data/word_filter/settings.json",
              "data/word_filter/whitelist.json"]
     for file in files:
@@ -45,6 +46,8 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
         self.bot = bot
         self.lock = Lock()
         self.lockSettings = Lock()
+        self.commandBlacklist = dataIO.load_json("data/word_filter/"
+                                                 "command_blacklist.json")
         self.filters = dataIO.load_json("data/word_filter/filter.json")
         self.whitelist = dataIO.load_json("data/word_filter/whitelist.json")
         self.settings = dataIO.load_json("data/word_filter/settings.json")
@@ -62,6 +65,15 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
         try:
             dataIO.save_json("data/word_filter/filter.json", newObj)
             self.filters = dataIO.load_json("data/word_filter/filter.json")
+        finally:
+            self.lock.release()
+
+    def _updateCommandBlacklist(self, newObj):
+        self.lock.acquire()
+        try:
+            dataIO.save_json("data/word_filter/command_blacklist.json", newObj)
+            self.commandBlacklist = dataIO.load_json("data/word_filter/"
+                                                     "command_blacklist.json")
         finally:
             self.lock.release()
 

--- a/cogs/word_filter.py
+++ b/cogs/word_filter.py
@@ -429,6 +429,9 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
         if not self.checkMessageServerAndChannel(msg):
             return
 
+        # If message contains the blacklisted command, set a flag.
+        # Check this using split()
+
         guildId = msg.server.id
 
         filteredWords = self.filters[guildId]
@@ -453,6 +456,12 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
 
         if filteredMsg == originalMsg:
             return # no bad words, don't need to do anything else
+
+        # If the it contains a filtered word AND the blacklisted command flag was
+        # set above, then:
+        # - Delete the message,
+        # - Notify on the channel that the message was filtered without showing context
+        # - DM user with the filtered context as per what we see usually.
 
         if (filteredMsg != originalMsg and oneWord) or allFiltered:
             await self.bot.delete_message(msg) # delete message but don't show full message context

--- a/cogs/word_filter.py
+++ b/cogs/word_filter.py
@@ -18,6 +18,11 @@ from cogs.utils.paginator import Pages
 
 COLOUR = discord.Colour
 LOGGER = None
+PATH = "data/word_filter/"
+PATH_BLACKLIST = PATH + "command_blacklist.json"
+PATH_FILTER = PATH + "filter.json"
+PATH_SETTINGS = PATH + "settings.json"
+PATH_WHITELIST = PATH + "whitelist.json"
 
 def checkFileSystem():
     """Check if the folders/files are created."""
@@ -28,10 +33,8 @@ def checkFileSystem():
             print("Word Filter: Creating folder: {} ...".format(folder))
             os.makedirs(folder)
 
-    files = ["data/word_filter/command_blacklist.json",
-             "data/word_filter/filter.json",
-             "data/word_filter/settings.json",
-             "data/word_filter/whitelist.json"]
+    files = [PATH_BLACKLIST, PATH_FILTER, PATH_SETTINGS, PATH_WHITELIST]
+
     for file in files:
         if not os.path.exists(file):
             #build a default filter.json
@@ -46,11 +49,10 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
         self.bot = bot
         self.lock = Lock()
         self.lockSettings = Lock()
-        self.commandBlacklist = dataIO.load_json("data/word_filter/"
-                                                 "command_blacklist.json")
-        self.filters = dataIO.load_json("data/word_filter/filter.json")
-        self.whitelist = dataIO.load_json("data/word_filter/whitelist.json")
-        self.settings = dataIO.load_json("data/word_filter/settings.json")
+        self.commandBlacklist = dataIO.load_json(PATH_BLACKLIST)
+        self.filters = dataIO.load_json(PATH_FILTER)
+        self.whitelist = dataIO.load_json(PATH_WHITELIST)
+        self.settings = dataIO.load_json(PATH_SETTINGS)
         self.colours = [COLOUR.purple(),
                         COLOUR.red(),
                         COLOUR.blue(),
@@ -63,33 +65,32 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
     def _updateFilters(self, newObj):
         self.lock.acquire()
         try:
-            dataIO.save_json("data/word_filter/filter.json", newObj)
-            self.filters = dataIO.load_json("data/word_filter/filter.json")
+            dataIO.save_json(PATH_FILTER, newObj)
+            self.filters = dataIO.load_json(PATH_FILTER)
         finally:
             self.lock.release()
 
     def _updateCommandBlacklist(self, newObj):
         self.lock.acquire()
         try:
-            dataIO.save_json("data/word_filter/command_blacklist.json", newObj)
-            self.commandBlacklist = dataIO.load_json("data/word_filter/"
-                                                     "command_blacklist.json")
+            dataIO.save_json(PATH_BLACKLIST, newObj)
+            self.commandBlacklist = dataIO.load_json(PATH_BLACKLIST)
         finally:
             self.lock.release()
 
     def _updateWhitelist(self, newObj):
         self.lock.acquire()
         try:
-            dataIO.save_json("data/word_filter/whitelist.json", newObj)
-            self.whitelist = dataIO.load_json("data/word_filter/whitelist.json")
+            dataIO.save_json(PATH_WHITELIST, newObj)
+            self.whitelist = dataIO.load_json(PATH_WHITELIST)
         finally:
             self.lock.release()
 
     def _updateSettings(self, newObj):
         self.lockSettings.acquire()
         try:
-            dataIO.save_json("data/word_filter/settings.json", newObj)
-            self.settings = dataIO.load_json("data/word_filter/settings.json")
+            dataIO.save_json(PATH_SETTINGS, newObj)
+            self.settings = dataIO.load_json(PATH_SETTINGS)
         finally:
             self.lockSettings.release()
 

--- a/cogs/word_filter.py
+++ b/cogs/word_filter.py
@@ -62,34 +62,34 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
         #JSON keys for settings:
         self.keyToggleMod = "toggleMod"
 
-    def _updateFilters(self, newObj):
+    def _updateFilters(self):
         self.lock.acquire()
         try:
-            dataIO.save_json(PATH_FILTER, newObj)
+            dataIO.save_json(PATH_FILTER, self.filters)
             self.filters = dataIO.load_json(PATH_FILTER)
         finally:
             self.lock.release()
 
-    def _updateCommandBlacklist(self, newObj):
+    def _updateCommandBlacklist(self):
         self.lock.acquire()
         try:
-            dataIO.save_json(PATH_BLACKLIST, newObj)
+            dataIO.save_json(PATH_BLACKLIST, self.commandBlacklist)
             self.commandBlacklist = dataIO.load_json(PATH_BLACKLIST)
         finally:
             self.lock.release()
 
-    def _updateWhitelist(self, newObj):
+    def _updateWhitelist(self):
         self.lock.acquire()
         try:
-            dataIO.save_json(PATH_WHITELIST, newObj)
+            dataIO.save_json(PATH_WHITELIST, self.whitelist)
             self.whitelist = dataIO.load_json(PATH_WHITELIST)
         finally:
             self.lock.release()
 
-    def _updateSettings(self, newObj):
+    def _updateSettings(self):
         self.lockSettings.acquire()
         try:
-            dataIO.save_json(PATH_SETTINGS, newObj)
+            dataIO.save_json(PATH_SETTINGS, self.settings)
             self.settings = dataIO.load_json(PATH_SETTINGS)
         finally:
             self.lockSettings.release()
@@ -113,11 +113,11 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
             myDict = {}
             myDict[guildId] = []
             self.filters.update(myDict)
-            self._updateFilters(self.filters)
+            self._updateFilters()
 
         if word not in self.filters[guildId]:
             self.filters[guildId].append(word)
-            self._updateFilters(self.filters)
+            self._updateFilters()
             await self.bot.send_message(user,
                                         "`Word Filter:` `{0}` was added to the filter "
                                         "in the guild **{1}**".format(word, guildName))
@@ -147,7 +147,7 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
                                         "filter for guild **{1}**".format(word, guildName))
         else:
             self.filters[guildId].remove(word)
-            self._updateFilters(self.filters)
+            self._updateFilters()
             await self.bot.send_message(user,
                                         "`Word Filter:` `{0}` removed from the filter "
                                         "in the guild **{1}**".format(word, guildName))
@@ -194,7 +194,7 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
     @checks.mod_or_permissions(manage_messages=True)
     async def toggleMod(self, ctx):
         """Toggle global override of filters for server admins/mods."""
-        self._updateSettings(self.settings)
+        self._updateSettings()
         try:
             if self.settings[ctx.message.author.server.id][self.keyToggleMod] is True:
                 self.settings[ctx.message.author.server.id][self.keyToggleMod] = False
@@ -207,15 +207,13 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
                 self.settings[ctx.message.author.server.id] = {}
             self.settings[ctx.message.author.server.id][self.keyToggleMod] = True
             isSet = True
-        self._updateSettings(self.settings)
+        self._updateSettings()
         if isSet:
             await self.bot.say(":white_check_mark: Word Filter: Moderators (and "
                                "higher) **will not be** filtered.")
         else:
             await self.bot.say(":negative_squared_cross_mark: Word Filter: Moderators "
                                "(and higher) **will be** filtered.")
-
-        self._updateSettings(self.settings)
 
     #########################################
     # COMMANDS - COMMAND BLACKLIST SETTINGS #
@@ -243,11 +241,11 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
             myDict = {}
             myDict[guildId] = []
             self.commandBlacklist.update(myDict)
-            self._updateCommandBlacklist(self.commandBlacklist)
+            self._updateCommandBlacklist()
 
         if cmd not in self.commandBlacklist[guildId]:
             self.commandBlacklist[guildId].append(cmd)
-            self._updateCommandBlacklist(self.commandBlacklist)
+            self._updateCommandBlacklist()
             await self.bot.say(":white_check_mark: Word Filter: Command `{0}` is now "
                                "blacklisted.  It will have the entire message filtered "
                                "if it contains any filterable words, and its contents "
@@ -281,7 +279,7 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
                                "`{0}` wasn't on the blacklist.".format(cmd))
         else:
             self.commandBlacklist[guildId].remove(cmd)
-            self._updateCommandBlacklist(self.commandBlacklist)
+            self._updateCommandBlacklist()
             await self.bot.say(":white_check_mark: Word Filter: `{0}` removed from "
                                "the command blacklist.".format(cmd))
 
@@ -340,11 +338,11 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
             myDict = {}
             myDict[guildId] = []
             self.whitelist.update(myDict)
-            self._updateWhitelist(self.whitelist)
+            self._updateWhitelist()
 
         if channelName not in self.whitelist[guildId]:
             self.whitelist[guildId].append(channelName)
-            self._updateWhitelist(self.whitelist)
+            self._updateWhitelist()
             await self.bot.say(":white_check_mark: Word Filter: Channel with name "
                                "`{0}` will not be filtered.".format(channelName))
         else:
@@ -372,7 +370,7 @@ class WordFilter(): # pylint: disable=too-many-instance-attributes
                                "`{0}` was already not whitelisted.".format(channelName))
         else:
             self.whitelist[guildId].remove(channelName)
-            self._updateWhitelist(self.whitelist)
+            self._updateWhitelist()
             await self.bot.say(":white_check_mark: Word Filter: `{0}` removed from "
                                "the channel whitelist.".format(channelName))
 


### PR DESCRIPTION
### Type
- [x] Bugfix

### Description of the changes
For discussion first: no implementation yet.
To address the spoiler issue, add the ability to blacklist certain commands.
- If a command is blacklisted, and it doesn't contain filterable words, then it goes through as normal.
- If a command is blacklisted and it **does** contain filterable words, filter out the **entire** message and DM the user the context like we do normally.

Let me know what you all think about the proposed implementation.

Also added one minor fix for spoilers.