### PR TITLE
[Respects] Handle case where bot has no Send Message perms

### DIFF
--- a/cogs/respects.py
+++ b/cogs/respects.py
@@ -161,7 +161,10 @@ class Respects:
                                                 before=ctx.message):
                 prevMsgs.append(msg.id)
 
-            exceedMessages = self.settings[sid][cid][KEY_MSG].id not in prevMsgs
+            if self.settings[sid][cid][KEY_MSG]:
+                exceedMessages = self.settings[sid][cid][KEY_MSG].id not in prevMsgs
+            else:
+                exceedMessages = False
             exceedTime = datetime.now() - self.settings[sid][cid][KEY_TIME] > self.timeBetween
 
             if exceedMessages and exceedTime:


### PR DESCRIPTION
### Type

- [x] Bugfix

### Description of the changes
Resolves #213. 
- Keep tabs on the user that has paid respects.
- Do a check to see if the discord.Message object exists first before trying to access its attributes.

This fixes the case where someone types renf in a channel where send permissions are denied (e.g. #dark-hour). When this happens, the message object is not saved to `...[KEY_MSG]` as it errors out in line 228. At that point, the sid and cid of the server and channel IDs have been set in the dict, respectively. This fixes the case where if send message perms are re-enabled in the channel, the check above doesn't error out due to accessing a non-existent Message object, since we already had a previous respect being paid (albeit didn't send properly).
