### PR TITLE
[Highlight] Add exception handling for no DMs

### DIFF
--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -380,7 +380,7 @@ class Highlight(commands.Cog):
         """
         if seconds < 0 or seconds > 3600:
             await ctx.send(
-                "Please specifiy a timeout between 0 and 3600 seconds!")
+                "Please specify a timeout between 0 and 3600 seconds!")
             return
 
         await self.config.member(ctx.author).timeout.set(seconds)

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -3,10 +3,7 @@
 Credit: This idea was first implemented by Danny (https://github.com/Rapptz/) but at
 the time, that bot was closed source.
 """
-from copy import deepcopy
 from datetime import timedelta, timezone
-import logging
-import os
 import re
 from threading import Lock
 import asyncio
@@ -29,16 +26,17 @@ KEY_IGNORE = "ignoreChannelID"
 
 BASE_GUILD_MEMBER = \
 {
- KEY_BLACKLIST: [],
- KEY_TIMEOUT: DEFAULT_TIMEOUT,
- KEY_WORDS: [],
- KEY_WORDS_IGNORE: []
+    KEY_BLACKLIST: [],
+    KEY_TIMEOUT: DEFAULT_TIMEOUT,
+    KEY_WORDS: [],
+    KEY_WORDS_IGNORE: []
 }
 
 BASE_GUILD = \
 {
- KEY_IGNORE: None
+    KEY_IGNORE: None
 }
+
 
 class Highlight(commands.Cog):
     """Slack-like feature to be notified based on specific words."""
@@ -46,7 +44,9 @@ class Highlight(commands.Cog):
         super().__init__()
         self.bot = bot
         self.lock = Lock()
-        self.config = Config.get_conf(self, identifier=5842647, force_registration=True)
+        self.config = Config.get_conf(self,
+                                      identifier=5842647,
+                                      force_registration=True)
         self.config.register_member(**BASE_GUILD_MEMBER)
         self.config.register_guild(**BASE_GUILD)
 
@@ -56,13 +56,13 @@ class Highlight(commands.Cog):
         self.logger = None
 
     async def _sleepThenDelete(self, msg, time):
-        await asyncio.sleep(time) # pylint: disable=no-member
+        await asyncio.sleep(time)  # pylint: disable=no-member
         await msg.delete()
 
     def _registerUser(self, guildId, userId):
         """Checks to see if user is registered, and if not, registers the user.
-        If the user is already registered, this method will do nothing.
-        If the user is not, they will be initialized to contain an empty words list.
+        If the user is already registered, this method will do nothing. If the
+        user is not, they will be initialized to contain an empty words list.
 
         Parameters:
         -----------
@@ -79,8 +79,11 @@ class Highlight(commands.Cog):
             self.highlights[guildId] = {}
 
         if userId not in self.highlights[guildId].keys():
-            self.highlights[guildId][userId] = {KEY_WORDS: [], KEY_BLACKLIST: [],
-                                                KEY_TIMEOUT: DEFAULT_TIMEOUT}
+            self.highlights[guildId][userId] = {
+                KEY_WORDS: [],
+                KEY_BLACKLIST: [],
+                KEY_TIMEOUT: DEFAULT_TIMEOUT
+            }
             return
 
         if KEY_BLACKLIST not in self.highlights[guildId][userId].keys():
@@ -92,12 +95,12 @@ class Highlight(commands.Cog):
     @commands.group(name="highlight", aliases=["hl"])
     @commands.guild_only()
     async def highlight(self, ctx):
-        """Slack-like feature to be notified based on specific words outside of at-mentions"""
-
+        """Slack-like feature to be notified based on specific words outside of
+        at-mentions."""
     @highlight.command(name="add")
     @commands.guild_only()
     async def addHighlight(self, ctx, *, word: str):
-        """Add a word to be highlighted in the current guild"""
+        """Add a word to be highlighted in the current guild."""
         userName = ctx.message.author.name
 
         async with self.config.member(ctx.author).words() as userWords:
@@ -107,16 +110,17 @@ class Highlight(commands.Cog):
                 await ctx.send("Highlight word added, {}".format(userName),
                                delete_after=DELETE_TIME)
             else:
-                await ctx.send("Sorry {}, you already have {} words highlighted, or you "
-                               "are trying to add a duplicate word".format(userName,
-                                                                           MAX_WORDS_HIGHLIGHT),
-                               delete_after=DELETE_TIME)
+                await ctx.send(
+                    "Sorry {}, you already have {} words highlighted, or you "
+                    "are trying to add a duplicate word".format(
+                        userName, MAX_WORDS_HIGHLIGHT),
+                    delete_after=DELETE_TIME)
         await ctx.message.delete()
 
     @highlight.command(name="del", aliases=["delete", "remove", "rm"])
     @commands.guild_only()
     async def removeHighlight(self, ctx, *, word: str):
-        """Remove a highlighted word in the current guild"""
+        """Remove a highlighted word in the current guild."""
         userName = ctx.message.author.name
 
         async with self.config.member(ctx.author).words() as userWords:
@@ -133,7 +137,7 @@ class Highlight(commands.Cog):
     @highlight.command(name="list", aliases=["ls"])
     @commands.guild_only()
     async def listHighlight(self, ctx: Context):
-        """List your highighted words for the current guild"""
+        """List your highighted words for the current guild."""
         userName = ctx.message.author.name
 
         async with self.config.member(ctx.author).words() as userWords:
@@ -149,19 +153,21 @@ class Highlight(commands.Cog):
                 try:
                     await ctx.message.author.send(embed=embed)
                 except discord.Forbidden:
-                    await ctx.send("You do not have DMs enabled, please enable them!",
-                                   delete_after=DELETE_TIME)
+                    await ctx.send(
+                        "You do not have DMs enabled, please enable them!",
+                        delete_after=DELETE_TIME)
                 else:
-                    await ctx.send("Please check your DMs.", delete_after=DELETE_TIME)
+                    await ctx.send("Please check your DMs.",
+                                   delete_after=DELETE_TIME)
             else:
                 await ctx.send("Sorry {}, you have no highlighted words "
-                               "currently".format(userName), delete_after=DELETE_TIME)
+                               "currently".format(userName),
+                               delete_after=DELETE_TIME)
 
     @highlight.group(name="blacklist", aliases=["bl"])
     @commands.guild_only()
     async def userBlacklist(self, ctx: Context):
         """Blacklist certain users from triggering your words."""
-
     @userBlacklist.command(name="add")
     @commands.guild_only()
     async def userBlAdd(self, ctx: Context, user: discord.Member):
@@ -177,7 +183,8 @@ class Highlight(commands.Cog):
         async with self.config.member(ctx.author).blacklist() as userBl:
             if user.id not in userBl:
                 userBl.append(user.id)
-                await ctx.send("{} added to the blacklist, {}".format(user.name, userName),
+                await ctx.send("{} added to the blacklist, {}".format(
+                    user.name, userName),
                                delete_after=DELETE_TIME)
             else:
                 await ctx.send("This user is already on the blacklist!",
@@ -199,22 +206,27 @@ class Highlight(commands.Cog):
         async with self.config.member(ctx.author).blacklist() as userBl:
             if user.id in userBl:
                 userBl.remove(user.id)
-                await ctx.send("{} removed from blacklist, {}".format(user.name, userName),
+                await ctx.send("{} removed from blacklist, {}".format(
+                    user.name, userName),
                                delete_after=DELETE_TIME)
             else:
-                await ctx.send("This user is not on the blacklist!", delete_after=DELETE_TIME)
+                await ctx.send("This user is not on the blacklist!",
+                               delete_after=DELETE_TIME)
         await ctx.message.delete()
 
     @userBlacklist.command(name="clear", aliases=["cls"])
     @commands.guild_only()
     async def userBlClear(self, ctx: Context):
-        """Clear your user blacklist.  Will ask for confirmation."""
+        """Clear your user blacklist.
+
+        Will ask for confirmation.
+        """
         await ctx.send("Are you sure you want to clear your blacklist?  Type "
                        "`yes` to continue, otherwise type something else.")
 
         def check(msg):
-            return (msg.author == ctx.message.author and
-                    msg.channel == ctx.message.channel)
+            return (msg.author == ctx.message.author
+                    and msg.channel == ctx.message.channel)
 
         response = await self.bot.wait_for("message", timeout=10, check=check)
 
@@ -235,7 +247,8 @@ class Highlight(commands.Cog):
             if userBl:
                 msg = ""
                 for userId in userBl:
-                    userObj = discord.utils.get(ctx.message.guild.members, id=userId)
+                    userObj = discord.utils.get(ctx.message.guild.members,
+                                                id=userId)
                     if not userObj:
                         continue
                     msg += "{}\n".format(userObj.name)
@@ -244,19 +257,23 @@ class Highlight(commands.Cog):
 
                 embed = discord.Embed(description=msg,
                                       colour=discord.Colour.red())
-                embed.title = "Blacklisted users on {}".format(ctx.message.guild.name)
+                embed.title = "Blacklisted users on {}".format(
+                    ctx.message.guild.name)
                 embed.set_author(name=userName,
                                  icon_url=ctx.message.author.avatar_url)
                 try:
                     await ctx.message.author.send(embed=embed)
                 except discord.Forbidden:
-                    await ctx.send("You do not have DMs enabled, please enable them!",
-                                   delete_after=DELETE_TIME)
+                    await ctx.send(
+                        "You do not have DMs enabled, please enable them!",
+                        delete_after=DELETE_TIME)
                 else:
-                    await ctx.send("Please check your DMs.", delete_after=DELETE_TIME)
+                    await ctx.send("Please check your DMs.",
+                                   delete_after=DELETE_TIME)
             else:
                 await ctx.send("Sorry {}, you have no backlisted users "
-                               "currently".format(userName), delete_after=DELETE_TIME)
+                               "currently".format(userName),
+                               delete_after=DELETE_TIME)
 
     @highlight.group(name="ignore")
     @commands.guild_only()
@@ -269,7 +286,6 @@ class Highlight(commands.Cog):
         - "X Y": does NOT triggers DM.
         - "X something something Y": does NOT trigger DM.
         """
-
     @wordIgnore.command(name="add")
     @commands.guild_only()
     async def wordIgnoreAdd(self, ctx: Context, *, word: str):
@@ -285,13 +301,15 @@ class Highlight(commands.Cog):
         async with self.config.member(ctx.author).ignoreWords() as ignoreWords:
             if len(ignoreWords) < MAX_WORDS_IGNORE and word not in ignoreWords:
                 ignoreWords.append(word)
-                await ctx.send("{} added to the ignore list, {}".format(word, userName),
+                await ctx.send("{} added to the ignore list, {}".format(
+                    word, userName),
                                delete_after=DELETE_TIME)
             else:
-                await ctx.send("Sorry {}, you are already ignoring {} words, or you are "
-                               "trying to add a duplicate word".format(userName,
-                                                                       MAX_WORDS_IGNORE),
-                               delete_after=DELETE_TIME)
+                await ctx.send(
+                    "Sorry {}, you are already ignoring {} words, or you are "
+                    "trying to add a duplicate word".format(
+                        userName, MAX_WORDS_IGNORE),
+                    delete_after=DELETE_TIME)
         await ctx.message.delete()
 
     @wordIgnore.command(name="del", aliases=["delete", "remove", "rm"])
@@ -303,7 +321,8 @@ class Highlight(commands.Cog):
         async with self.config.member(ctx.author).ignoreWords() as ignoreWords:
             if word in ignoreWords:
                 ignoreWords.remove(word)
-                await ctx.send("{} removed from the ignore list, {}".format(word, userName),
+                await ctx.send("{} removed from the ignore list, {}".format(
+                    word, userName),
                                delete_after=DELETE_TIME)
             else:
                 await ctx.send("You are not currently ignoring this word!",
@@ -329,14 +348,16 @@ class Highlight(commands.Cog):
                 try:
                     await ctx.message.author.send(embed=embed)
                 except discord.Forbidden:
-                    await ctx.send("You do not have DMs enabled, please enable them!",
-                                   delete_after=DELETE_TIME)
+                    await ctx.send(
+                        "You do not have DMs enabled, please enable them!",
+                        delete_after=DELETE_TIME)
                 else:
                     await ctx.send("Please check your DMs.")
             else:
-                await ctx.send("Sorry {}, you currently do not have any ignored "
-                               "words.".format(userName),
-                               delete_after=DELETE_TIME)
+                await ctx.send(
+                    "Sorry {}, you currently do not have any ignored "
+                    "words.".format(userName),
+                    delete_after=DELETE_TIME)
 
     @highlight.command(name="timeout")
     @commands.guild_only()
@@ -355,11 +376,9 @@ class Highlight(commands.Cog):
             Maximum timeout is 3600 seconds (1 hour).
         """
         if seconds < 0 or seconds > 3600:
-            await ctx.send("Please specifiy a timeout between 0 and 3600 seconds!")
+            await ctx.send(
+                "Please specifiy a timeout between 0 and 3600 seconds!")
             return
-
-        guildId = ctx.message.guild.id
-        userId = ctx.message.author.id
 
         await self.config.member(ctx.author).timeout.set(seconds)
 
@@ -398,8 +417,9 @@ class Highlight(commands.Cog):
 
         timeoutVal = timedelta(seconds=timeout)
         lastTrig = self.lastTriggered[sid][cid][uid]
-        self.logger.debug("Timeout %s, last triggered %s, message timestamp %s",
-                     timeoutVal, lastTrig, msg.created_at)
+        self.logger.debug(
+            "Timeout %s, last triggered %s, message timestamp %s", timeoutVal,
+            lastTrig, msg.created_at)
         if msg.created_at - lastTrig < timeoutVal:
             # User has been triggered recently.
             return True
@@ -432,16 +452,15 @@ class Highlight(commands.Cog):
                 self.lastTriggered[sid][cid] = {}
             self.lastTriggered[sid][cid][uid] = msg.created_at
 
-
     async def checkHighlights(self, msg: discord.Message):
         """Background listener to check if a highlight has been triggered."""
         if not isinstance(msg.channel, discord.TextChannel):
             return
 
-        guildId = msg.guild.id
         userId = msg.author.id
         user = msg.author
-        channelBlId = await self.config.guild(msg.channel.guild).ignoreChannelID()
+        channelBlId = await self.config.guild(msg.channel.guild
+                                              ).ignoreChannelID()
 
         # Prevents messages in a blacklisted channel from triggering highlight word
         if channelBlId and msg.channel.id == channelBlId:
@@ -464,10 +483,12 @@ class Highlight(commands.Cog):
             async for message in msg.channel.history(limit=50, before=msg):
                 activeMessages.append(message)
         except aiohttp.ClientResponseError as error:
-            self.logger.error("Client response error within discord.py!", exc_info=True)
+            self.logger.error("Client response error within discord.py!",
+                              exc_info=True)
             self.logger.error(error)
         except aiohttp.ServerDisconnectedError:
-            self.logger.error("Server disconnect error within discord.py!", exc_info=True)
+            self.logger.error("Server disconnect error within discord.py!",
+                              exc_info=True)
             self.logger.error(error)
 
         # Iterate through every user's words on the guild, and notify all highlights
@@ -477,15 +498,17 @@ class Highlight(commands.Cog):
             isWordIgnored = False
 
             # Handle case where message author has been blacklisted by the user.
-            if KEY_BLACKLIST in data.keys() and msg.author.id in data[KEY_BLACKLIST]:
+            if KEY_BLACKLIST in data.keys(
+            ) and msg.author.id in data[KEY_BLACKLIST]:
                 continue
 
             # Handle case where message contains words being ignored byu the user.
             if KEY_WORDS_IGNORE in data.keys():
                 self.logger.debug("Checking for ignored words")
                 for word in data[KEY_WORDS_IGNORE]:
-                    if _isWordMatch(word, msg.content):
-                        self.logger.debug("%s is being ignored, skipping user.", word)
+                    if self._isWordMatch(word, msg.content):
+                        self.logger.debug(
+                            "%s is being ignored, skipping user.", word)
                         isWordIgnored = True
                         break
 
@@ -497,9 +520,11 @@ class Highlight(commands.Cog):
             # check to see if there is anything that needs to be highlighted.
             for word in data[KEY_WORDS]:
                 active = _isActive(currentUserId, msg, activeMessages)
-                match = _isWordMatch(word, msg.content)
-                timeout = data[KEY_TIMEOUT] if KEY_TIMEOUT in data.keys() else DEFAULT_TIMEOUT
-                triggeredRecently = self._triggeredRecently(msg, currentUserId, timeout)
+                match = self._isWordMatch(word, msg.content)
+                timeout = data[KEY_TIMEOUT] if KEY_TIMEOUT in data.keys(
+                ) else DEFAULT_TIMEOUT
+                triggeredRecently = self._triggeredRecently(
+                    msg, currentUserId, timeout)
                 if match and not active and not triggeredRecently \
                         and userId != currentUserId:
                     hiliteUser = msg.guild.get_member(currentUserId)
@@ -513,79 +538,121 @@ class Highlight(commands.Cog):
                     self._triggeredUpdate(msg, currentUserId)
                     tasks.append(self._notifyUser(hiliteUser, msg, word))
 
-        await asyncio.gather(*tasks) # pylint: disable=no-member
+        await asyncio.gather(*tasks)  # pylint: disable=no-member
 
-    async def _notifyUser(self, user: discord.Member, message: discord.Message, word: str):
+    async def _notifyUser(self, user: discord.Member, message: discord.Message,
+                          word: str):
         """Notify the user of the triggered highlight word."""
         msgs = []
         try:
             async for msg in message.channel.history(limit=6, around=message):
                 msgs.append(msg)
         except aiohttp.ClientResponseError as error:
-            self.logger.error("Client response error within discord.py!", exc_info=True)
+            self.logger.error("Client response error within discord.py!",
+                              exc_info=True)
             self.logger.error(error)
         except aiohttp.ServerDisconnectedError as error:
-            self.logger.error("Server disconnect error within discord.py!", exc_info=True)
+            self.logger.error("Server disconnect error within discord.py!",
+                              exc_info=True)
             self.logger.error(error)
         msgContext = sorted(msgs, key=lambda r: r.created_at)
         msgUrl = message.jump_url
-        notifyMsg = ("In #{1.channel.name}, you were mentioned with highlight word "
-                     "**{0}**:".format(word, message))
+        notifyMsg = (
+            "In #{1.channel.name}, you were mentioned with highlight word "
+            "**{0}**:".format(word, message))
         embedMsg = ""
         msgStillThere = False
         for msg in msgContext:
             time = msg.created_at
-            time = time.replace(tzinfo=timezone.utc).astimezone(tz=None).strftime('%H:%M:%S %Z')
+            time = time.replace(tzinfo=timezone.utc).astimezone(
+                tz=None).strftime('%H:%M:%S %Z')
             escapedMsg = chat_formatting.escape(msg.content, formatting=True)
             embedMsg += ("[{0}] {1.author.name}#{1.author.discriminator}: {2}"
                          "\n".format(time, msg, escapedMsg))
-            if _isWordMatch(word, msg.content):
+            if self._isWordMatch(word, msg.content):
                 msgStillThere = True
         if not msgStillThere:
             return
-        embed = discord.Embed(title=user.name, description=embedMsg,
+        embed = discord.Embed(title=user.name,
+                              description=embedMsg,
                               colour=discord.Colour.red())
-        embed.add_field(name="Context", value="[Click to Jump]({})".format(msgUrl))
-        time = message.created_at.replace(tzinfo=timezone.utc).astimezone(tz=None)
-        footer = "Triggered at | {}".format(time.strftime('%a, %d %b %Y %I:%M%p %Z'))
+        embed.add_field(name="Context",
+                        value="[Click to Jump]({})".format(msgUrl))
+        time = message.created_at.replace(tzinfo=timezone.utc).astimezone(
+            tz=None)
+        footer = "Triggered at | {}".format(
+            time.strftime('%a, %d %b %Y %I:%M%p %Z'))
         embed.set_footer(text=footer)
         try:
             await user.send(content=notifyMsg, embed=embed)
             self.logger.info("%s#%s (%s) was successfully triggered.",
-                        user.name, user.discriminator, user.id)
+                             user.name, user.discriminator, user.id)
         except discord.errors.Forbidden as error:
-            self.logger.error("Could not notify %s#%s (%s)!  They probably has DMs disabled!",
-                         user.name, user.discriminator, user.id)
+            self.logger.error(
+                "Could not notify %s#%s (%s)!  They probably has DMs disabled!",
+                user.name, user.discriminator, user.id)
 
     # Event listeners
     @commands.Cog.listener()
-    async def on_message(self, msg):
+    async def on_message(self, msg):  # pylint: disable=invalid-name
         await self.checkHighlights(msg)
 
     @commands.Cog.listener()
-    async def on_guild_channel_create(self, channel: discord.abc.GuildChannel):
-        """Background listener to check if dark-hour has been created"""
-        self.logger.info("New Channel creation has been detected. Name: %s, ID: %s",
-                         channel.name, channel.id)
+    async def on_guild_channel_create(self, channel: discord.abc.GuildChannel):         \
+            # pylint: disable=invalid-name
+        """Background listener to check if dark-hour has been created."""
+        self.logger.info(
+            "New Channel creation has been detected. Name: %s, ID: %s",
+            channel.name, channel.id)
         if channel.name == "dark-hour":
-            await self.config.guild(channel.guild).ignoreChannelID.set(channel.id)
-            self.logger.info("Dark hour has been detected and channel id %s "
-                             "will be blacklisted from highlights.", channel.id)
+            await self.config.guild(channel.guild
+                                    ).ignoreChannelID.set(channel.id)
+            self.logger.info(
+                "Dark hour has been detected and channel id %s "
+                "will be blacklisted from highlights.", channel.id)
         else:
-            self.logger.info("New channel is not called dark hour and will not be "
-                             "blacklisted")
+            self.logger.info(
+                "New channel is not called dark hour and will not be "
+                "blacklisted")
 
     @commands.Cog.listener()
-    async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel):
-        """Background listener to check if dark-hour has been deleted"""
+    async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel):         \
+            # pylint: disable=invalid-name
+        """Background listener to check if dark-hour has been deleted."""
         channelBlId = await self.config.guild(channel.guild).ignoreChannelID()
         if channelBlId and channel.id == channelBlId:
             await self.config.guild(channel.guild).ignoreChannelID.set(None)
-            self.logger.info("Dark hour deletion has been detected and channelBlId has "
-                             "been reset")
+            self.logger.info(
+                "Dark hour deletion has been detected and channelBlId has "
+                "been reset")
         else:
-            self.logger.info("Deleted channel is not dark hour so dark hour ID remains "
-                             "unchanged")
+            self.logger.info(
+                "Deleted channel is not dark hour so dark hour ID remains "
+                "unchanged")
+
+    def _isWordMatch(self, word, string):
+        """See if the word/regex matches anything in string.
+
+        Parameters:
+        -----------
+        word: str
+            The regex/word you wish to see exists.
+        string: str
+            The string in which you want to check if word is in.
+
+        Returns:
+        --------
+        bool
+            Whether or not word is in string.
+        """
+        try:
+            regex = r'\b{}\b'.format(re.escape(word.lower()))
+            return bool(re.search(regex, string.lower()))
+        except Exception as error:  # pylint: disable=broad-except
+            self.logger.error("Regex error: %s", word)
+            self.logger.error(error)
+            return False
+
 
 def _isActive(userId, originalMessage, messages, timeout=DEFAULT_TIMEOUT):
     """Checks to see if the user has been active on a channel, given a message.
@@ -611,29 +678,7 @@ def _isActive(userId, originalMessage, messages, timeout=DEFAULT_TIMEOUT):
     """
     for msg in messages:
         deltaSinceMsg = originalMessage.created_at - msg.created_at
-        if msg.author.id == userId and deltaSinceMsg <= timedelta(seconds=timeout):
+        if msg.author.id == userId and deltaSinceMsg <= timedelta(
+                seconds=timeout):
             return True
     return False
-
-def _isWordMatch(word, string):
-    """See if the word/regex matches anything in string.
-
-    Parameters:
-    -----------
-    word: str
-        The regex/word you wish to see exists.
-    string: str
-        The string in which you want to check if word is in.
-
-    Returns:
-    --------
-    bool
-        Whether or not word is in string.
-    """
-    try:
-        regex = r'\b{}\b'.format(re.escape(word.lower()))
-        return bool(re.search(regex, string.lower()))
-    except Exception as error: # pylint: disable=broad-except
-        self.logger.error("Regex error: %s", word)
-        self.logger.error(error)
-        return False

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -593,13 +593,12 @@ class Highlight(commands.Cog):
                 user.name, user.discriminator, user.id)
 
     # Event listeners
-    @commands.Cog.listener()
-    async def on_message(self, msg):  # pylint: disable=invalid-name
+    @commands.Cog.listener("on_message")
+    async def onMessage(self, msg):
         await self.checkHighlights(msg)
 
-    @commands.Cog.listener()
-    async def on_guild_channel_create(self, channel: discord.abc.GuildChannel):         \
-            # pylint: disable=invalid-name
+    @commands.Cog.listener("on_guild_channel_create")
+    async def onGuildChannelCreate(self, channel: discord.abc.GuildChannel):
         """Background listener to check if dark-hour has been created."""
         self.logger.info(
             "New Channel creation has been detected. Name: %s, ID: %s",
@@ -615,9 +614,8 @@ class Highlight(commands.Cog):
                 "New channel is not called dark hour and will not be "
                 "blacklisted")
 
-    @commands.Cog.listener()
-    async def on_guild_channel_delete(self, channel: discord.abc.GuildChannel):         \
-            # pylint: disable=invalid-name
+    @commands.Cog.listener("on_guild_channel_delete")
+    async def onGuildChannelDelete(self, channel: discord.abc.GuildChannel):
         """Background listener to check if dark-hour has been deleted."""
         channelBlId = await self.config.guild(channel.guild).ignoreChannelID()
         if channelBlId and channel.id == channelBlId:

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -154,7 +154,8 @@ class Highlight(commands.Cog):
                     await ctx.message.author.send(embed=embed)
                 except discord.Forbidden:
                     await ctx.send(
-                        "You do not have DMs enabled, please enable them!",
+                        "{}, you do not have DMs enabled, please enable them!".
+                        format(ctx.message.author.mention),
                         delete_after=DELETE_TIME)
                 else:
                     await ctx.send("Please check your DMs.",
@@ -265,7 +266,8 @@ class Highlight(commands.Cog):
                     await ctx.message.author.send(embed=embed)
                 except discord.Forbidden:
                     await ctx.send(
-                        "You do not have DMs enabled, please enable them!",
+                        "{}, you do not have DMs enabled, please enable them!".
+                        format(ctx.message.author.mention),
                         delete_after=DELETE_TIME)
                 else:
                     await ctx.send("Please check your DMs.",
@@ -349,7 +351,8 @@ class Highlight(commands.Cog):
                     await ctx.message.author.send(embed=embed)
                 except discord.Forbidden:
                     await ctx.send(
-                        "You do not have DMs enabled, please enable them!",
+                        "{}, you do not have DMs enabled, please enable them!".
+                        format(ctx.message.author.mention),
                         delete_after=DELETE_TIME)
                 else:
                     await ctx.send("Please check your DMs.")


### PR DESCRIPTION
### Type
- [x] Bugfix

### Description of the changes
- Gracefully handles case where user does not have DMs by replying in channel that the user has DMs disabled.
- Resolves #239 by using d.py API's `delete_after` arguments.
- Clean up unused imports and run file through yapf and docformatter. 