### PR TITLE
[Respects] Add configurable settings

### DIFF
--- a/cogs/respects.py
+++ b/cogs/respects.py
@@ -2,6 +2,7 @@
 A replica of +f seen in another bot, except smarter..
 """
 import copy
+import os
 from datetime import datetime, timedelta
 from threading import Lock
 from random import choice
@@ -19,8 +20,14 @@ HEARTS = [":green_heart:", ":heart:", ":black_heart:", ":yellow_heart:",
 DEFAULT_CH_DICT = {KEY_MSG : None, KEY_TIME : None, KEY_USERS : []}
 DEFAULT_TIME_BETWEEN = timedelta(seconds=30) # Time between paid respects.
 DEFAULT_MSGS_BETWEEN = 20 # The number of messages in between
-
+SAVE_FOLDER = "data/lui-cogs/respects"
 TEXT_RESPECTS = "paid their respects"
+
+def checkFolder():
+    """Used to create the data folder at first startup"""
+    if not os.path.exists(SAVE_FOLDER):
+        print("Creating " + SAVE_FOLDER + " folder...")
+        os.makedirs(SAVE_FOLDER)
 
 class Respects:
     """Pay your respects."""
@@ -79,6 +86,15 @@ class Respects:
         await self.bot.say(":white_check_mark: **Respects - Messages**: A new respect will be "
                            "created after **{}** messages and **{}** seconds have passed "
                            "since the previous one.".format(self.msgsBetween, self.timeBetween))
+
+    @setf.command(name="show", pass_context=False, no_pm=True)
+    async def setfShow(self):
+        """Show the current settings."""
+        msg = ":information_source: **Respects - Current Settings:**\n"
+        msg += "A new respect will be made if a previous respect does not exist, or:\n"
+        msg += "- **{}** seconds have passed since the last respect, **and**\n"
+        msg += "- **{}** messages have been passed since the last respect."
+        await self.bot.say(msg.format(self.timeBetween, self.msgsBetween))
 
     @setf.command(name="time", pass_context=False, no_pm=True)
     async def setfTime(self, seconds: int):
@@ -200,5 +216,6 @@ class Respects:
 
 def setup(bot):
     """Add the cog to the bot."""
+    checkFolder()
     customCog = Respects(bot)
     bot.add_cog(customCog)

--- a/cogs/respects.py
+++ b/cogs/respects.py
@@ -7,6 +7,7 @@ from threading import Lock
 from random import choice
 import discord
 from discord.ext import commands
+from cogs.utils import config
 
 KEY_USERS = "users"
 KEY_TIME = "time"
@@ -27,6 +28,7 @@ class Respects:
         self.plusFLock = Lock()
         self.settingsLock = Lock()
         self.settings = {}
+        self.config = config.Config("settings.json", cogname="lui-cogs/respects")
 
     @commands.command(name="f", pass_context=True, no_pm=True)
     async def plusF(self, ctx):

--- a/cogs/respects.py
+++ b/cogs/respects.py
@@ -22,7 +22,7 @@ DEFAULT_CH_DICT = {KEY_MSG : None, KEY_TIME : None, KEY_USERS : []}
 DEFAULT_TIME_BETWEEN = timedelta(seconds=30) # Time between paid respects.
 DEFAULT_MSGS_BETWEEN = 20 # The number of messages in between
 LOGGER = None
-SAVE_FOLDER = "data/lui-cogs/respects"
+SAVE_FOLDER = "data/lui-cogs/respects/"
 TEXT_RESPECTS = "paid their respects"
 
 def checkFolder():
@@ -43,10 +43,10 @@ class Respects:
         self.config = config.Config("settings.json", cogname="lui-cogs/respects")
 
         timeBetween = self.config.get(KEY_TIME_BETWEEN)
-        self.timeBetween = timeBetween if timeBetween else DEFAULT_TIME_BETWEEN
+        self.timeBetween = timedelta(seconds=timeBetween) if timeBetween else DEFAULT_TIME_BETWEEN
 
         msgsBetween = self.config.get(KEY_MSGS_BETWEEN)
-        self.msgsBetween = timedelta(seconds=msgsBetween) if msgsBetween else DEFAULT_MSGS_BETWEEN
+        self.msgsBetween = msgsBetween if msgsBetween else DEFAULT_MSGS_BETWEEN
 
     @commands.command(name="f", pass_context=True, no_pm=True)
     async def plusF(self, ctx):
@@ -87,7 +87,8 @@ class Respects:
         await self.config.put(KEY_MSGS_BETWEEN, self.msgsBetween)
         await self.bot.say(":white_check_mark: **Respects - Messages**: A new respect will be "
                            "created after **{}** messages and **{}** seconds have passed "
-                           "since the previous one.".format(self.msgsBetween, self.timeBetween))
+                           "since the previous one.".format(self.msgsBetween,
+                                                            self.timeBetween.seconds))
         LOGGER.info("%s#%s (%s) changed the messages between respects to %s messages",
                     ctx.message.author.name,
                     ctx.message.author.discriminator,
@@ -101,7 +102,7 @@ class Respects:
         msg += "A new respect will be made if a previous respect does not exist, or:\n"
         msg += "- **{}** seconds have passed since the last respect, **and**\n"
         msg += "- **{}** messages have been passed since the last respect."
-        await self.bot.say(msg.format(self.timeBetween, self.msgsBetween))
+        await self.bot.say(msg.format(self.timeBetween.seconds, self.msgsBetween))
 
     @setf.command(name="time", pass_context=True, no_pm=True)
     async def setfTime(self, ctx, seconds: int):
@@ -116,11 +117,12 @@ class Respects:
             await self.bot.say(":negative_squared_cross_mark: Please enter a number "
                                "between 1 and 100!")
             return
-        self.timeBetween = seconds
-        await self.config.put(KEY_TIME_BETWEEN, self.timeBetween)
+        self.timeBetween = timedelta(seconds=seconds)
+        await self.config.put(KEY_TIME_BETWEEN, seconds)
         await self.bot.say(":white_check_mark: **Respects - Time**: A new respect will be "
                            "created after **{}** messages and **{}** seconds have passed "
-                           "since the previous one.".format(self.msgsBetween, self.timeBetween))
+                           "since the previous one.".format(self.msgsBetween,
+                                                            self.timeBetween.seconds))
         LOGGER.info("%s#%s (%s) changed the time between respects to %s seconds",
                     ctx.message.author.name,
                     ctx.message.author.discriminator,


### PR DESCRIPTION
### Type
- [x] Enhancement

### Description of the changes
Building from #156, add the ability to adjust timeout and messages between new respect messages, and also log modify entries as with #104.

3 new commands:
- `rensetf show` - Shows current settings
- `rensetf time` - Set time between respects in seconds.
- `rensetf messages` - Set messages between respects.