### PR TITLE
[TempChannels] Add archiving capabilities

### DIFF
--- a/cogs/tempchannels/tempchannels.py
+++ b/cogs/tempchannels/tempchannels.py
@@ -151,6 +151,7 @@ class TempChannels(commands.Cog):
         await ctx.send(msg)
 
     @tempChannels.command(name="archive")
+    @checks.admin()
     async def tempChannelsArchive(self, ctx: Context):
         """Toggle archiving the channel after the fact."""
         async with self.config.guild(ctx.guild).all() as guildData:

--- a/cogs/tempchannels/tempchannels.py
+++ b/cogs/tempchannels/tempchannels.py
@@ -634,9 +634,6 @@ class TempChannels(commands.Cog):
                                 guildData[KEY_CH_CREATED] = False
 
                                 if chanObj and guildData[KEY_ARCHIVE]:
-                                    currentDate = datetime.now().strftime(
-                                        "%Y-%m-%d_%H-%M-%S")
-                                    await chanObj.edit(name=f"tc-{currentDate}")
                                     await chanObj.set_permissions(guild.default_role,
                                         overwrite=PERMS_READ_N)
                                     for role in guild.roles:
@@ -645,6 +642,9 @@ class TempChannels(commands.Cog):
                                         await chanObj.set_permissions(
                                             role, overwrite=None,
                                             reason="Archiving tempchannel")
+                                    currentDate = datetime.now().strftime(
+                                        "%Y-%m-%d_%H-%M-%S")
+                                    await chanObj.edit(name=f"tc-{currentDate}")
                                     self.logger.info(
                                         "Channel #%s (%s) in %s (%s) was archived.",
                                         chanObj.name, chanObj.id, guild.name,


### PR DESCRIPTION
### Type

- [x] Enhancement

### Description of the changes
Closes #277 . Add archive capabilities in case we need to go back on temporary channel contents. The channel and the settings toggle will only be visible to admins.

- Add archive subcommand.
- Add archive check to show command.