### PR TITLE
[Triggered] New cog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install pylint==2.2.0
-  - pip install mysqlclient
 script:
   - python -m compileall ./red.py
   - python -m compileall ./cogs

--- a/cogs/triggered.py
+++ b/cogs/triggered.py
@@ -33,6 +33,7 @@ class Triggered: # pylint: disable=too-few-public-methods
         await self.bot.send_typing(ctx.message.channel)
         savePath = await self._createTrigger(user)
         if not savePath:
+            await self.bot.say("This user doesn't have an avatar.")
             return
         await self.bot.send_file(ctx.message.channel, savePath)
 
@@ -57,6 +58,8 @@ class Triggered: # pylint: disable=too-few-public-methods
             url = "https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.png?size=512"
             urllib.request.urlretrieve(url.format(user), path)
         except urllib.request.ContentTooShortError:
+            return None
+        except urllib.error.HTTPError:
             return None
 
         avatar = Image.open(path)

--- a/cogs/triggered.py
+++ b/cogs/triggered.py
@@ -33,7 +33,7 @@ class Triggered: # pylint: disable=too-few-public-methods
         await self.bot.send_typing(ctx.message.channel)
         savePath = await self._createTrigger(user)
         if not savePath:
-            await self.bot.say("This user doesn't have an avatar.")
+            await self.bot.say("Something went wrong, try again.")
             return
         await self.bot.send_file(ctx.message.channel, savePath)
 
@@ -50,17 +50,20 @@ class Triggered: # pylint: disable=too-few-public-methods
         """
         path = "{}{}.png".format(SAVE_FOLDER, user.id)
         savePath = "{}{}-trig.gif".format(SAVE_FOLDER, user.id)
+
+        opener = urllib.request.build_opener()
+        # We need a custom header or else we get a HTTP 403 Unauthorized
+        opener.addheaders = [("User-agent", "Mozilla/5.0")]
+        urllib.request.install_opener(opener)
+
         try:
-            opener = urllib.request.build_opener()
-            # We need a custom header or else we get a HTTP 403 Unauthorized
-            opener.addheaders = [("User-agent", "Mozilla/5.0")]
-            urllib.request.install_opener(opener)
             url = "https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.png?size=512"
             urllib.request.urlretrieve(url.format(user), path)
         except urllib.request.ContentTooShortError:
             return None
         except urllib.error.HTTPError:
-            return None
+            # Use the default.
+            urllib.request.urlretrieve(user.default_avatar_url, path)
 
         avatar = Image.open(path)
 

--- a/cogs/triggered.py
+++ b/cogs/triggered.py
@@ -4,7 +4,20 @@
 
 import os
 import discord
+import urllib.request
 from discord.ext import commands
+from cogs.utils.dataIO import dataIO
+from PIL import Image, ImageChops, ImageOps
+
+SAVE_FOLDER = "data/lui-cogs/triggered/" # Path to save folder.
+SAVE_FILE = "settings.json"
+AVATAR_URL = "https://images.discordapp.net/avatars/{0.id}/{0.avatar}.png?size=1024"
+
+def checkFolder():
+    """Used to create the data folder at first startup"""
+    if not os.path.exists(SAVE_FOLDER):
+        print("Creating " + SAVE_FOLDER + " folder...")
+        os.makedirs(SAVE_FOLDER)
 
 class Triggered: # pylint: disable=too-many-instance-attributes
     """We triggered, fam."""
@@ -16,10 +29,59 @@ class Triggered: # pylint: disable=too-many-instance-attributes
     
     @commands.command(name="triggered", pass_context=True)
     async def triggered(self, ctx):
-        pass
+        """Are you triggered? Say no more."""
+        savePath = await self._createTrigger(ctx.message.author)
+        if not savePath:
+            return
+        await self.bot.send_file(ctx.message.channel, savePath),
+
+
+    async def _createTrigger(self, user):
+        """Fetches the user's avatar, and creates a triggered GIF
+
+        Parameters:
+        -----------
+        user: discord.User
+
+        Returns:
+        --------
+        savePath: str, or None
+        """
+        path = "{}{}.png".format(SAVE_FOLDER, user.id)
+        savePath = "{}{}-trig.gif".format(SAVE_FOLDER, user.id)
+        try:
+            opener = urllib.request.build_opener()
+            opener.addheaders = [("User-agent", "Mozilla/5.0")]
+            urllib.request.install_opener(opener)
+            urllib.request.urlretrieve(user.avatar_url, path)
+        except Exception as error:
+            print(user.avatar_url)
+            print(error)
+        avatar = Image.open(path)
+        if not avatar:
+            return
+        OFFSET = 30
+        topRight = ImageChops.offset(avatar, -OFFSET, OFFSET)
+        topLeft = ImageChops.offset(avatar, -OFFSET, -OFFSET+6)
+        botRight = ImageChops.offset(avatar, OFFSET-5, OFFSET-15)
+        botLeft = ImageChops.offset(avatar, -OFFSET+15, OFFSET-10)
+
+        topRight = ImageOps.crop(topRight, OFFSET)
+        botRight = ImageOps.crop(botRight, OFFSET)
+        avatar = ImageOps.crop(avatar, OFFSET)
+        topLeft = ImageOps.crop(topLeft, OFFSET)
+        botLeft = ImageOps.crop(botLeft, OFFSET)
+        topRight.save(savePath, format="GIF",
+                      append_images=[botLeft, botRight, topLeft, avatar],
+                      save_all=True,
+                      duration=30,
+                      loop=0)
+        return savePath
+
 
 
 def setup(bot):
     """Add the cog to the bot."""
+    checkFolder()
     customCog = Triggered(bot)
     bot.add_cog(customCog)

--- a/cogs/triggered.py
+++ b/cogs/triggered.py
@@ -3,10 +3,9 @@
 """
 
 import os
-import discord
 import urllib.request
+import discord
 from discord.ext import commands
-from cogs.utils.dataIO import dataIO
 from PIL import Image, ImageChops, ImageOps
 
 SAVE_FOLDER = "data/lui-cogs/triggered/" # Path to save folder.
@@ -19,29 +18,30 @@ def checkFolder():
         print("Creating " + SAVE_FOLDER + " folder...")
         os.makedirs(SAVE_FOLDER)
 
-class Triggered: # pylint: disable=too-many-instance-attributes
+class Triggered: # pylint: disable=too-few-public-methods
     """We triggered, fam."""
-
 
     # Class constructor
     def __init__(self, bot):
         self.bot = bot
-    
+
     @commands.command(name="triggered", pass_context=True)
-    async def triggered(self, ctx):
+    async def triggered(self, ctx, user: discord.Member = None):
         """Are you triggered? Say no more."""
-        savePath = await self._createTrigger(ctx.message.author)
+        if not user:
+            user = ctx.message.author
+        await self.bot.send_typing(ctx.message.channel)
+        savePath = await self._createTrigger(user)
         if not savePath:
             return
-        await self.bot.send_file(ctx.message.channel, savePath),
-
+        await self.bot.send_file(ctx.message.channel, savePath)
 
     async def _createTrigger(self, user):
         """Fetches the user's avatar, and creates a triggered GIF
 
         Parameters:
         -----------
-        user: discord.User
+        user: discord.Member
 
         Returns:
         --------
@@ -51,31 +51,34 @@ class Triggered: # pylint: disable=too-many-instance-attributes
         savePath = "{}{}-trig.gif".format(SAVE_FOLDER, user.id)
         try:
             opener = urllib.request.build_opener()
+            # We need a custom header or else we get a HTTP 403 Unauthorized
             opener.addheaders = [("User-agent", "Mozilla/5.0")]
             urllib.request.install_opener(opener)
-            urllib.request.urlretrieve(user.avatar_url, path)
-        except Exception as error:
-            print(user.avatar_url)
-            print(error)
+            url = "https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.png?size=512"
+            urllib.request.urlretrieve(url.format(user), path)
+        except urllib.request.ContentTooShortError:
+            return None
+
         avatar = Image.open(path)
+
         if not avatar:
             return
-        OFFSET = 30
-        topRight = ImageChops.offset(avatar, -OFFSET, OFFSET)
-        topLeft = ImageChops.offset(avatar, -OFFSET, -OFFSET+6)
-        botRight = ImageChops.offset(avatar, OFFSET-5, OFFSET-15)
-        botLeft = ImageChops.offset(avatar, -OFFSET+15, OFFSET-10)
 
-        topRight = ImageOps.crop(topRight, OFFSET)
-        botRight = ImageOps.crop(botRight, OFFSET)
-        avatar = ImageOps.crop(avatar, OFFSET)
-        topLeft = ImageOps.crop(topLeft, OFFSET)
-        botLeft = ImageOps.crop(botLeft, OFFSET)
-        topRight.save(savePath, format="GIF",
-                      append_images=[botLeft, botRight, topLeft, avatar],
-                      save_all=True,
-                      duration=30,
-                      loop=0)
+        offsets = [(15, 15), (5, 10), (-15, -15),
+                   (10, -10), (10, 0), (-15, 10),
+                   (10, -5)]
+        images = []
+
+        for xcoord, ycoord in offsets:
+            image = ImageChops.offset(avatar, xcoord, ycoord)
+            image = ImageOps.crop(image, 15)
+            images.append(image)
+        avatar = ImageOps.crop(avatar, 15)
+        avatar.save(savePath, format="GIF",
+                    append_images=images,
+                    save_all=True,
+                    duration=25,
+                    loop=0)
         return savePath
 
 

--- a/cogs/triggered.py
+++ b/cogs/triggered.py
@@ -10,7 +10,7 @@ from PIL import Image, ImageChops, ImageOps
 
 SAVE_FOLDER = "data/lui-cogs/triggered/" # Path to save folder.
 SAVE_FILE = "settings.json"
-AVATAR_URL = "https://images.discordapp.net/avatars/{0.id}/{0.avatar}.png?size=1024"
+AVATAR_URL = "https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.png?size=512"
 
 def checkFolder():
     """Used to create the data folder at first startup"""
@@ -57,8 +57,7 @@ class Triggered: # pylint: disable=too-few-public-methods
         urllib.request.install_opener(opener)
 
         try:
-            url = "https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.png?size=512"
-            urllib.request.urlretrieve(url.format(user), path)
+            urllib.request.urlretrieve(AVATAR_URL.format(user), path)
         except urllib.request.ContentTooShortError:
             return None
         except urllib.error.HTTPError:

--- a/cogs/triggered.py
+++ b/cogs/triggered.py
@@ -1,0 +1,25 @@
+"""Triggered cog
+`triggered from spoopy.
+"""
+
+import os
+import discord
+from discord.ext import commands
+
+class Triggered: # pylint: disable=too-many-instance-attributes
+    """We triggered, fam."""
+
+
+    # Class constructor
+    def __init__(self, bot):
+        self.bot = bot
+    
+    @commands.command(name="triggered", pass_context=True)
+    async def triggered(self, ctx):
+        pass
+
+
+def setup(bot):
+    """Add the cog to the bot."""
+    customCog = Triggered(bot)
+    bot.add_cog(customCog)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ youtube_dl
 imgurpython
 bs4
 feedparser
+mysqlclient
+Pillow


### PR DESCRIPTION
### Type
- [x] New feature

### Description of the changes
Implement custom version of `triggered as per #166.  Implemented using Pillow (PIL).  Had to insert a custom header to simulate a browser in the avatar fetch, as I got a HTTP 403 without it.  See the spam in the test server.