### PR TITLE
Save logs to each cog's respective data folder

### DIFF
--- a/cogs/highlight/__init__.py
+++ b/cogs/highlight/__init__.py
@@ -20,17 +20,5 @@ def checkFolders():
 
 def setup(bot: Red):
     """Add the cog to the bot."""
-    global LOGGER # pylint: disable=global-statement
-    checkFolders()
     highlightCog = Highlight(bot)
-    highlightCog.logger = logging.getLogger("red.Highlight")
-    if highlightCog.logger.level == 0:
-        # Prevents the LOGGER from being loaded again in case of module reload.
-        highlightCog.logger.setLevel(logging.INFO)
-        handler = logging.FileHandler(filename="{}info.log".format(LOG_FOLDER),
-                                      encoding="utf-8",
-                                      mode="a")
-        handler.setFormatter(logging.Formatter("%(asctime)s %(message)s",
-                                               datefmt="[%d/%m/%Y %H:%M:%S]"))
-        highlightCog.logger.addHandler(handler)
     bot.add_cog(highlightCog)

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -9,7 +9,7 @@ from threading import Lock
 import asyncio
 import aiohttp
 import discord
-from redbot.core import Config, commands
+from redbot.core import Config, commands, data_manager
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
 from redbot.core.utils import chat_formatting
@@ -53,7 +53,22 @@ class Highlight(commands.Cog):
         self.lastTriggered = {}
         self.triggeredLock = Lock()
         self.wordFilter = None
-        self.logger = None
+
+        # Initialize logger and save to cog folder.
+        saveFolder = data_manager.cog_data_path(cog_instance=self)
+        self.logger = logging.getLogger("red.Highlight")
+        if self.logger.level == 0:
+            # Prevents the self.logger from being loaded again in case of module reload.
+            self.logger.setLevel(logging.INFO)
+            handler = logging.FileHandler(filename=str(saveFolder) +
+                                          "/info.log",
+                                          encoding="utf-8",
+                                          mode="a")
+            handler.setFormatter(
+                logging.Formatter("%(asctime)s %(message)s",
+                                  datefmt="[%d/%m/%Y %H:%M:%S]"))
+            self.logger.addHandler(handler)
+
 
     async def _sleepThenDelete(self, msg, time):
         await asyncio.sleep(time)  # pylint: disable=no-member

--- a/cogs/rss/__init__.py
+++ b/cogs/rss/__init__.py
@@ -2,34 +2,11 @@
 Init file for RSS cog.
 """
 
-
-import logging
-import os
-
 from redbot.core.bot import Red
 from .rss import RSSFeed
 
-LOG_FOLDER = "log/lui-cogs/rss"
-LOGGER = None
-def checkFolders():
-    """Make sure folder for logs is available."""
-    if not os.path.exists(LOG_FOLDER):
-        os.makedirs(LOG_FOLDER)
-
 def setup(bot: Red):
     """Add the cog to the bot."""
-    global LOGGER # pylint: disable=global-statement
-    LOGGER = logging.getLogger("red.RSSFeed")
-    if LOGGER.level == 0:
-        # Prevents the LOGGER from being loaded again in case of module reload.
-        LOGGER.setLevel(logging.INFO)
-        handler = logging.FileHandler(filename="data/rss/info.log",
-                                      encoding="utf-8",
-                                      mode="a")
-        handler.setFormatter(logging.Formatter("%(asctime)s %(message)s",
-                                               datefmt="[%d/%m/%Y %H:%M:%S]"))
-        LOGGER.addHandler(handler)
     rssCog = RSSFeed(bot)
-    rssCog.logger = LOGGER
     bot.add_cog(rssCog)
     bot.loop.create_task(rssCog.rss())

--- a/cogs/rss/rss.py
+++ b/cogs/rss/rss.py
@@ -11,7 +11,7 @@ import aiohttp
 import feedparser
 from bs4 import BeautifulSoup
 import discord
-from redbot.core  import checks, Config, commands
+from redbot.core  import checks, Config, commands, data_manager
 from redbot.core.bot import Red
 
 KEY_CHANNEL = "post_channel"

--- a/cogs/rss/rss.py
+++ b/cogs/rss/rss.py
@@ -54,7 +54,6 @@ class RSSFeed(commands.Cog):
         self.bot = bot
         self.config = Config.get_conf(self, identifier=5842647,
                                       force_registration=True)
-        self.logger = logging.getLogger('discord')
         defaultGlobal = {
             "interval": 60
                 }
@@ -65,6 +64,21 @@ class RSSFeed(commands.Cog):
                 }
         self.config.register_global(**defaultGlobal)
         self.config.register_guild(**defaultGuild)
+
+        # Initialize logger and save to cog folder.
+        saveFolder = data_manager.cog_data_path(cog_instance=self)
+        self.logger = logging.getLogger("red.RSSFeed")
+        if self.logger.level == 0:
+            # Prevents the self.logger from being loaded again in case of module reload.
+            self.logger.setLevel(logging.INFO)
+            handler = logging.FileHandler(filename=str(saveFolder) +
+                                          "/info.log",
+                                          encoding="utf-8",
+                                          mode="a")
+            handler.setFormatter(
+                logging.Formatter("%(asctime)s %(message)s",
+                                  datefmt="[%d/%m/%Y %H:%M:%S]"))
+            self.logger.addHandler(handler)
 
     @checks.mod_or_permissions(manage_messages=True)
     @commands.group(name="rss", pass_context=True, no_pm=True)

--- a/cogs/wordfilter/__init__.py
+++ b/cogs/wordfilter/__init__.py
@@ -6,32 +6,10 @@ deleting a message.
 This cog requires paginator.py, obtainable from Rapptz/RoboDanny.
 """
 
-LOG_FOLDER = "log/lui-cogs/wordfilter/"
-
-import logging
-import os
-
 from redbot.core.bot import Red
 from .wordfilter import WordFilter
 
-def checkFolders():
-    """Make sure folder for logs is available."""
-    if not os.path.exists(LOG_FOLDER):
-        os.makedirs(LOG_FOLDER)
-
 def setup(bot: Red):
     """Add the cog to the bot."""
-    global LOGGER # pylint: disable=global-statement
-    checkFolders()
     wordFilterCog = WordFilter(bot)
-    wordFilterCog.logger = logging.getLogger("red.WordFilter")
-    if wordFilterCog.logger.level == 0:
-        # Prevents the LOGGER from being loaded again in case of module reload.
-        wordFilterCog.logger.setLevel(logging.INFO)
-        handler = logging.FileHandler(filename="{}info.log".format(LOG_FOLDER),
-                                      encoding="utf-8",
-                                      mode="a")
-        handler.setFormatter(logging.Formatter("%(asctime)s %(message)s",
-                                               datefmt="[%d/%m/%Y %H:%M:%S]"))
-        wordFilterCog.logger.addHandler(handler)
     bot.add_cog(wordFilterCog)

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -37,7 +37,21 @@ class WordFilter(commands.Cog): # pylint: disable=too-many-instance-attributes
         self.bot = bot
         self.config = Config.get_conf(self, identifier=5842647, force_registration=True)
         self.config.register_guild(**BASE) # Register default (empty) settings.
-        self.logger = None
+
+        # Initialize logger, and save to cog folder.
+        saveFolder = data_manager.cog_data_path(cog_instance=self)
+        self.logger = logging.getLogger("red.WordFilter")
+        if self.logger.level == 0:
+            # Prevents the self.logger from being loaded again in case of module reload.
+            self.logger.setLevel(logging.INFO)
+            handler = logging.FileHandler(filename=str(saveFolder) +
+                                          "/info.log",
+                                          encoding="utf-8",
+                                          mode="a")
+            handler.setFormatter(
+                logging.Formatter("%(asctime)s %(message)s",
+                                  datefmt="[%d/%m/%Y %H:%M:%S]"))
+            self.logger.addHandler(handler)
 
         # self.commandBlacklist = dataIO.load_json(PATH_BLACKLIST)
         # self.filters = dataIO.load_json(PATH_FILTER)

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -10,7 +10,7 @@ import logging
 import asyncio
 import random
 import discord
-from redbot.core import Config, checks, commands
+from redbot.core import Config, checks, commands, data_manager
 from redbot.core.utils import paginator
 from redbot.core.bot import Red
 


### PR DESCRIPTION
### Type
- [x] Bugfix

### Description of the changes
Make logging save logs within each cog's data folder by getting the folder path from Red's `data_manager`.