### PR TITLE
[RoleAssigner] Don't assign role if user already has one from list

### DIFF
--- a/cogs/role_assigner.py
+++ b/cogs/role_assigner.py
@@ -106,7 +106,10 @@ class RoleAssigner:
             roles.append(roleObject)
 
         for index, user in enumerate(users):
-            await self.bot.add_roles(user, roles[index % numberOfRoles])
+            anyRoles = [ i for i in user.roles if i in roles ]
+            if not anyRoles:
+                await self.bot.add_roles(user, roles[index % numberOfRoles])
+
         msg = ":white_check_mark: **Role Assigner - Assign:** Roles assigned"
         if role:
             msg += " to users with the {} role.".format(role.name)

--- a/cogs/role_assigner.py
+++ b/cogs/role_assigner.py
@@ -106,7 +106,7 @@ class RoleAssigner:
             roles.append(roleObject)
 
         for index, user in enumerate(users):
-            anyRoles = [ i for i in user.roles if i in roles ]
+            anyRoles = [i for i in user.roles if i in roles]
             if not anyRoles:
                 await self.bot.add_roles(user, roles[index % numberOfRoles])
 


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Fix issue where if a user was already assigned a role and we went to rerun `[p]ra assign`, it would assign another role.  This fixes it by skipping over the user.