### PR TITLE
[Highlight] Add user configurable timer

### DIFF
--- a/cogs/highlight.py
+++ b/cogs/highlight.py
@@ -316,6 +316,39 @@ class Highlight:
             await self.settings.put(KEY_GUILDS, self.highlights)
         await self._sleepThenDelete(confMsg, 5)
 
+    @highlight.command(name="timeout", pass_context=True, no_pm=True)
+    async def setTimeout(self, ctx, seconds: int):
+        """Set the timeout between consecutive highlight triggers.
+
+        This applies to consecutive highlights within the same channel.
+        If your words are triggered within this timeout period, you will
+        only be notified once.
+
+        Parameters:
+        -----------
+        seconds: int
+            The timeout between consecutive triggers within a channel, in seconds.
+            Minimum timeout is 0 (always trigger).
+            Maximum timeout is 3600 seconds (1 hour).
+        """
+        if seconds < 0 or seconds > 3600:
+            await self.bot.say("Please specifiy a timeout between 0 and 3600 seconds!")
+            return
+
+        with self.lock:
+            guildId = ctx.message.server.id
+            userId = ctx.message.author.id
+            userName = ctx.message.author.name
+
+            self._registerUser(guildId, userId)
+            self.highlights[guildId][userId][KEY_TIMEOUT] = seconds
+
+            confMsg = await self.bot.say("Timeout set to {} seconds.".format(seconds))
+            await self.settings.put(KEY_GUILDS, self.highlights)
+            await self.bot.delete_message(ctx.message)
+        await self._sleepThenDelete(confMsg, 5)
+
+
     def _triggeredRecently(self, msg, uid, timeout=DEFAULT_TIMEOUT):
         """See if a user has been recently triggered.
 

--- a/cogs/highlight.py
+++ b/cogs/highlight.py
@@ -16,11 +16,12 @@ from discord.ext import commands
 from cogs.utils import config, chat_formatting
 from cogs.utils.dataIO import dataIO
 
-ACTIVE_TIME = 20
+DEFAULT_TIMEOUT = 20
 LOGGER = None
 MAX_WORDS = 5
 KEY_GUILDS = "guilds"
 KEY_BLACKLIST = "blacklist"
+KEY_TIMEOUT = "timeout"
 KEY_WORDS = "words"
 SAVE_FOLDER = "data/lui-cogs/highlight/"
 SAVE_FILE = "settings.json"
@@ -72,11 +73,15 @@ class Highlight:
             self.highlights[guildId] = {}
 
         if userId not in self.highlights[guildId].keys():
-            self.highlights[guildId][userId] = {KEY_WORDS: [], KEY_BLACKLIST: []}
+            self.highlights[guildId][userId] = {KEY_WORDS: [], KEY_BLACKLIST: [],
+                                                KEY_TIMEOUT: DEFAULT_TIMEOUT}
             return
 
         if KEY_BLACKLIST not in self.highlights[guildId][userId].keys():
             self.highlights[guildId][userId][KEY_BLACKLIST] = []
+
+        if KEY_TIMEOUT not in self.highlights[guildId][userId].keys():
+            self.highlights[guildId][userId][KEY_TIMEOUT] = DEFAULT_TIMEOUT
 
     @commands.group(name="highlight", pass_context=True, no_pm=True,
                     aliases=["hl"])
@@ -427,12 +432,12 @@ def _isActive(userId, originalMessage, messages):
     Returns:
     --------
     bool
-        True, if the user has spoken ACTIVE_TIME seconds before originalMessage.
+        True, if the user has spoken DEFAULT_TIMEOUT seconds before originalMessage.
         False, otherwise.
     """
     for msg in messages:
         deltaSinceMsg = originalMessage.timestamp - msg.timestamp
-        if msg.author.id == userId and deltaSinceMsg <= timedelta(seconds=ACTIVE_TIME):
+        if msg.author.id == userId and deltaSinceMsg <= timedelta(seconds=DEFAULT_TIMEOUT):
             return True
     return False
 


### PR DESCRIPTION
### Type
- [x] Enhancement

### Description of the changes
- Resolves #187.
- Resolves #204.
- Resolves #205.

This PR adds a per-user configurable timer to allow a user to:
1. Set the interval between consecutive triggers within the same channel.
2. Set how long they need to be inactive for to cause one of their highlight words to be triggered.

Currently, this time interval controls both of the aforementioned points.  A future PR could separate 2 from 1.