### PR TITLE
[Pylint] Hold version at 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5.2"
 install:
   - pip install -r requirements.txt
-  - pip install pylint
+  - pip install pylint==2.2.0
   - pip install mysqlclient
 script:
   - python -m compileall ./red.py

--- a/cogs/ranks.py
+++ b/cogs/ranks.py
@@ -306,7 +306,7 @@ class Ranks:
 
         currentXP = 0
 
-        if fetch is not 0: # This user has past XP that we can add to.
+        if fetch != 0: # This user has past XP that we can add to.
             result = cursor.fetchall()
             currentXP = result[0][0] + pointsToAdd
         else: # New user

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -143,7 +143,6 @@ class RSSFeed():
     @_rss.command(pass_context=True, no_pm=True)
     async def setinterval(self, ctx):
         """Set the interval for rss to scan for updates"""
-        pass
 
     async def rss(self): # pylint: disable=too-many-locals
         """RSS background checker.


### PR DESCRIPTION
Upgrade and hold pylint at the current version (2.2.0, released today), and fix issues found.