### PR TITLE
[Highlight] Exclude dark hour from triggering Highlight notifications

### DIFF
--- a/cogs/highlight.py
+++ b/cogs/highlight.py
@@ -38,7 +38,7 @@ def checkFilesystem():
         print("Creating default highlight settings.json...")
         dataIO.save_json(theFile, {})
 
-class Highlight:
+class Highlight: # pylint: disable=too-many-instance-attributes
     """Slack-like feature to be notified based on specific words."""
     def __init__(self, bot):
         self.bot = bot
@@ -51,7 +51,7 @@ class Highlight:
         self.channelBlId = self.settings.get(KEY_IGNORE, None)
         self.lastTriggered = {}
         self.triggeredLock = Lock()
-        
+
         # previously: dataIO.load_json("data/highlight/words.json")
         self.wordFilter = None
 

--- a/cogs/highlight.py
+++ b/cogs/highlight.py
@@ -436,7 +436,7 @@ class Highlight: # pylint: disable=too-many-instance-attributes
     async def checkForDarkHourDeletion(self, channel):
         """Background listener to check if dark-hour has been deleted"""
         if self.channelBlId and str(channel.id) == self.channelBlId:
-            self.channelBlId = "ignoreChannelID"
+            self.channelBlId = None
             LOGGER.info("Dark hour deletion has been detected and channelBlId has"
                         "been reset")
         else:


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Created two new functions that listen to the creation and deletion of a channel
Added variable channelBlId to store every new dark-hour channel ID

Function:
If the channel is named "dark-hour" the channel ID will be recorded and excluded from highlight notifications

