### PR TITLE
[Highlight] Remove channel mention from DM

### DIFF
--- a/cogs/highlight.py
+++ b/cogs/highlight.py
@@ -493,7 +493,7 @@ class Highlight:
         msgUrl = "https://discordapp.com/channels/{}/{}/{}".format(message.server.id,
                                                                    message.channel.id,
                                                                    message.id)
-        notifyMsg = ("In {1.channel.mention}, you were mentioned with highlight word "
+        notifyMsg = ("In #{1.channel.name}, you were mentioned with highlight word "
                      "**{0}**:".format(word, message))
         embedMsg = ""
         msgStillThere = False


### PR DESCRIPTION
### Type
- [x] Bugfix

### Description of the changes
Change channel mention to name to ensure it shows up properly on mobile notifications.  Since we already have a method to jump to the context, there is no need for the channel to be mentionable: we can just show the name as is without using its ID.