### PR TITLE
Economy patch 

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -487,10 +487,13 @@ class Economy:
             for page in pagify(highscore, shorten_by=12):
             #Adding info site.
                 siteInfo = "\nFull rankings at https://ren.injabie3.moe/economy"
-                sleepTime = 60
-                msgId = await self.bot.say(box(page, lang="text") + siteInfo)
+                sleepTime = 5 
+                msgObj = await self.bot.say(box(page, lang="text") + siteInfo)
                 await asyncio.sleep(sleepTime)
-                await self.bot.delete_message(msgId)
+                try:
+                    await self.bot.delete_message(msgObj)
+                except discord.NotFound:
+                    logger.info("Could not delete leaderboard due to the message already being deleted")
         else:
             await self.bot.say("There are no accounts in the bank.")
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -487,7 +487,7 @@ class Economy:
             for page in pagify(highscore, shorten_by=12):
             #Adding info site.
                 siteInfo = "\nFull rankings at https://ren.injabie3.moe/economy"
-                sleepTime = 5 
+                sleepTime = 60 
                 msgObj = await self.bot.say(box(page, lang="text") + siteInfo)
                 await asyncio.sleep(sleepTime)
                 try:

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -487,7 +487,7 @@ class Economy:
             for page in pagify(highscore, shorten_by=12):
             #Adding info site.
                 siteInfo = "\nFull rankings at https://ren.injabie3.moe/economy"
-                sleepTime = 60 
+                sleepTime = 60
                 msgObj = await self.bot.say(box(page, lang="text") + siteInfo)
                 await asyncio.sleep(sleepTime)
                 try:


### PR DESCRIPTION
### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes

Issue #195 

Fixed error that would occur when leaderboard is filtered and the "existing" message could not be deleted
Added Try except block to capture when msgObj returned a discord.NotFound error
Added Statement that logs when this exception happens