### PR TITLE
[Pylint] Disable duplicate-code check

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -200,7 +200,8 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
A lot of cogs are using the same set up code, so we'll disable this check for now.  As mentioned by @Tetimaru, we can make this some function that can be imported or something, and then turn this check back on.