### PR TITLE
[RSS] Refactor and add config commands

### DIFF
--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -162,14 +162,15 @@ class RSSFeed():
             The number of minutes between checks, between 1 and 180 inclusive.
         """
         if minutes < 1 or minutes > 180:
-            await self.bot.say(":negative_squared_cross_mark: The interval must be "
-                               "between 1 and 180 minutes!")
+            await self.bot.say(":negative_squared_cross_mark: **RSS - Check Interval:** "
+                               "The interval must be between 1 and 180 minutes!")
             return
 
         self.checkInterval = minutes * 60
         await self.config.put(KEY_INTERVAL, self.checkInterval)
 
-        await self.bot.say(":white_check_mark: Interval set to {} minutes".format(minutes))
+        await self.bot.say(":white_check_mark: **RSS - Check Interval:** Interval set to "
+                           "**{}** minutes".format(minutes))
 
     async def rss(self):
         """RSS background checker.

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -99,8 +99,8 @@ class RSSFeed():
         if ctx.invoked_subcommand is None:
             await self.bot.send_cmd_help(ctx)
 
-    @_rss.command(name="interval", pass_context=False, no_pm=True)
-    async def setInterval(self, minutes: int):
+    @_rss.command(name="interval", pass_context=True, no_pm=True)
+    async def setInterval(self, ctx, minutes: int):
         """Set the interval for RSS to scan for updates.
 
         Parameters:
@@ -119,6 +119,45 @@ class RSSFeed():
         await self.bot.say(":white_check_mark: **RSS - Check Interval:** Interval set to "
                            "**{}** minutes".format(minutes))
 
+        LOGGER.info("%s#%s (%s) changed the RSS check interval to %s minutes",
+                    ctx.message.author.name,
+                    ctx.message.author.discriminator,
+                    ctx.message.author.id,
+                    minutes)
+
+    @_rss.command(name="channel", pass_context=True, no_pm=True)
+    async def setInterval(self, ctx, channel: discord.Channel):
+        """Set the channel to post new RSS news items.
+
+        Parameters:
+        -----------
+        channel: discord.Channel
+            The channel to post new RSS news items to.
+        """
+        self.channelId = channel.id
+        await self.bot.say(":white_check_mark: **RSS - Channel**: New updates will now "
+                           "be posted to {}".format(channel.mention))
+        LOGGER.info("%s#%s (%s) changed the RSS post channel to %s (%s)",
+                    ctx.message.author.name,
+                    ctx.message.author.discriminator,
+                    ctx.message.author.id,
+                    channel.name,
+                    channel.id)
+
+    @_rss.command(name="show", pass_context=False, no_pm=True)
+    async def showSettings(self):
+        """Show the current RSS configuration."""
+        msg = ":information_source: **RSS - Current Settings**:\n```"
+
+        channel = self.bot.get_channel(self.channelId)
+        if not channel:
+            await self.bot.say("Invalid channel, please set a channel and try again!")
+            return
+        msg += "Posting Channel: #{}\n".format(channel.name)
+        msg += "Check Interval:  {} minutes\n".format(self.checkInterval/60)
+        msg += "```"
+
+        await self.bot.say(msg)
 
     async def getFeed(self, rssUrl):
         """Gets news items from a given RSS URL

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -126,7 +126,7 @@ class RSSFeed():
                     minutes)
 
     @_rss.command(name="channel", pass_context=True, no_pm=True)
-    async def setInterval(self, ctx, channel: discord.Channel):
+    async def setChannel(self, ctx, channel: discord.Channel):
         """Set the channel to post new RSS news items.
 
         Parameters:

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -66,62 +66,9 @@ def checkFilesystem():
                 #build a default config.json
                 defaultDict = {}
                 defaultDict[KEY_CHANNEL] = "change_me"
-                defaultDict[KEY_FEED_URLS] = {}
+                defaultDict[KEY_FEEDS] = {}
                 defaultDict[KEY_INTERVAL] = 3600 #default to checking every hour
                 dataIO.save_json("data/rss/config.json", defaultDict)
-
-def _getFeed(rssUrl, index=None):
-    """Gets news items from a given RSS URL
-
-    Parameters:
-    -----------
-    rssUrl: str
-        The URL of the RSS feed.
-    index: int
-        The index from feeds.json (to be removed).
-
-    Returns:
-    --------
-    news: [feedparser.FeedParserDict]
-        A list of news items obtained using the feedparser library.
-    """
-
-    feeds = dataIO.load_json("data/rss/feeds.json")
-
-    #ensure every rss url has a specified id and most recent post epoch
-    try:
-        latestPostTime = feeds['feeds'][index]['latest_post_time']
-    except IndexError:
-        feedDict = {}
-        feedDict['id'] = index
-        feedDict['latest_post_time'] = 0
-        feeds['feeds'].append(feedDict)
-        dataIO.save_json("data/rss/feeds.json", feeds)
-        feeds = dataIO.load_json("data/rss/feeds.json")
-        latestPostTime = feeds['feeds'][index]['latest_post_time']
-
-    news = []
-    feed = feedparser.parse(rssUrl)
-
-    for item in feed.entries:
-        itemPostTime = date2epoch(item['published'])
-        if _isNewItem(latestPostTime, itemPostTime):
-            news.append(item)
-
-    if not news:
-        LOGGER.info("No new items in feed %s", str(index))
-    else:
-        LOGGER.info("%s new items in feed %s", len(news), str(index))
-
-    latestPostTime = _getLatestPostTime(feed.entries)
-    if latestPostTime:
-        feeds['feeds'][index]['latest_post_time'] = latestPostTime
-    dataIO.save_json("data/rss/feeds.json", feeds)
-
-    # Heartbeat
-    dataIO.save_json("data/rss/timestamp.json", "{}")
-
-    return news
 
 def _getLatestPostTime(feedItems):
     publishedTimes = []

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -15,7 +15,6 @@ from discord.ext import commands
 import feedparser
 from bs4 import BeautifulSoup
 from cogs.utils.dataIO import dataIO
-from __main__ import send_cmd_help # pylint: disable=no-name-in-module
 
 LOGGER = None
 RSS_IMAGE = ("https://upload.wikimedia.org/wikipedia/en/thumb/4/43/Feed-icon.svg/"
@@ -138,7 +137,7 @@ class RSSFeed():
     async def _rss(self, ctx):
         """Utilities for the RSS cog"""
         if ctx.invoked_subcommand is None:
-            await send_cmd_help(ctx)
+            await self.bot.send_cmd_help(ctx)
 
     @_rss.command(pass_context=True, no_pm=True)
     async def setinterval(self, ctx):

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -21,7 +21,7 @@ LOGGER = None
 KEY_CHANNEL = "post_channel"
 KEY_INTERVAL = "check_interval"
 KEY_LAST_POST_TIME = "last_post_time"
-KEY_FEEDS = "rss_feeds"
+KEY_FEEDS = "rss_feed_urls"
 RSS_IMAGE_URL = ("https://upload.wikimedia.org/wikipedia/en/thumb/4/43/Feed-icon.svg/"
                  "1200px-Feed-icon.svg.png")
 
@@ -141,7 +141,7 @@ class RSSFeed():
                                     cogname="rss")
         self.settings = dataIO.load_json("data/rss/config.json")
         self.bot = bot
-        self.rssFeeds = self.config.get(KEY_FEEDS)
+        self.rssFeedUrls = self.config.get(KEY_FEEDS)
         self.checkInterval = self.config.get(KEY_INTERVAL)
         self.channelId = self.config.get(KEY_CHANNEL)
 

--- a/cogs/rss.py
+++ b/cogs/rss.py
@@ -21,7 +21,7 @@ LOGGER = None
 KEY_CHANNEL = "post_channel"
 KEY_INTERVAL = "check_interval"
 KEY_LAST_POST_TIME = "last_post_time"
-KEY_FEED_URLS = "rss_feed_urls"
+KEY_FEEDS = "rss_feeds"
 RSS_IMAGE_URL = ("https://upload.wikimedia.org/wikipedia/en/thumb/4/43/Feed-icon.svg/"
                  "1200px-Feed-icon.svg.png")
 
@@ -45,13 +45,13 @@ def checkFilesystem():
     folders = ("data/rss")
     for folder in folders:
         if not os.path.exists(folder):
-            print("RSS: Creating folder: {} ...".format(folder))
+            LOGGER.info("Creating folder: %s ...", folder)
             os.makedirs(folder)
 
     files = ("data/rss/config.json", "data/rss/feeds.json")
     for file in files:
         if not os.path.exists(file):
-            print("RSS: Creating file: {} ...".format(file))
+            LOGGER.info("Creating file: %s...", file)
 
             if "feeds" in file:
                 #build a default feeds.json
@@ -141,7 +141,7 @@ class RSSFeed():
                                     cogname="rss")
         self.settings = dataIO.load_json("data/rss/config.json")
         self.bot = bot
-        self.rssFeedUrls = self.config.get(KEY_FEED_URLS)
+        self.rssFeeds = self.config.get(KEY_FEEDS)
         self.checkInterval = self.config.get(KEY_INTERVAL)
         self.channelId = self.config.get(KEY_CHANNEL)
 


### PR DESCRIPTION
### Type
- [x] Enhancement

### Description of the changes
As per #155, refactor the RSS cog to:
- Use config.Config to handle loading and saving settings.
- Unify feed.json and config.json into a single config.json (BREAKING CHANGE)
- Add config commands for posting channel and check interval (add, remove channels to come in next PR)
- Add show command.