### PR TITLE
[Ranks] Add logging; fix bugs

### DIFF
--- a/cogs/ranks.py
+++ b/cogs/ranks.py
@@ -241,7 +241,7 @@ class Ranks:
 
     #[p]rank settings maxpoints
     @_settings.command(name="maxpoints", pass_context=True)
-    async def _settingsMaxpoints(self, ctx, maxpoints: int=25):
+    async def _settingsMaxpoints(self, ctx, maxpoints: int = 25):
         """Set max points per eligible message.  Defaults to 25 points."""
         sid = ctx.message.server.id
 
@@ -382,7 +382,7 @@ class Ranks:
             if timestamp - self.lastspoke[sid][uid]["timestamp"] <= self.settings[sid]["cooldown"]:
                 return
             # Update last spoke time with new message time.
-        except KeyError as error:
+        except KeyError:
             # Most likely key error, so create the key, then update
             # last spoke time with new message time.
             try:
@@ -395,7 +395,6 @@ class Ranks:
                          message.author.name,
                          message.author.discriminator,
                          uid)
-            # LOGGER.exception("Actual error")
 
         self.lastspoke[sid][uid]["timestamp"] = timestamp
         self.addPoints(message.server.id, message.author.id)

--- a/cogs/ranks.py
+++ b/cogs/ranks.py
@@ -170,6 +170,19 @@ class Ranks:
         if str(ctx.invoked_subcommand).lower() == "ranks settings":
             await send_cmd_help(ctx)
 
+    # [p]ranks settings default
+    @_settings.command(name="default", pass_context=True, no_pm=True)
+    async def _settingsDefault(self, ctx):
+        """Set default for max points and cooldown."""
+        sid = ctx.message.server.id
+
+        self.settings[sid] = {}
+        self.settings[sid]["cooldown"] = 0
+        self.settings[sid]["maxPoints"] = 25
+
+        await self.bot.say(":information_source: **Ranks - Default:** Defaults set, run "
+                           "`{}rank settings show` to verify the settings.".format(ctx.prefix))
+
     # [p]ranks settings show
     @_settings.command(name="show", pass_context=True, no_pm=True)
     async def _settingsShow(self, ctx):

--- a/cogs/ranks.py
+++ b/cogs/ranks.py
@@ -187,17 +187,18 @@ class Ranks:
     @_settings.command(name="show", pass_context=True, no_pm=True)
     async def _settingsShow(self, ctx):
         """Show current settings."""
+        sid = ctx.message.server.id
+
         try:
-            cooldown = self.settings[ctx.message.server.id]["cooldown"]
+            cooldown = self.settings[sid]["cooldown"]
+            maxPoints = self.settings[sid]["maxPoints"]
         except KeyError:
             # Not set.
-            cooldown = 0
-        try:
-            maxPoints = self.settings[ctx.message.server.id]["maxPoints"]
-        except KeyError:
-            # Not set.
-            maxPoints = 25
-        msg = ":information_source: Ranks - Current Settings\n```"
+            await self.bot.say(":warning: **Ranks - Current Settings**: The server is "
+                               "not configured!  Please run `{}rank settings default` "
+                               "first and try again.".format(ctx.prefix))
+            return
+        msg = ":information_source: **Ranks - Current Settings**:\n```"
         msg += "Cooldown time:  {0} seconds.\n".format(cooldown)
         msg += "Maximum points: {0} points per eligible message```".format(maxPoints)
 
@@ -205,15 +206,17 @@ class Ranks:
 
     # [p]rank settings cooldown
     @_settings.command(name="cooldown", pass_context=True)
-    async def _settingsCcooldown(self, ctx, seconds: int):
+    async def _settingsCooldown(self, ctx, seconds: int):
         """Set the cooldown required between XP gains (in seconds)"""
+        sid = ctx.message.server.id
+
         if seconds is None:
-            await self.bot.say(":negative_squared_cross_mark: Ranks - Cooldown: "
+            await self.bot.say(":negative_squared_cross_mark: **Ranks - Cooldown**: "
                                "Please enter a time in seconds!")
             return
 
         if seconds < 0:
-            await self.bot.say(":negative_squared_cross_mark: Ranks - Cooldown: "
+            await self.bot.say(":negative_squared_cross_mark: **Ranks - Cooldown**: "
                                "Please enter a valid time in seconds!")
             return
 
@@ -221,13 +224,13 @@ class Ranks:
         self.settings = dataIO.load_json(SAVE_FOLDER + 'settings.json')
 
         # Make sure the server id key exists.
-        if ctx.message.server.id not in self.settings.keys():
-            self.settings[ctx.message.server.id] = {}
+        if sid not in self.settings.keys():
+            self.settings[sid] = {}
 
-        self.settings[ctx.message.server.id]["cooldown"] = seconds
+        self.settings[sid]["cooldown"] = seconds
         dataIO.save_json(SAVE_FOLDER + 'settings.json', self.settings)
 
-        await self.bot.say(":white_check_mark: Ranks - Cooldown: Set to {0} "
+        await self.bot.say(":white_check_mark: **Ranks - Cooldown**: Set to {0} "
                            "seconds.".format(seconds))
         LOGGER.info("Cooldown changed by %s#%s (%s)",
                     ctx.message.author.name,
@@ -238,27 +241,24 @@ class Ranks:
 
     #[p]rank settings maxpoints
     @_settings.command(name="maxpoints", pass_context=True)
-    async def _settingsMaxpoints(self, ctx, maxpoints: int):
-        """Set the max points you can gain for every eligible message. Defaults to 25 points."""
-        if maxpoints is None:
-            await self.bot.say(":white_check_mark: Ranks - Max Points: Setting "
-                               "default (up to 25 points per eligible message).")
-            return
+    async def _settingsMaxpoints(self, ctx, maxpoints: int=25):
+        """Set max points per eligible message.  Defaults to 25 points."""
+        sid = ctx.message.server.id
 
         if maxpoints < 0:
-            await self.bot.say(":negative_squared_cross_mark: Ranks - Max Points: "
+            await self.bot.say(":negative_squared_cross_mark: **Ranks - Max Points**: "
                                "Please enter a positive number.")
             return
 
         # Save settings
         self.settings = dataIO.load_json(SAVE_FOLDER + 'settings.json')
         # Make sure the server id key exists.
-        if ctx.message.server.id not in self.settings.keys():
-            self.settings[ctx.message.server.id] = {}
-        self.settings[ctx.message.server.id]["maxPoints"] = maxpoints
+        if sid not in self.settings.keys():
+            self.settings[sid] = {}
+        self.settings[sid]["maxPoints"] = maxpoints
         dataIO.save_json(SAVE_FOLDER + 'settings.json', self.settings)
 
-        await self.bot.say(":white_check_mark: Ranks - Max Points: Users can gain "
+        await self.bot.say(":white_check_mark: **Ranks - Max Points**: Users can gain "
                            "up to {0} points per eligible message.".format(maxpoints))
         LOGGER.info("Maximum points changed by %s#%s (%s)",
                     ctx.message.author.name,

--- a/cogs/ranks.py
+++ b/cogs/ranks.py
@@ -2,6 +2,7 @@
 Keep track of active members on the server.
 """
 
+import logging
 import os
 import random
 import MySQLdb # The use of MySQL is debatable, but will use it to incorporate CMPT 354 stuff.
@@ -15,6 +16,7 @@ from .utils.dataIO import dataIO # pylint: disable=relative-beyond-top-level
 from .utils import checks # pylint: disable=relative-beyond-top-level
 
 # Global variables
+LOGGER = None
 SAVE_FOLDER = "data/lui-cogs/ranks/" # Path to save folder.
 
 def checkFolder():
@@ -366,9 +368,19 @@ class Ranks:
 
 def setup(bot):
     """Add the cog to the bot"""
-
+    global LOGGER # pylint: disable=global-statement
     checkFolder()   # Make sure the data folder exists!
     checkFiles()    # Make sure we have a local database!
+    LOGGER = logging.getLogger("red.Welcome")
+    if LOGGER.level == 0:
+        # Prevents the LOGGER from being loaded again in case of module reload.
+        LOGGER.setLevel(logging.INFO)
+        handler = logging.FileHandler(filename=SAVE_FOLDER+"info.log",
+                                      encoding="utf-8",
+                                      mode="a")
+        handler.setFormatter(logging.Formatter("%(asctime)s %(message)s",
+                                               datefmt="[%d/%m/%Y %H:%M:%S]"))
+        LOGGER.addHandler(handler)
     rankingSystem = Ranks(bot)
     bot.add_cog(rankingSystem)
     bot.add_listener(rankingSystem.checkFlood, 'on_message')

--- a/cogs/ranks.py
+++ b/cogs/ranks.py
@@ -120,7 +120,7 @@ class Ranks:
         data = cursor.fetchone() # Data from the database.
 
         try:
-            print(data)
+            LOGGER.info(data)
             rank = data[0]
             userID = data[1]
             level = data[2]


### PR DESCRIPTION
### Type

- [x] Bugfix
- [x] Enhancement

### Description of the changes
Add logging for the ranks cog, and fix some bugs in the settings commands:
- Default to 25 points if no arguments are passed into [p]ranks settings maxpoints.
- Shorten ctx.message.server.id to sid.
- Keep configuration messages consistent with other custom cogs.
- Change show command to error out if no keys are available, and force user to set default settings.
- Dump rank checking data to logger.