### PR TITLE
[Spoilers] Add auto-removal of reaction emoji back

### DIFF
--- a/cogs/spoilers.py
+++ b/cogs/spoilers.py
@@ -107,8 +107,19 @@ class Spoilers: # pylint: disable=too-many-instance-attributes
             if msgId in self.messages.keys():
                 server = discord.utils.get(self.bot.servers,
                                            id=payload["guild_id"])
+                channel = discord.utils.get(server.channels,
+                                            id=payload["channel_id"])
+                message = await self.bot.get_message(channel, msgId)
+
+                if payload["emoji"]["id"]:
+                    emoji = discord.Emoji(name=payload["emoji"]["name"],
+                                          id=payload["emoji"]["id"],
+                                          server=server)
+                else:
+                    emoji = payload["emoji"]["name"]
                 reactedUser = discord.utils.get(server.members,
                                                 id=payload["user_id"])
+                await self.bot.remove_reaction(message, emoji, reactedUser)
 
                 if (msgId in self.onCooldown.keys() and
                         reactedUser.id in self.onCooldown[msgId].keys() and


### PR DESCRIPTION
### Type

- [x] Enhancement

### Description of the changes
Bring back auto-removal of emoji reactions from reacting users for spoilers.

We handle emojis with 2 cases:
- Custom emojis: get the emoji id and name, and reconstruct the discord.Emoji object.
- Standard emojis: use the standard emoji name.