### PR TITLE
[RoleAssigner] Add random command

### DIFF
--- a/cogs/role_assigner.py
+++ b/cogs/role_assigner.py
@@ -144,7 +144,8 @@ class RoleAssigner:
 
     @roleAssigner.command(name="random", pass_context=True)
     async def raRandom(self, ctx, fromRole: discord.Role, number: int,
-                       assignRole: discord.Role):
+                       assignRole: discord.Role,
+                       excludeFromRole: discord.Role=None):
         """Assign a role to some users from a certain role.
 
         Pick `number` of users from fromRole at random, and assign assignRole to
@@ -156,7 +157,13 @@ class RoleAssigner:
             return
 
         users = ctx.message.server.members
-        eligibleUsers = [user for user in users if fromRole in user.roles]
+        if excludeFromRole:
+            eligibleUsers = [user for user in users if fromRole in user.roles and
+                             excludeFromRole not in user.roles and assignRole not
+                             in user.roles]
+        else:
+            eligibleUsers = [user for user in users if fromRole in user.roles and
+                             assignRole not in user.roles]
 
         if number > len(eligibleUsers):
             # Assign role to all eligible users.
@@ -166,8 +173,15 @@ class RoleAssigner:
             random.shuffle(eligibleUsers)
             picked = eligibleUsers[0:number]
 
+        if not picked:
+            await self.bot.say(":negative_squared_cross_mark: **Role Assigner - "
+                               "Random:** Nobody was eligible to be assigned!")
+            return
+
         await self.bot.say(":white_check_mark: **Role Assigner - Random:** The "
-                           "following users were picked:")
+                           "following users were picked from the **{}** role and "
+                           "assigned to the role **{}**:"
+                           .format(fromRole.name, assignRole.name))
 
         msg = ""
         for user in picked:

--- a/cogs/role_assigner.py
+++ b/cogs/role_assigner.py
@@ -178,19 +178,24 @@ class RoleAssigner:
                                "Random:** Nobody was eligible to be assigned!")
             return
 
-        await self.bot.say(":white_check_mark: **Role Assigner - Random:** The "
-                           "following users were picked from the **{}** role and "
-                           "assigned to the role **{}**:"
-                           .format(fromRole.name, assignRole.name))
+        status = await self.bot.say(":hourglass: **Role Assigner - Random:** Randomly "
+                                    "picking users from the role **{}** and assigning "
+                                    "them to the role **{}**.  Please wait...\n"
+                                    "Users being assigned:"
+                                    .format(fromRole.name, assignRole.name))
 
-        msg = ""
+        msg = "**|** "
         for user in picked:
             await self.bot.add_roles(user, assignRole)
             if len(msg) > MAX_LENGTH:
                 await self.bot.say(msg)
-                msg = ""
-            msg += "{}\n".format(user.name)
+                msg = "**|** "
+            msg += "{} **|** ".format(user.name)
         await self.bot.say(msg)
+        msg = (":white_check_mark: **Role Assigner - Random:** The following users "
+               "were picked from the **{}** role and assigned to the role **{}**:"
+               .format(fromRole.name, assignRole.name))
+        await self.bot.edit_message(status, msg)
 
 def setup(bot):
     """Add the cog to the bot."""

--- a/cogs/role_assigner.py
+++ b/cogs/role_assigner.py
@@ -4,6 +4,7 @@ Randomly assigns roles to users.
 """
 
 import os # Used to create folder path.
+import random
 import itertools
 import discord
 from discord.ext import commands
@@ -11,6 +12,7 @@ from __main__ import send_cmd_help # pylint: disable=no-name-in-module
 from .utils import config, checks # pylint: disable=relative-beyond-top-level
 
 SAVE_FOLDER = "data/lui-cogs/roleAssigner"
+MAX_LENGTH = 2000 # For a message
 
 def checkFolder():
     """Used to create the data folder at first startup"""
@@ -144,11 +146,37 @@ class RoleAssigner:
     async def raRandom(self, ctx, fromRole: discord.Role, number: int,
                        assignRole: discord.Role):
         """Assign a role to some users from a certain role.
-        
+
         Pick `number` of users from fromRole at random, and assign assignRole to
         those users.
         """
-        pass
+        if number <= 0:
+            await self.bot.say(":negative_squared_cross_mark: **Role Assigner - "
+                               "Random:** Please enter a positive number!")
+            return
+
+        users = ctx.message.server.members
+        eligibleUsers = [user for user in users if fromRole in user.roles]
+
+        if number > len(eligibleUsers):
+            # Assign role to all eligible users.
+            picked = eligibleUsers
+        else:
+            # Randomize and select the first `number` users.
+            random.shuffle(eligibleUsers)
+            picked = eligibleUsers[0:number]
+
+        await self.bot.say(":white_check_mark: **Role Assigner - Random:** The "
+                           "following users were picked:")
+
+        msg = ""
+        for user in picked:
+            await self.bot.add_roles(user, assignRole)
+            if len(msg) > MAX_LENGTH:
+                await self.bot.say(msg)
+                msg = ""
+            msg += "{}\n".format(user.name)
+        await self.bot.say(msg)
 
 def setup(bot):
     """Add the cog to the bot."""

--- a/cogs/role_assigner.py
+++ b/cogs/role_assigner.py
@@ -140,6 +140,16 @@ class RoleAssigner:
             msg += "."
         await self.bot.edit_message(msgId, msg)
 
+    @roleAssigner.command(name="random", pass_context=True)
+    async def raRandom(self, ctx, fromRole: discord.Role, number: int,
+                       assignRole: discord.Role):
+        """Assign a role to some users from a certain role.
+        
+        Pick `number` of users from fromRole at random, and assign assignRole to
+        those users.
+        """
+        pass
+
 def setup(bot):
     """Add the cog to the bot."""
     checkFolder()

--- a/cogs/role_assigner.py
+++ b/cogs/role_assigner.py
@@ -145,7 +145,7 @@ class RoleAssigner:
     @roleAssigner.command(name="random", pass_context=True)
     async def raRandom(self, ctx, fromRole: discord.Role, number: int,
                        assignRole: discord.Role,
-                       excludeFromRole: discord.Role=None):
+                       excludeFromRole: discord.Role = None):
         """Assign a role to some users from a certain role.
 
         Pick `number` of users from fromRole at random, and assign assignRole to

--- a/pylintrc
+++ b/pylintrc
@@ -548,7 +548,7 @@ valid-metaclass-classmethod-first-arg=cls
 [DESIGN]
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Add command to assign X users from a role to another role.
Usage: `renra random <fromRole> <number> <assignRole>` will assign `number` of users from `fromRole` to `assignRole`.