### PR TITLE
[Tags] Migrate to v3

### DIFF
--- a/cogs/tags/LICENSE.txt
+++ b/cogs/tags/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/cogs/tags/__init__.py
+++ b/cogs/tags/__init__.py
@@ -1,0 +1,10 @@
+"""Tags module
+Custom commands with ownership, stats, and more.
+"""
+
+from redbot.core.bot import Red
+from .tags import Tags
+
+def setup(bot: Red):
+    """Add the cog to the bot."""
+    bot.add_cog(Tags(bot))

--- a/cogs/tags/config.py
+++ b/cogs/tags/config.py
@@ -32,7 +32,7 @@ class Config:
             self._db = {}
 
     async def load(self):
-        with await self.lock:
+        async with self.lock:
             await self.loop.run_in_executor(None, self.load_from_file)
 
     def _dump(self):
@@ -44,7 +44,7 @@ class Config:
         os.replace(temp, self.directory+self.name)
 
     async def save(self):
-        with await self.lock:
+        async with self.lock:
             await self.loop.run_in_executor(None, self._dump)
 
     def get(self, key, *args):

--- a/cogs/tags/config.py
+++ b/cogs/tags/config.py
@@ -1,0 +1,74 @@
+import json
+import os
+import uuid
+import asyncio
+
+"""
+NOTE: I wrote none of this (well, updated some things),
+all credit goes to the author of RoboDanny: https://github.com/Rapptz/RoboDanny/
+"""
+
+class Config:
+    """The "database" object. Internally based on ``json``."""
+
+    def __init__(self, name, **options):
+        self.name = name
+        self.cogname = options.pop('cogname', None)
+        self.directory = "data/{}/".format(self.cogname)
+        self.object_hook = options.pop('object_hook', None)
+        self.encoder = options.pop('encoder', None)
+        self.loop = options.pop('loop', asyncio.get_event_loop())
+        self.lock = asyncio.Lock()
+        if options.pop('load_later', False):
+            self.loop.create_task(self.load())
+        else:
+            self.load_from_file()
+
+    def load_from_file(self):
+        try:
+            with open(self.directory+self.name, 'r') as f:
+                self._db = json.load(f, object_hook=self.object_hook)
+        except FileNotFoundError:
+            self._db = {}
+
+    async def load(self):
+        with await self.lock:
+            await self.loop.run_in_executor(None, self.load_from_file)
+
+    def _dump(self):
+        temp = '%s-%s.tmp' % (uuid.uuid4(), self.name)
+        with open(temp, 'w', encoding='utf-8') as tmp:
+            json.dump(self._db.copy(), tmp, ensure_ascii=True, cls=self.encoder, separators=(',', ':'))
+
+        # atomically move the file
+        os.replace(temp, self.directory+self.name)
+
+    async def save(self):
+        with await self.lock:
+            await self.loop.run_in_executor(None, self._dump)
+
+    def get(self, key, *args):
+        """Retrieves a config entry."""
+        return self._db.get(key, *args)
+
+    async def put(self, key, value, *args):
+        """Edits a config entry."""
+        self._db[key] = value
+        await self.save()
+
+    async def remove(self, key):
+        """Removes a config entry."""
+        del self._db[key]
+        await self.save()
+
+    def __contains__(self, item):
+        return item in self._db
+
+    def __getitem__(self, item):
+        return self._db[item]
+
+    def __len__(self):
+        return len(self._db)
+
+    def all(self):
+        return self._db

--- a/cogs/tags/constants.py
+++ b/cogs/tags/constants.py
@@ -1,0 +1,6 @@
+DEFAULT_MAX = 50 # Default max number of tags per user.
+KEY_MAX = "max"
+KEY_USE_ALIAS = "useAlias"
+DUMP_IN = "data/tags/tags.json"
+DUMP_OUT = "data/tags/export.csv"
+ALLOWED_ROLE = "Sensei"

--- a/cogs/tags/rolecheck.py
+++ b/cogs/tags/rolecheck.py
@@ -1,0 +1,38 @@
+import discord
+from discord.ext import commands
+import functools
+
+async def check_permissions(ctx, perms):
+    if await ctx.bot.is_owner(ctx.author):
+        return True
+    elif not perms:
+        return False
+
+    ch = ctx.message.channel
+    author = ctx.message.author
+    resolved = ch.permissions_for(author)
+    return all(getattr(resolved, name, None) == value for name, value in perms.items())
+
+async def role_or_permissions(ctx, check, **perms):
+    if await check_permissions(ctx, perms):
+        return True
+
+    ch = ctx.message.channel
+    author = ctx.message.author
+    if isinstance(ch, discord.DMChannel):
+        return False # can't have roles in PMs
+
+    role = discord.utils.find(check, author.roles)
+    return role is not None
+
+def role_or_mod_or_permissions(role=None, **perms):
+    async def predicate(ctx):
+        server = ctx.guild
+        mod_roles = [r.name.lower() for r in await ctx.bot.get_mod_roles(server)] 
+        admin_roles = [r.name.lower() for r in await ctx.bot.get_admin_roles(server)]
+        roles = mod_roles + admin_roles
+        if role:
+            roles.append(role.lower())
+        return await role_or_permissions(ctx, lambda r: r.name.lower() in roles, **perms)
+        return retVal
+    return commands.check(predicate)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -408,6 +408,8 @@ class Tags(commands.Cog):
     async def generic_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send('Tag ' + str(error))
+        else:
+            raise error
 
     @tag.command(name="alias")
     @commands.guild_only()
@@ -526,6 +528,8 @@ class Tags(commands.Cog):
     async def tag_make_error(self, ctx: Context, error):
         if isinstance(error, commands.TooManyArguments):
             await ctx.send('Please call just {0.prefix}tag make'.format(ctx))
+        else:
+            raise error
 
     def top_three_tags(self, db):
         emoji = 129351 # ord(':first_place:')
@@ -755,6 +759,8 @@ class Tags(commands.Cog):
     async def info_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send('Missing tag name to get info of.')
+        else:
+            raise error
 
     @tag.command(name="raw")
     async def raw(self, ctx: Context, *, name: str):
@@ -948,6 +954,8 @@ class Tags(commands.Cog):
     async def search_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send('Missing query to search for.')
+        else:
+            raise error
     
     @tag.command(name="toggledm")
     @commands.guild_only()

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -248,23 +248,29 @@ class Tags(commands.Cog):
         if len(lookup) > 100:
             raise RuntimeError('Tag name is a maximum of 100 characters.')
 
-    @tag.command(pass_context=True, no_pm=True)
+    @tag.command(name="max")
+    @commands.guild_only()
     @checks.mod_or_permissions()
-    async def max(self, ctx, num_tags: int=None):
+    async def max(self, ctx: Context, num_tags: int=None):
         """Set the max number of tags per user. Leave blank to show current setting.
 
         This limit does not apply to admins or mods.
+
+        Parameters:
+        -----------
+        num_tags: int
+            The maximum number of tags per user.
         """
         if not num_tags:
             limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
-            await self.bot.say("The current tag limit per user is {}.".format(limit))
+            await ctx.send("The current tag limit per user is {}.".format(limit))
             return
         if num_tags < 0:
-            await self.bot.say("Please set a value greater than 0.")
+            await ctx.send("Please set a value greater than 0.")
             return
 
         await self.settings.put(KEY_MAX, num_tags)
-        await self.bot.say("The tag limit was set to {}".format(num_tags))
+        await ctx.send("The tag limit was set to {}".format(num_tags))
 
     @tag.command(pass_context=True, no_pm=True)
     @checks.mod_or_permissions()

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -60,7 +60,7 @@ class TagInfo:
 
         owner = discord.utils.find(lambda m: m.id == self.owner_id, ctx.bot.get_all_members())
         if owner is None:
-            owner = await ctx.bot.get_user_info(self.owner_id)
+            owner = await ctx.bot.fetch_user(self.owner_id)
 
         e.set_author(name=str(owner), icon_url=owner.avatar_url or owner.default_avatar_url)
         e.set_footer(text='Generic' if self.is_generic else 'Server-specific')
@@ -93,7 +93,7 @@ class TagAlias:
 
         owner = discord.utils.find(lambda m: m.id == self.owner_id, ctx.bot.get_all_members())
         if owner is None:
-            owner = await ctx.bot.get_user_info(self.owner_id)
+            owner = await ctx.bot.get_user(self.owner_id)
 
         e.set_author(name=str(owner), icon_url=owner.avatar_url or owner.default_avatar_url)
         return e

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -360,9 +360,9 @@ class Tags(commands.Cog):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send('Tag ' + str(error))
 
-    @tag.command(pass_context=True)
+    @tag.command(name="generic")
     @checks.mod_or_permissions(administrator=True)
-    async def generic(self, ctx, name : str, *, content : str):
+    async def generic(self, ctx: Context, name : str, *, content : str):
         """Creates a new generic tag owned by you.
         Unlike the create tag subcommand,  this will always attempt to create
         a generic tag and not a server-specific one.
@@ -372,27 +372,27 @@ class Tags(commands.Cog):
         try:
             self.verify_lookup(lookup)
         except RuntimeError as e:
-            await self.bot.say(str(e))
+            await ctx.send(str(e))
             return
 
         db = self.config.get('generic', {})
         if lookup in db:
-            await self.bot.say('A tag with the name of "{}" already exists.'.format(name))
+            await ctx.send('A tag with the name of "{}" already exists.'.format(name))
             return
 
         db[lookup] = TagInfo(name, content, ctx.message.author.id,
                              location='generic',
                              created_at=datetime.datetime.utcnow().timestamp())
         await self.config.put('generic', db)
-        await self.bot.say('Tag "{}" successfully created.'.format(name))
+        await ctx.send('Tag "{}" successfully created.'.format(name))
         
-        aliasCog = self.bot.get_cog('Alias')
-        await aliasCog.add_alias(ctx.message.server, name, "tag {}".format(name))
+        # aliasCog = self.bot.get_cog('Alias')
+        # await aliasCog.add_alias(ctx.message.server, name, "tag {}".format(name))
 
     @generic.error
-    async def generic_error(self, error, ctx):
+    async def generic_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
-            await self.bot.say('Tag ' + str(error))
+            await ctx.send('Tag ' + str(error))
 
     @tag.command(pass_context=True, no_pm=True)
     @checks.mod_or_permissions(administrator=True)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -814,35 +814,36 @@ class Tags(commands.Cog):
         else:
             await ctx.send('{0.name} has no tags.'.format(owner))
 
-    @tag.command(name='all', pass_context=True, no_pm=True)
+    @tag.command(name="all")
+    @commands.guild_only()
     async def _all(self, ctx):
         """Lists all server-specific tags for this server."""
 
-        tags = [tag.name for tag in self.config.get(ctx.message.server.id, {}).values()]
+        tags = [tag.name for tag in self.config.get(ctx.message.guild.id, {}).values()]
         tags.sort()
 
         if tags:
             try:
                 self.dm = self.settings.get("dm", False)
                 if self.dm:
-                    await self.bot.say("Check your DMs.")
-                    msg = "Here are a list of tags for {}:\n```".format(ctx.message.server.name)
+                    await ctx.send("Check your DMs.")
+                    msg = "Here are a list of tags for {}:\n```".format(ctx.message.guild.name)
                     for item in tags:
                         if len(msg) + len(item) > 1990:
                             msg += "```"
-                            await self.bot.send_message(ctx.message.author, msg)
+                            await ctx.author.send(msg)
                             msg = "```"
                         msg += item + "\n"
                     msg += "```"
-                    await self.bot.send_message(ctx.message.author, msg)
+                    await ctx.author.send(msg)
                 else:
                     p = Pages(self.bot, message=ctx.message, entries=tags, per_page=15)
                     p.embed.colour =  0x738bd7 # blurple
                     await p.paginate()
             except Exception as e:
-                await self.bot.say(e)
+                await ctx.send(e)
         else:
-            await self.bot.say('This server has no server-specific tags.')
+            await ctx.send('This server has no server-specific tags.')
 
     @tag.command(pass_context=True, no_pm=True)
     @checks.mod_or_permissions(manage_messages=True)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -4,7 +4,6 @@
 # DATE LAST MODIFIED: 2017-04-13
 
 from .config import Config
-from .utils.paginator import Pages
 
 import csv
 import json
@@ -21,7 +20,7 @@ import logging
 from redbot.core import checks, commands
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
-
+from redbot.core.utils.paginator import Pages
 DEFAULT_MAX = 50 # Default max number of tags per user.
 KEY_MAX = "max"
 DUMP_IN = "data/tags/tags.json"
@@ -441,7 +440,7 @@ class Tags(commands.Cog):
 
     @tag.command(ignore_extra=False)
     @commands.guild_only()
-    @checks.sensei_or_mod_or_permissions(administrator=True)
+    # @checks.sensei_or_mod_or_permissions(administrator=True) # TODO Fix this later
     async def make(self, ctx):
         """Interactive makes a tag for you.
         This walks you through the process of creating a tag with
@@ -461,7 +460,7 @@ class Tags(commands.Cog):
         await ctx.send('Hello. What would you like the name tag to be?')
 
         def check(msg: discord.Message):
-            return msg.author == ctx.message.author and msg.channel == ctx.message.channel:
+            return msg.author == ctx.message.author and msg.channel == ctx.message.channel
 
         def name_check(msg: discord.Message):
             if not check( msg ):
@@ -589,7 +588,7 @@ class Tags(commands.Cog):
 
     @tag.command(name="transfer")
     @commands.guild_only()
-    @checks.sensei_or_mod_or_permissions(manage_messages=True)
+    # @checks.sensei_or_mod_or_permissions(manage_messages=True) # TODO Fix this later
     async def transfer(self, ctx: Context, tag_name, user: discord.Member):
         """Transfer your tag to another user.
 
@@ -665,7 +664,7 @@ class Tags(commands.Cog):
                            "cancelled.".format(user.name))
 
     @tag.command(name="delete", aliases=["del", "remove", "rm"])
-    @checks.sensei_or_mod_or_permissions(manage_messages=True)
+    # @checks.sensei_or_mod_or_permissions(manage_messages=True) # TODO Fix this later
     async def remove(self, ctx: Context, *, name : str):
         """Removes a tag that you own.
         The tag owner can always delete their own tags. If someone requests
@@ -804,7 +803,7 @@ class Tags(commands.Cog):
                     msg += "```"
                     await ctx.author.send(msg)
                 else:
-                    p = Pages(self.bot, message=ctx.message, entries=tags)
+                    p = Pages(ctx=ctx, entries=tags, show_entry_count=True)
                     p.embed.colour = 0x738bd7 # blurple
                     p.embed.set_author(name=owner.display_name, icon_url=owner.avatar_url or
                                        owner.default_avatar_url)
@@ -837,7 +836,7 @@ class Tags(commands.Cog):
                     msg += "```"
                     await ctx.author.send(msg)
                 else:
-                    p = Pages(self.bot, message=ctx.message, entries=tags, per_page=15)
+                    p = Pages(ctx=ctx, entries=tags, per_page=15, show_entry_count=True)
                     p.embed.colour =  0x738bd7 # blurple
                     await p.paginate()
             except Exception as e:
@@ -927,7 +926,7 @@ class Tags(commands.Cog):
 
         if results:
             try:
-                p = Pages(self.bot, message=ctx.message, entries=results, per_page=15)
+                p = Pages(ctx=ctx, entries=results, per_page=15, show_entry_count=True)
                 p.embed.colour = 0x738bd7 # blurple
                 await p.paginate()
             except Exception as e:

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -206,17 +206,18 @@ class Tags(commands.Cog):
 
         if server:
             # No limit for mods and admins of server.
+            # Methods below return role IDs.
             mod_roles = await self.bot.get_mod_roles(server)
             admin_roles = await self.bot.get_admin_roles(server)
-            roles = [role.name for role in user.roles]
-            if list(set(admin_roles) & set(roles)) or list(set(mod_role) & set(roles)):
+            roles = user.roles
+            if list(set(admin_roles) & set(roles)) or list(set(mod_roles) & set(roles)):
                 return False
 
         tags = [tag.name for tag in self.config.get('generic', {}).values()
-                if tag.owner_id == user.id]
+                if tag.owner_id == str(user.id)]
         if server:
-            tags.extend(tag.name for tag in self.config.get(server.id, {}).values()
-                        if tag.owner_id == user.id)
+            tags.extend(tag.name for tag in self.config.get(str(server.id), {}).values()
+                        if tag.owner_id == str(user.id))
         limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
         if len(tags) >= limit:
             return True

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -272,16 +272,17 @@ class Tags(commands.Cog):
         await self.settings.put(KEY_MAX, num_tags)
         await ctx.send("The tag limit was set to {}".format(num_tags))
 
-    @tag.command(pass_context=True, no_pm=True)
+    @tag.command(name="dump")
+    @commands.guild_only()
     @checks.mod_or_permissions()
-    async def dump(self, ctx):
+    async def dump(self, ctx: Context):
         """Dumps server-specific tags to a CSV file, sorted by number of uses."""
         sid = ctx.message.server.id
         with self.lock:
             with open(DUMP_IN, "r") as inputFile, open(DUMP_OUT, "w") as outputFile:
                 tags = json.load(inputFile)
                 if sid not in tags.keys():
-                    await self.bot.say("There are no tags on this server!")
+                    await ctx.send("There are no tags on this server!")
 
                 csvWriter = csv.writer(outputFile)
                 headerCreated = False
@@ -299,7 +300,7 @@ class Tags(commands.Cog):
                         csvWriter.writerow(header)
                         headerCreated = True
 
-                    owner = discord.utils.get(ctx.message.server.members, id=tag["owner_id"])
+                    owner = discord.utils.get(ctx.guild.members, id=tag["owner_id"])
                     if not owner:
                         owner = "Unknown"
                     else:
@@ -308,7 +309,7 @@ class Tags(commands.Cog):
                     data = list(tag.values()) + [owner]
                     csvWriter.writerow(data)
 
-            await self.bot.send_file(ctx.message.channel, DUMP_OUT)
+            await ctx.send(file=DUMP_OUT)
 
     @tag.command(pass_context=True, aliases=['add'], no_pm=True)
     @checks.sensei_or_mod_or_permissions(manage_messages=True)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -726,26 +726,26 @@ class Tags(commands.Cog):
         # aliasCog = self.bot.get_cog('Alias')
         # await aliasCog.del_alias(ctx.message.server, lookup)
 
-    @tag.command(pass_context=True, aliases=['owner'])
-    async def info(self, ctx, *, name : str):
+    @tag.command(name="info", aliases=['owner'])
+    async def info(self, ctx: Context, *, name : str):
         """Retrieves info about a tag.
         The info includes things like the owner and how many times it was used.
         """
 
         lookup = name.lower()
-        server = ctx.message.server
+        server = ctx.message.guild
         try:
             tag = self.get_tag(server, lookup, redirect=False)
         except RuntimeError as e:
-            return await self.bot.say(e)
+            return await ctx.send(e)
 
         embed = await tag.embed(ctx, self.get_possible_tags(server))
-        await self.bot.say(embed=embed, content="")
+        await ctx.send(embed=embed)
 
     @info.error
-    async def info_error(self, error, ctx):
+    async def info_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
-            await self.bot.say('Missing tag name to get info of.')
+            await ctx.send('Missing tag name to get info of.')
 
     @tag.command(pass_context=True)
     async def raw(self, ctx, *, name: str):

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -1,0 +1,888 @@
+# Manually imported from:
+# https://github.com/Rapptz/RoboDanny/blob/master/cogs/tags.py
+# DATE IMPORTED: 2017-04-10
+# DATE LAST MODIFIED: 2017-04-13
+
+from .utils import config, checks, formats
+from .utils.paginator import Pages
+
+from discord.ext import commands
+import csv
+import json
+import re
+import datetime
+import discord
+import difflib
+from threading import Lock
+
+DEFAULT_MAX = 50 # Default max number of tags per user.
+KEY_MAX = "max"
+DUMP_IN = "data/tags/tags.json"
+DUMP_OUT = "data/tags/export.csv"
+
+class TagInfo:
+    __slots__ = ('name', 'content', 'owner_id', 'uses', 'location', 'created_at')
+
+    def __init__(self, name, content, owner_id, **kwargs):
+        self.name = name
+        self.content = content
+        self.owner_id = owner_id
+        self.uses = kwargs.pop('uses', 0)
+        self.location = kwargs.pop('location')
+        self.created_at = kwargs.pop('created_at', 0.0)
+
+    @property
+    def is_generic(self):
+        return self.location == 'generic'
+
+    def __str__(self):
+        return self.content
+
+    async def embed(self, ctx, db):
+        e = discord.Embed(title=self.name)
+        e.add_field(name='Owner', value='<@!%s>' % self.owner_id)
+        e.add_field(name='Uses', value=self.uses)
+
+        popular = sorted(db.values(), key=lambda t: t.uses, reverse=True)
+        try:
+            e.add_field(name='Rank', value=popular.index(self) + 1)
+        except:
+            e.add_field(name='Rank', value='Unknown')
+
+        if self.created_at:
+            e.timestamp = datetime.datetime.fromtimestamp(self.created_at)
+
+        owner = discord.utils.find(lambda m: m.id == self.owner_id, ctx.bot.get_all_members())
+        if owner is None:
+            owner = await ctx.bot.get_user_info(self.owner_id)
+
+        e.set_author(name=str(owner), icon_url=owner.avatar_url or owner.default_avatar_url)
+        e.set_footer(text='Generic' if self.is_generic else 'Server-specific')
+        return e
+
+class TagAlias:
+    __slots__ = ('name', 'original', 'owner_id', 'created_at')
+
+    def __init__(self, **kwargs):
+        self.name = kwargs.pop('name')
+        self.original = kwargs.pop('original')
+        self.owner_id = kwargs.pop('owner_id')
+        self.created_at = kwargs.pop('created_at', 0.0)
+
+    @property
+    def is_generic(self):
+        return False
+
+    @property
+    def uses(self):
+        return 0 # compatibility with TagInfo
+
+    async def embed(self, ctx, db):
+        e = discord.Embed(title=self.name)
+        e.add_field(name='Owner', value='<@!%s>' % self.owner_id)
+        e.add_field(name='Original Tag', value=self.original)
+
+        if self.created_at:
+            e.timestamp = datetime.datetime.fromtimestamp(self.created_at)
+
+        owner = discord.utils.find(lambda m: m.id == self.owner_id, ctx.bot.get_all_members())
+        if owner is None:
+            owner = await ctx.bot.get_user_info(self.owner_id)
+
+        e.set_author(name=str(owner), icon_url=owner.avatar_url or owner.default_avatar_url)
+        return e
+
+class TagEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, TagInfo):
+            payload = {
+                attr: getattr(obj, attr)
+                for attr in TagInfo.__slots__
+            }
+            payload['__tag__'] = True
+            return payload
+        if isinstance(obj, TagAlias):
+            payload = {
+                attr: getattr(obj, attr)
+                for attr in TagAlias.__slots__
+            }
+            payload['__tag_alias__'] = True
+            return payload
+        return json.JSONEncoder.default(self, obj)
+
+def tag_decoder(obj):
+    if '__tag__' in obj:
+        return TagInfo(**obj)
+    if '__tag_alias__' in obj:
+        return TagAlias(**obj)
+    return obj
+
+class Tags:
+    """The tag related commands."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = config.Config('tags.json', cogname='tags', encoder=TagEncoder, object_hook=tag_decoder,
+                                                 loop=bot.loop, load_later=True)
+        self.settings = config.Config('settings.json', cogname='tags')
+        self.lock = Lock()
+                                                 
+    def get_database_location(self, message):
+        return 'generic' if message.channel.is_private else message.server.id
+
+    def clean_tag_content(self, content):
+        return content.replace('@everyone', '@\u200beveryone').replace('@here', '@\u200bhere')
+
+    def get_possible_tags(self, server):
+        """Returns a dict of possible tags that the server can execute.
+        If this is a private message then only the generic tags are possible.
+        Server specific tags will override the generic tags.
+        """
+        generic = self.config.get('generic', {}).copy()
+        if server is None:
+            return generic
+
+        generic.update(self.config.get(server.id, {}))
+        return generic
+
+    def get_tag(self, server, name, *, redirect=True):
+        # Basically, if we're in a PM then we will use the generic tag database
+        # if we aren't, we will check the server specific tag database.
+        # If we don't have a server specific database, fallback to generic.
+        # If it isn't found, fallback to generic.
+        all_tags = self.get_possible_tags(server)
+        try:
+            tag = all_tags[name]
+            if isinstance(tag, TagInfo):
+                return tag
+            elif redirect:
+                return all_tags[tag.original.lower()]
+            else:
+                return tag
+        except KeyError:
+            possible_matches = difflib.get_close_matches(name, tuple(all_tags.keys()))
+            if not possible_matches:
+                raise RuntimeError('Tag not found.')
+            raise RuntimeError('Tag not found. Did you mean...\n' + '\n'.join(possible_matches))
+
+    async def user_exceeds_tag_limit(self, server, user: discord.Member):
+        """Check to see if user has too many tags.
+        Accepts:
+        --------
+        server
+            A specific server to check for too many tags
+        user
+            The user being checked for being over the limit
+
+        Returns:
+        --------
+        bool
+            True if too many tags, False if okay.
+        """
+
+        if user.id == self.bot.settings.owner or user.id in self.bot.settings.co_owners:
+            # No limit for bot owner
+            return False
+
+        if server:
+            # No limit for mods and admins of server.
+            mod_role = self.bot.settings.get_server_mod(server).lower()
+            admin_role = self.bot.settings.get_server_admin(server).lower()
+            roles = [role.name for role in user.roles]
+            if admin_role in roles or mod_role in roles:
+                return False
+
+        tags = [tag.name for tag in self.config.get('generic', {}).values()
+                if tag.owner_id == user.id]
+        if server:
+            tags.extend(tag.name for tag in self.config.get(server.id, {}).values()
+                        if tag.owner_id == user.id)
+        limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
+        if len(tags) >= limit:
+            return True
+        return False
+
+    @commands.group(pass_context=True, invoke_without_command=True)
+    async def tag(self, ctx, *, name : str):
+        """Allows you to tag text for later retrieval.
+        If a subcommand is not called, then this will search the tag database
+        for the tag requested.
+        """
+        lookup = name.lower()
+        server = ctx.message.server
+        try:
+            tag = self.get_tag(server, lookup)
+        except RuntimeError as e:
+            return await self.bot.say(e)
+
+        tag.uses += 1
+        await self.bot.say(tag)
+
+        # update the database with the new tag reference
+        db = self.config.get(tag.location)
+        await self.config.put(tag.location, db)
+
+    @tag.error
+    async def tag_error(self, error, ctx):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await self.bot.say('You need to pass in a tag name.')
+
+    def verify_lookup(self, lookup):
+        if '@everyone' in lookup or '@here' in lookup:
+            raise RuntimeError('That tag is using blocked words.')
+
+        if not lookup:
+            raise RuntimeError('You need to actually pass in a tag name.')
+
+        if len(lookup) > 100:
+            raise RuntimeError('Tag name is a maximum of 100 characters.')
+
+    @tag.command(pass_context=True, no_pm=True)
+    @checks.mod_or_permissions()
+    async def max(self, ctx, num_tags: int=None):
+        """Set the max number of tags per user. Leave blank to show current setting.
+
+        This limit does not apply to admins or mods.
+        """
+        if not num_tags:
+            limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
+            await self.bot.say("The current tag limit per user is {}.".format(limit))
+            return
+        if num_tags < 0:
+            await self.bot.say("Please set a value greater than 0.")
+            return
+
+        await self.settings.put(KEY_MAX, num_tags)
+        await self.bot.say("The tag limit was set to {}".format(num_tags))
+
+    @tag.command(pass_context=True, no_pm=True)
+    @checks.mod_or_permissions()
+    async def dump(self, ctx):
+        """Dumps server-specific tags to a CSV file, sorted by number of uses."""
+        sid = ctx.message.server.id
+        with self.lock:
+            with open(DUMP_IN, "r") as inputFile, open(DUMP_OUT, "w") as outputFile:
+                tags = json.load(inputFile)
+                if sid not in tags.keys():
+                    await self.bot.say("There are no tags on this server!")
+
+                csvWriter = csv.writer(outputFile)
+                headerCreated = False
+
+                # Convert to list, and sort by ascending number of uses.
+                tags = [contents for contents in tags[sid].values()]
+                tags = sorted(tags, key=lambda k: k["uses"])
+
+                # We only care about server tags
+                for tag in tags:
+                    tag["created_at"] = datetime.datetime.fromtimestamp(tag["created_at"])
+
+                    if not headerCreated:
+                        header = list(tag.keys()) + ["owner_name"]
+                        csvWriter.writerow(header)
+                        headerCreated = True
+
+                    owner = discord.utils.get(ctx.message.server.members, id=tag["owner_id"])
+                    if not owner:
+                        owner = "Unknown"
+                    else:
+                        owner = owner.name
+
+                    data = list(tag.values()) + [owner]
+                    csvWriter.writerow(data)
+
+            await self.bot.send_file(ctx.message.channel, DUMP_OUT)
+
+    @tag.command(pass_context=True, aliases=['add'], no_pm=True)
+    @checks.sensei_or_mod_or_permissions(manage_messages=True)
+    async def create(self, ctx, name : str, *, content : str):
+        """Creates a new tag owned by you.
+        If you create a tag via private message then the tag is a generic
+        tag that can be accessed in all servers. Otherwise the tag you
+        create can only be accessed in the server that it was created in.
+        """
+        aliasCog = self.bot.get_cog('Alias')
+        if aliasCog.part_of_existing_command(name, ctx.message.server.id):
+            await self.bot.say("This name cannot be used because there is already an internal "
+                               "command with this name.")
+            return
+
+        limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
+        if await self.user_exceeds_tag_limit(ctx.message.server, ctx.message.author):
+            await self.bot.say("You have too many commands. The maximum number of commands "
+                               "per user is {}, please delete some first!".format(limit))
+            return
+
+        content = self.clean_tag_content(content)
+        lookup = name.lower().strip()
+        try:
+            self.verify_lookup(lookup)
+        except RuntimeError as e:
+            return await self.bot.say(e)
+
+        location = self.get_database_location(ctx.message)
+        db = self.config.get(location, {})
+        if lookup in db:
+            await self.bot.say('A tag with the name of "{}" already exists.'.format(name))
+            return
+
+        db[lookup] = TagInfo(name, content, ctx.message.author.id,
+                             location=location,
+                             created_at=datetime.datetime.utcnow().timestamp())
+
+        await self.config.put(location, db)
+        await self.bot.say('Tag "{}" successfully created.'.format(name))
+        
+        aliasCog = self.bot.get_cog('Alias')
+        await aliasCog.add_alias(ctx.message.server, lookup, "tag {}".format(lookup))
+
+    @create.error
+    async def create_error(self, error, ctx):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await self.bot.say('Tag ' + str(error))
+
+    @tag.command(pass_context=True)
+    @checks.mod_or_permissions(administrator=True)
+    async def generic(self, ctx, name : str, *, content : str):
+        """Creates a new generic tag owned by you.
+        Unlike the create tag subcommand,  this will always attempt to create
+        a generic tag and not a server-specific one.
+        """
+        content = self.clean_tag_content(content)
+        lookup = name.lower().strip()
+        try:
+            self.verify_lookup(lookup)
+        except RuntimeError as e:
+            await self.bot.say(str(e))
+            return
+
+        db = self.config.get('generic', {})
+        if lookup in db:
+            await self.bot.say('A tag with the name of "{}" already exists.'.format(name))
+            return
+
+        db[lookup] = TagInfo(name, content, ctx.message.author.id,
+                             location='generic',
+                             created_at=datetime.datetime.utcnow().timestamp())
+        await self.config.put('generic', db)
+        await self.bot.say('Tag "{}" successfully created.'.format(name))
+        
+        aliasCog = self.bot.get_cog('Alias')
+        await aliasCog.add_alias(ctx.message.server, name, "tag {}".format(name))
+
+    @generic.error
+    async def generic_error(self, error, ctx):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await self.bot.say('Tag ' + str(error))
+
+    @tag.command(pass_context=True, no_pm=True)
+    @checks.mod_or_permissions(administrator=True)
+    async def alias(self, ctx, new_name: str, *, old_name: str):
+        """Creates an alias for a pre-existing tag.
+        You own the tag alias. However, when the original
+        tag is deleted the alias is deleted as well.
+        Tag aliases cannot be edited. You must delete
+        the alias and remake it to point it to another
+        location.
+        You cannot have generic aliases.
+        """
+
+        message = ctx.message
+        server = ctx.message.server
+        lookup = new_name.lower().strip()
+        old = old_name.lower()
+
+        tags = self.get_possible_tags(server)
+        db = self.config.get(server.id, {})
+        try:
+            original = tags[old]
+        except KeyError:
+            return await self.bot.say('Pointed to tag does not exist.')
+
+        if isinstance(original, TagAlias):
+            return await self.bot.say('Cannot make an alias to an alias.')
+
+        try:
+            self.verify_lookup(lookup)
+        except RuntimeError as e:
+            return await self.bot.say(e)
+
+        if lookup in db:
+            return await self.bot.say('A tag with this name already exists.')
+
+        db[lookup] = TagAlias(name=new_name, original=old, owner_id=ctx.message.author.id,
+                              created_at=datetime.datetime.utcnow().timestamp())
+
+        await self.config.put(server.id, db)
+        await self.bot.say('Tag alias "{}" that points to "{.name}" successfully created.'.format(new_name, original))
+
+    @tag.command(pass_context=True, ignore_extra=False, no_pm=True)
+    @checks.sensei_or_mod_or_permissions(administrator=True)
+    async def make(self, ctx):
+        """Interactive makes a tag for you.
+        This walks you through the process of creating a tag with
+        its name and its content. This works similar to the tag
+        create command.
+        """
+        if await self.user_exceeds_tag_limit(ctx):
+            limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
+            await self.bot.say("You have too many commands. The maximum number of commands "
+                               "per user is {}, please delete some first!".format(limit))
+            return
+
+        message = ctx.message
+        location = self.get_database_location(message)
+        db = self.config.get(location, {})
+
+        await self.bot.say('Hello. What would you like the name tag to be?')
+
+        def check(msg):
+            try:
+                self.verify_lookup(msg.content.lower())
+                return True
+            except:
+                return False
+
+        name = await self.bot.wait_for_message(author=message.author, channel=message.channel, timeout=60.0, check=check)
+        if name is None:
+            await self.bot.say('You took too long. Goodbye.')
+            return
+
+        lookup = name.content.lower()
+        if lookup in db:
+            fmt = 'Sorry. A tag with that name exists already. Redo the command {0.prefix}tag make.'
+            await self.bot.say(fmt.format(ctx))
+            return
+
+        await self.bot.say('Alright. So the name is {0.content}. What about the tag\'s content?'.format(name))
+        content = await self.bot.wait_for_message(author=name.author, channel=name.channel, timeout=300.0)
+        if content is None:
+            await self.bot.say('You took too long. Goodbye.')
+            return
+
+        if len(content.content) == 0 and len(content.attachments) > 0:
+            # we have an attachment
+            content = content.attachments[0].get('url', '*Could not get attachment data*')
+        else:
+            content = self.clean_tag_content(content.content)
+
+        db[lookup] = TagInfo(name.content, content, name.author.id,
+                             location=location,
+                             created_at=datetime.datetime.utcnow().timestamp())
+        await self.config.put(location, db)
+        await self.bot.say('Cool. I\'ve made your {0.content} tag.'.format(name))
+        
+        aliasCog = self.bot.get_cog('Alias')
+        await aliasCog.add_alias(ctx.message.server, lookup, "tag {}".format(lookup))
+
+    @make.error
+    async def tag_make_error(self, error, ctx):
+        if isinstance(error, commands.TooManyArguments):
+            await self.bot.say('Please call just {0.prefix}tag make'.format(ctx))
+
+    def top_three_tags(self, db):
+        emoji = 129351 # ord(':first_place:')
+        popular = sorted(db.values(), key=lambda t: t.uses, reverse=True)
+        for tag in popular[:3]:
+            yield (chr(emoji), tag)
+            emoji += 1
+
+    @tag.command(pass_context=True)
+    async def stats(self, ctx):
+        """Gives stats about the tag database."""
+        server = ctx.message.server
+        generic = self.config.get('generic', {})
+        e = discord.Embed()
+        e.add_field(name='Generic', value='%s tags\n%s uses' % (len(generic), sum(t.uses for t in generic.values())))
+
+        total_tags = sum(len(c) for c in self.config.all().values())
+        total_uses = sum(sum(t.uses for t in c.values()) for c in self.config.all().values())
+        e.add_field(name='Global', value='%s tags\n%s uses' % (total_tags, total_uses))
+
+        if server is not None:
+            db = self.config.get(server.id, {})
+            e.add_field(name='Server-Specific', value='%s tags\n%s uses' % (len(db), sum(t.uses for t in db.values())))
+        else:
+            db = {}
+            e.add_field(name='Server-Specific', value='No Info')
+
+        fmt = '{0.name} ({0.uses} uses)'
+        for emoji, tag in self.top_three_tags(generic):
+            e.add_field(name=emoji + ' Generic Tag', value=fmt.format(tag))
+
+        for emoji, tag in self.top_three_tags(db):
+            e.add_field(name=emoji + ' Server Tag', value=fmt.format(tag))
+
+        await self.bot.say(embed=e,content="")
+
+    @tag.command(pass_context=True)
+    @checks.sensei_or_mod_or_permissions(manage_messages=True)
+    async def edit(self, ctx, name : str, *, content : str):
+        """Modifies an existing tag that you own.
+        This command completely replaces the original text. If you edit
+        a tag via private message then the tag is looked up in the generic
+        tag database. Otherwise it looks at the server-specific database.
+        """
+
+        content = self.clean_tag_content(content)
+        lookup = name.lower()
+        server = ctx.message.server
+        try:
+            tag = self.get_tag(server, lookup, redirect=False)
+        except RuntimeError as e:
+            return await self.bot.say(e)
+
+        if isinstance(tag, TagAlias):
+            return await self.bot.say('Cannot edit tag aliases. Remake it if you want to re-point it.')
+
+        # Get admin and mod roles.
+        adminRoleName = self.bot.settings.get_server_admin(ctx.message.server)
+        modRoleName = self.bot.settings.get_server_mod(ctx.message.server)
+
+        adminRole = discord.utils.get(ctx.message.server.roles, name=adminRoleName)
+        modRole = discord.utils.get(ctx.message.server.roles, name=modRoleName) 
+        
+        # Check and see if the user is not the tag owner, or is not a mod, or is not an admin.
+        if (tag.owner_id != ctx.message.author.id and adminRole not in ctx.message.author.roles 
+                and modRole not in ctx.message.author.roles):
+            await self.bot.say('Only the tag owner can edit this tag.')
+            return
+
+        db = self.config.get(tag.location)
+        tag.content = content
+        await self.config.put(tag.location, db)
+        await self.bot.say('Tag successfully edited.')
+
+    @tag.command(pass_context=True, no_pm=True)
+    @checks.sensei_or_mod_or_permissions(manage_messages=True)
+    async def transfer(self, ctx, tag_name, user: discord.Member):
+        """
+        Transfers a tag that you have created to another user.
+        This can be done by the creator of the tag. Cannot transfer 
+        if the user being transfered to is over the tag limit.
+        """
+        lookup = tag_name.lower().strip()
+        server = ctx.message.server
+        try:
+            tag = self.get_tag(server, lookup, redirect=False)
+        except RuntimeError as e:
+            return await self.bot.say(e)
+        
+        adminRoleName = self.bot.settings.get_server_admin(server)
+        modRoleName = self.bot.settings.get_server_mod(server)
+        ownerID = self.bot.settings.owner
+
+        adminRole = discord.utils.get(ctx.message.server.roles, name=adminRoleName)
+        modRole = discord.utils.get(ctx.message.server.roles, name=modRoleName)
+    
+        sensei = discord.utils.get(ctx.message.server.roles, name="Sensei")
+        
+        #checks for mod/admin/owner of the tag
+        if (tag.owner_id != ctx.message.author.id and adminRole not in ctx.message.author.roles 
+                and modRole not in ctx.message.author.roles and ctx.message.author.id != ownerID 
+                and ctx.message.author.id not in ctx.bot.settings.co_owners):
+            await self.bot.say("Only the tag owner can transfer this tag.")
+            return
+
+        #checks if the user in question has permissions to create tags
+        if (sensei not in user.roles and adminRole not in user.roles and modRole not in user.roles 
+                and user.id != ownerID and user.id not in ctx.bot.settings.co_owners):
+            await self.bot.say("The person you are trying to transfer to cannot create commands.")
+            return
+
+        #checks if the user has exceeded the tag limit
+        if await self.user_exceeds_tag_limit(ctx.message.server, user):
+            await self.bot.say("The person you are trying to transfer a tag to already has too many commands!")
+            return
+
+        await self.bot.say("{} please confirm by saying \"yes\" that you would like to receive "
+                           "this tag from {}. \nAny other message in this channel by the recipient "
+                           "will be treated as no.".format(user.mention, ctx.message.author.mention))
+        response = await self.bot.wait_for_message(timeout=15, author=user,
+                                                   channel=ctx.message.channel)
+        if not response:
+            await self.bot.say("No confirmation from {}. Transfer has been cancelled.".format(user.name))
+            return
+        if response.content.lower() == 'yes':
+            #The user has answered yes; transfering tag
+            db = self.config.get(tag.location)
+            tag.owner_id = user.id
+            await self.config.put(tag.location, db)
+            await self.bot.say("Tag successfully transferred from the current owner "
+                               "to {}.".format(user.mention))
+        else:
+            await self.bot.say("Tag has been rejected by {}. Transfer has been "
+                               "cancelled.".format(user.name))
+
+    @tag.command(pass_context=True, aliases=['delete','del'])
+    @checks.sensei_or_mod_or_permissions(manage_messages=True)
+    async def remove(self, ctx, *, name : str):
+        """Removes a tag that you own.
+        The tag owner can always delete their own tags. If someone requests
+        deletion and has Manage Messages permissions or a Bot Mod role then
+        they can also remove tags from the server-specific database. Generic
+        tags can only be deleted by the bot owner or the tag owner.
+        Deleting a tag will delete all of its aliases as well.
+        """
+        lookup = name.lower()
+        server = ctx.message.server
+        try:
+            tag = self.get_tag(server, lookup, redirect=False)
+        except RuntimeError as e:
+            return await self.bot.say(e)
+
+        if not tag.is_generic:
+            can_delete = checks.role_or_permissions(ctx, lambda r: r.name == 'Bot Admin', manage_messages=True)
+        else:
+            can_delete = checks.is_owner_check(ctx)
+
+        can_delete = can_delete or tag.owner_id == ctx.message.author.id
+
+        # Get admin and mod roles.
+        adminRoleName = self.bot.settings.get_server_admin(ctx.message.server)
+        modRoleName = self.bot.settings.get_server_mod(ctx.message.server)
+
+        adminRole = discord.utils.get(ctx.message.server.roles, name=adminRoleName)
+        modRole = discord.utils.get(ctx.message.server.roles, name=modRoleName) 
+        
+        # Check and see if the user is not the tag owner, or is not a mod, or is not an admin.
+        if not can_delete and adminRole not in ctx.message.author.roles and modRole not in ctx.message.author.roles:
+            await self.bot.say('You do not have permissions to delete this tag.')
+            return
+
+        if isinstance(tag, TagAlias):
+            location = server.id
+            db = self.config.get(location)
+            del db[lookup]
+            msg = 'Tag alias successfully removed.'
+        else:
+            location = tag.location
+            db = self.config.get(location)
+            msg = 'Tag and all corresponding aliases successfully removed.'
+
+            if server is not None:
+                alias_db = self.config.get(server.id)
+                aliases = [key for key, t in alias_db.items() if isinstance(t, TagAlias) and t.original == lookup]
+                for alias in aliases:
+                    alias_db.pop(alias, None)
+
+            del db[lookup]
+
+        await self.config.put(location, db)
+        await self.bot.say(msg)
+        
+        aliasCog = self.bot.get_cog('Alias')
+        await aliasCog.del_alias(ctx.message.server, lookup)
+        
+        
+
+    @tag.command(pass_context=True, aliases=['owner'])
+    async def info(self, ctx, *, name : str):
+        """Retrieves info about a tag.
+        The info includes things like the owner and how many times it was used.
+        """
+
+        lookup = name.lower()
+        server = ctx.message.server
+        try:
+            tag = self.get_tag(server, lookup, redirect=False)
+        except RuntimeError as e:
+            return await self.bot.say(e)
+
+        embed = await tag.embed(ctx, self.get_possible_tags(server))
+        await self.bot.say(embed=embed, content="")
+
+    @info.error
+    async def info_error(self, error, ctx):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await self.bot.say('Missing tag name to get info of.')
+
+    @tag.command(pass_context=True)
+    async def raw(self, ctx, *, name: str):
+        """Gets the raw content of the tag.
+        This is with markdown escaped. Useful for editing.
+        """
+
+        lookup = name.lower()
+        server = ctx.message.server
+        try:
+            tag = self.get_tag(server, lookup)
+        except RuntimeError as e:
+            return await self.bot.say(e)
+
+        transformations = {
+            re.escape(c): '\\' + c
+            for c in ('*', '`', '_', '~', '\\', '<')
+        }
+
+        def replace(obj):
+            return transformations.get(re.escape(obj.group(0)), '')
+
+        pattern = re.compile('|'.join(transformations.keys()))
+        await self.bot.say(pattern.sub(replace, tag.content))
+
+    @tag.command(name='list', pass_context=True)
+    async def _list(self, ctx, *, member : discord.Member = None):
+        """Lists all the tags that belong to you or someone else.
+        This includes the generic tags as well. If this is done in a private
+        message then you will only get the generic tags you own and not the
+        server specific tags.
+        """
+
+        owner = ctx.message.author if member is None else member
+        server = ctx.message.server
+        tags = [tag.name for tag in self.config.get('generic', {}).values() if tag.owner_id == owner.id]
+        if server is not None:
+            tags.extend(tag.name for tag in self.config.get(server.id, {}).values() if tag.owner_id == owner.id)
+
+        tags.sort()
+
+        if tags:
+            try:
+                self.dm = self.settings.get("dm", False)
+                if self.dm:
+                    await self.bot.say("Check your DMs.")
+                    msg = "Here are a list of tags for {}:\n```".format(ctx.message.author.mention)
+                    for item in tags:
+                        if len(msg) + len(item) > 1990:
+                            msg += "```"
+                            await self.bot.send_message(ctx.message.author, msg)
+                            msg = "```"
+                        msg += item + "\n"
+                    msg += "```"
+                    await self.bot.send_message(ctx.message.author, msg)
+                else:
+                    p = Pages(self.bot, message=ctx.message, entries=tags)
+                    p.embed.colour = 0x738bd7 # blurple
+                    p.embed.set_author(name=owner.display_name, icon_url=owner.avatar_url or owner.default_avatar_url)
+                    await p.paginate()
+            except Exception as e:
+                await self.bot.say(e)
+        else:
+            await self.bot.say('{0.name} has no tags.'.format(owner))
+
+    @tag.command(name='all', pass_context=True, no_pm=True)
+    async def _all(self, ctx):
+        """Lists all server-specific tags for this server."""
+
+        tags = [tag.name for tag in self.config.get(ctx.message.server.id, {}).values()]
+        tags.sort()
+
+        if tags:
+            try:
+                self.dm = self.settings.get("dm", False)
+                if self.dm:
+                    await self.bot.say("Check your DMs.")
+                    msg = "Here are a list of tags for {}:\n```".format(ctx.message.server.name)
+                    for item in tags:
+                        if len(msg) + len(item) > 1990:
+                            msg += "```"
+                            await self.bot.send_message(ctx.message.author, msg)
+                            msg = "```"
+                        msg += item + "\n"
+                    msg += "```"
+                    await self.bot.send_message(ctx.message.author, msg)
+                else:
+                    p = Pages(self.bot, message=ctx.message, entries=tags, per_page=15)
+                    p.embed.colour =  0x738bd7 # blurple
+                    await p.paginate()
+            except Exception as e:
+                await self.bot.say(e)
+        else:
+            await self.bot.say('This server has no server-specific tags.')
+
+    @tag.command(pass_context=True, no_pm=True)
+    @checks.mod_or_permissions(manage_messages=True)
+    async def purge(self, ctx, member: discord.Member):
+        """Removes all server-specific tags by a user.
+        You must have Manage Messages permissions to use this.
+        """
+
+        db = self.config.get(ctx.message.server.id, {})
+        tags = [key for key, tag in db.items() if tag.owner_id == member.id]
+
+        if not ctx.message.channel.permissions_for(ctx.message.server.me).add_reactions:
+            return await self.bot.say('Bot cannot add reactions.')
+
+        if not tags:
+            return await self.bot.say('This user has no server-specific tags.')
+
+        msg = await self.bot.say('This will delete %s tags are you sure? **This action cannot be reversed**.\n\n' \
+                                 'React with either \N{WHITE HEAVY CHECK MARK} to confirm or \N{CROSS MARK} to deny.' % len(tags))
+
+        cancel = False
+        author_id = ctx.message.author.id
+        def check(reaction, user):
+            nonlocal cancel
+            if user.id != author_id:
+                return False
+
+            if reaction.emoji == '\N{WHITE HEAVY CHECK MARK}':
+                return True
+            elif reaction.emoji == '\N{CROSS MARK}':
+                cancel = True
+                return True
+            return False
+
+        for emoji in ('\N{WHITE HEAVY CHECK MARK}', '\N{CROSS MARK}'):
+            await self.bot.add_reaction(msg, emoji)
+
+        react = await self.bot.wait_for_reaction(message=msg, check=check, timeout=60.0)
+        if react is None or cancel:
+            await self.bot.delete_message(msg)
+            return await self.bot.say('Cancelling.')
+
+        for key in tags:
+            db.pop(key)
+
+        await self.config.put(ctx.message.server.id, db)
+        await self.bot.delete_message(msg)
+        await self.bot.say('Successfully removed all %s tags that belong to %s' % (len(tags), member.display_name))
+
+    @tag.command(pass_context=True)
+    async def search(self, ctx, *, query : str):
+        """Searches for a tag.
+        This searches both the generic and server-specific database. If it's
+        a private message, then only generic tags are searched.
+        The query must be at least 2 characters.
+        """
+
+        server = ctx.message.server
+        query = query.lower()
+        if len(query) < 2:
+            return await self.bot.say('The query length must be at least two characters.')
+
+        tags = self.get_possible_tags(server)
+        results = [tag.name for key, tag in tags.items() if query in key]
+
+        if results:
+            try:
+                p = Pages(self.bot, message=ctx.message, entries=results, per_page=15)
+                p.embed.colour = 0x738bd7 # blurple
+                await p.paginate()
+            except Exception as e:
+                await self.bot.say(e)
+        else:
+            await self.bot.say('No tags found.')
+
+    @search.error
+    async def search_error(self, error, ctx):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await self.bot.say('Missing query to search for.')
+    
+    @tag.command(name="toggledm", pass_context=True, no_pm=True)
+    @checks.mod_or_permissions(manage_messages=True)
+    async def toggledm(self, ctx):
+        """Toggle sending DM for list of tags."""
+        self.dm = self.settings.get("dm", False)
+        if self.dm:
+            self.dm = False
+            await self.settings.put("dm", False)
+            await self.bot.say("\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will be sent **in the channel they were requested**.")
+        else:
+            self.dm = True
+            await self.settings.put("dm", True)
+            await self.bot.say("\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will be sent **in a DM**.")
+
+def setup(bot):
+    bot.add_cog(Tags(bot))

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -323,7 +323,7 @@ class Tags(commands.Cog):
 
             await ctx.send(file=DUMP_OUT)
 
-    @tag.command(name="create", aliases=['add'])
+    @tag.command(name="add", aliases=['create'])
     @commands.guild_only()
     # @checks.sensei_or_mod_or_permissions(manage_messages=True) # TODO Fix this later.
     async def create(self, ctx: Context, name : str, *, content : str):
@@ -340,7 +340,7 @@ class Tags(commands.Cog):
         #     return
 
         limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
-        if await self.user_exceeds_tag_limit(ctx.message.server, ctx.message.author):
+        if await self.user_exceeds_tag_limit(ctx.guild, ctx.author):
             await ctx.send("You have too many commands. The maximum number of commands "
                            "per user is {}, please delete some first!".format(limit))
             return
@@ -358,7 +358,7 @@ class Tags(commands.Cog):
             await ctx.send('A tag with the name of "{}" already exists.'.format(name))
             return
 
-        db[lookup] = TagInfo(name, content, ctx.message.author.id,
+        db[lookup] = TagInfo(name, content, str(ctx.message.author.id),
                              location=location,
                              created_at=datetime.datetime.utcnow().timestamp())
 
@@ -371,6 +371,9 @@ class Tags(commands.Cog):
     async def create_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send('Tag ' + str(error))
+        else:
+            raise error
+
 
     @tag.command(name="generic")
     @checks.mod_or_permissions(administrator=True)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -150,7 +150,7 @@ class Tags(commands.Cog):
         if server is None:
             return generic
 
-        generic.update(self.config.get(server.id, {}))
+        generic.update(self.config.get(str(server.id), {}))
         return generic
 
     def get_tag(self, server, name, *, redirect=True):
@@ -231,9 +231,12 @@ class Tags(commands.Cog):
         await self.config.put(tag.location, db)
 
     @tag.error
-    async def tag_error(self, error, ctx):
+    async def tag_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
-            await self.bot.say('You need to pass in a tag name.')
+            await ctx.send('You need to pass in a tag name.')
+            await ctx.send_help()
+        else:
+            raise error
 
     def verify_lookup(self, lookup):
         if '@everyone' in lookup or '@here' in lookup:

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -909,18 +909,18 @@ class Tags(commands.Cog):
         await ctx.send("Successfully removed all {} tags that belong to {}".format(
                        len(tags), member.display_name))
 
-    @tag.command(pass_context=True)
-    async def search(self, ctx, *, query : str):
+    @tag.command(name="search")
+    async def search(self, ctx: Context, *, query : str):
         """Searches for a tag.
         This searches both the generic and server-specific database. If it's
         a private message, then only generic tags are searched.
         The query must be at least 2 characters.
         """
-
-        server = ctx.message.server
+        server = ctx.message.guild
         query = query.lower()
         if len(query) < 2:
-            return await self.bot.say('The query length must be at least two characters.')
+            await ctx.send('The query length must be at least two characters.')
+            return
 
         tags = self.get_possible_tags(server)
         results = [tag.name for key, tag in tags.items() if query in key]
@@ -931,28 +931,31 @@ class Tags(commands.Cog):
                 p.embed.colour = 0x738bd7 # blurple
                 await p.paginate()
             except Exception as e:
-                await self.bot.say(e)
+                await ctx.send(e)
         else:
-            await self.bot.say('No tags found.')
+            await ctx.send('No tags found.')
 
     @search.error
-    async def search_error(self, error, ctx):
+    async def search_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
-            await self.bot.say('Missing query to search for.')
+            await ctx.send('Missing query to search for.')
     
-    @tag.command(name="toggledm", pass_context=True, no_pm=True)
+    @tag.command(name="toggledm")
+    @commands.guild_only()
     @checks.mod_or_permissions(manage_messages=True)
-    async def toggledm(self, ctx):
+    async def toggledm(self, ctx: Context):
         """Toggle sending DM for list of tags."""
         self.dm = self.settings.get("dm", False)
         if self.dm:
             self.dm = False
             await self.settings.put("dm", False)
-            await self.bot.say("\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will be sent **in the channel they were requested**.")
+            await ctx.send("\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will "
+                           "be sent **in the channel they were requested**.")
         else:
             self.dm = True
             await self.settings.put("dm", True)
-            await self.bot.say("\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will be sent **in a DM**.")
+            await ctx.send("\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will "
+                           "be sent **in a DM**.")
 
 def setup(bot):
     bot.add_cog(Tags(bot))

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -395,7 +395,7 @@ class Tags(commands.Cog):
             await ctx.send('A tag with the name of "{}" already exists.'.format(name))
             return
 
-        db[lookup] = TagInfo(name, content, ctx.message.author.id,
+        db[lookup] = TagInfo(name, content, str(ctx.author.id),
                              location='generic',
                              created_at=datetime.datetime.utcnow().timestamp())
         await self.config.put('generic', db)
@@ -547,7 +547,7 @@ class Tags(commands.Cog):
         e.add_field(name='Global', value='%s tags\n%s uses' % (total_tags, total_uses))
 
         if server is not None:
-            db = self.config.get(server.id, {})
+            db = self.config.get(str(server.id), {})
             e.add_field(name='Server-Specific', value='%s tags\n%s uses' % (len(db), sum(t.uses for t in db.values())))
         else:
             db = {}
@@ -791,10 +791,10 @@ class Tags(commands.Cog):
         owner = ctx.message.author if member is None else member
         server = ctx.message.guild
         tags = [tag.name for tag in self.config.get('generic', {}).values()
-                if tag.owner_id == owner.id]
+                if tag.owner_id == str(owner.id)]
         if server is not None:
-            tags.extend(tag.name for tag in self.config.get(server.id, {}).values()
-                        if tag.owner_id == owner.id)
+            tags.extend(tag.name for tag in self.config.get(str(server.id), {}).values()
+                        if tag.owner_id == str(owner.id))
 
         tags.sort()
 
@@ -828,7 +828,7 @@ class Tags(commands.Cog):
     async def _all(self, ctx):
         """Lists all server-specific tags for this server."""
 
-        tags = [tag.name for tag in self.config.get(ctx.message.guild.id, {}).values()]
+        tags = [tag.name for tag in self.config.get(str(ctx.message.guild.id), {}).values()]
         tags.sort()
 
         if tags:

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -290,7 +290,7 @@ class Tags(commands.Cog):
     @checks.mod_or_permissions()
     async def dump(self, ctx: Context):
         """Dumps server-specific tags to a CSV file, sorted by number of uses."""
-        sid = ctx.message.server.id
+        sid = str(ctx.guild.id)
         with self.lock:
             with open(DUMP_IN, "r") as inputFile, open(DUMP_OUT, "w") as outputFile:
                 tags = json.load(inputFile)
@@ -322,7 +322,7 @@ class Tags(commands.Cog):
                     data = list(tag.values()) + [owner]
                     csvWriter.writerow(data)
 
-            await ctx.send(file=DUMP_OUT)
+            await ctx.send(file=discord.File(DUMP_OUT))
 
     @tag.command(name="add", aliases=['create'])
     @commands.guild_only()

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -1017,6 +1017,3 @@ class Tags(commands.Cog):
             await self.settings.put("dm", True)
             await ctx.send("\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will "
                            "be sent **in a DM**.")
-
-def setup(bot):
-    bot.add_cog(Tags(bot))

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -482,12 +482,8 @@ class Tags(commands.Cog):
                 await ctx.send("Could not access the Alias cog. Please load it and "
                                "try again.")
                 return
-            elif aliasCog.is_command(name):
-                await ctx.send("This name cannot be used because there is already "
-                               "an internal command with this name.")
-                return
 
-        if await self.user_exceeds_tag_limit(ctx):
+        if await self.user_exceeds_tag_limit(ctx.guild, ctx.author):
             limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
             await ctx.send("You have too many commands. The maximum number of commands "
                            f"per user is {limit}, please delete some first!")
@@ -522,6 +518,12 @@ class Tags(commands.Cog):
         if lookup in db:
             fmt = 'Sorry. A tag with that name exists already. Redo the command {0.prefix}tag make.'
             await ctx.send(fmt.format(ctx))
+            return
+
+        # Alias is already loaded
+        if self.settings.get(KEY_USE_ALIAS, False) and aliasCog.is_command(lookup):
+            await ctx.send("This name cannot be used because there is already "
+                           "an internal command with this name.")
             return
 
         await ctx.send('Alright. So the name is {0.content}. What about the tag\'s content?'.format(name))

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -4,6 +4,8 @@
 # DATE LAST MODIFIED: 2017-04-13
 
 from .config import Config
+from .rolecheck import role_or_mod_or_permissions
+from .constants import *
 
 import csv
 import json
@@ -21,11 +23,6 @@ from redbot.core import checks, commands
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
 from redbot.core.utils.paginator import Pages
-DEFAULT_MAX = 50 # Default max number of tags per user.
-KEY_MAX = "max"
-KEY_USE_ALIAS = "useAlias"
-DUMP_IN = "data/tags/tags.json"
-DUMP_OUT = "data/tags/export.csv"
 
 class TagInfo:
     __slots__ = ('name', 'content', 'owner_id', 'uses', 'location', 'created_at')
@@ -327,7 +324,7 @@ class Tags(commands.Cog):
 
     @tag.command(name="add", aliases=['create'])
     @commands.guild_only()
-    # @checks.sensei_or_mod_or_permissions(manage_messages=True) # TODO Fix this later.
+    @role_or_mod_or_permissions(role=ALLOWED_ROLE, manage_messages=True)
     async def create(self, ctx: Context, name : str, *, content : str):
         """Creates a new tag owned by you.
         If you create a tag via private message then the tag is a generic
@@ -380,6 +377,8 @@ class Tags(commands.Cog):
     async def create_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send('Tag ' + str(error))
+        elif isinstance(error, commands.CheckFailure):
+            pass
         else:
             await ctx.send("Something went wrong, please check the logs for details.")
             raise error
@@ -468,7 +467,7 @@ class Tags(commands.Cog):
 
     @tag.command(ignore_extra=False)
     @commands.guild_only()
-    # @checks.sensei_or_mod_or_permissions(administrator=True) # TODO Fix this later
+    @role_or_mod_or_permissions(role=ALLOWED_ROLE, administrator=True)
     async def make(self, ctx):
         """Interactive makes a tag for you.
         This walks you through the process of creating a tag with
@@ -553,6 +552,8 @@ class Tags(commands.Cog):
     async def tag_make_error(self, ctx: Context, error):
         if isinstance(error, commands.TooManyArguments):
             await ctx.send('Please call just {0.prefix}tag make'.format(ctx))
+        elif isinstance(error, commands.CheckFailure):
+            pass
         else:
             raise error
 
@@ -592,7 +593,7 @@ class Tags(commands.Cog):
         await ctx.send(embed=e)
 
     @tag.command()
-    # @checks.sensei_or_mod_or_permissions(manage_messages=True) # TODO Fix this later.
+    @role_or_mod_or_permissions(role=ALLOWED_ROLE, manage_messages=True)
     async def edit(self, ctx: Context, name : str, *, content : str):
         """Modifies an existing tag that you own.
         This command completely replaces the original text. If you edit
@@ -632,7 +633,7 @@ class Tags(commands.Cog):
 
     @tag.command(name="transfer")
     @commands.guild_only()
-    # @checks.sensei_or_mod_or_permissions(manage_messages=True) # TODO Fix this later
+    @role_or_mod_or_permissions(role=ALLOWED_ROLE, manage_messages=True)
     async def transfer(self, ctx: Context, tag_name, user: discord.Member):
         """Transfer your tag to another user.
 
@@ -657,7 +658,7 @@ class Tags(commands.Cog):
         mod_roles = await self.bot.get_mod_roles(server)
         admin_roles = await self.bot.get_admin_roles(server)
 
-        sensei = discord.utils.get(ctx.message.guild.roles, name="Sensei")
+        sensei = discord.utils.get(ctx.message.guild.roles, name=ALLOWED_ROLE)
 
         # Check and see if the user requesting the transfer is not the tag owner, or
         # is not a mod, or is not an admin.
@@ -708,7 +709,7 @@ class Tags(commands.Cog):
                            "cancelled.".format(user.name))
 
     @tag.command(name="delete", aliases=["del", "remove", "rm"])
-    # @checks.sensei_or_mod_or_permissions(manage_messages=True) # TODO Fix this later
+    @role_or_mod_or_permissions(role=ALLOWED_ROLE, manage_messages=True)
     async def remove(self, ctx: Context, *, name : str):
         """Removes a tag that you own.
         The tag owner can always delete their own tags. If someone requests

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -768,7 +768,9 @@ class Tags(commands.Cog):
         await self.config.put(location, db)
         await ctx.send(msg)
         
-        await aliasCog.del_alias(ctx, lookup)
+        if self.settings.get(KEY_USE_ALIAS, False):
+            # Alias is already loaded.
+            await aliasCog.del_alias(ctx, lookup)
 
     @tag.command(name="info", aliases=['owner'])
     async def info(self, ctx: Context, *, name : str):

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -1,11 +1,11 @@
-# Manually imported from:
+# Cog from old v2 bot running async branch of discord.py
 # https://github.com/Rapptz/RoboDanny/blob/master/cogs/tags.py
-# DATE IMPORTED: 2017-04-10
-# DATE LAST MODIFIED: 2017-04-13
+# Date first imported: 2017-04-10
+# Ported to rewrite branch of discord.py for Red v3
 
 from .config import Config
-from .rolecheck import role_or_mod_or_permissions
 from .constants import *
+from .rolecheck import role_or_mod_or_permissions
 
 import csv
 import json
@@ -145,7 +145,7 @@ class Tags(commands.Cog):
         str
             The guild ID if the message was from a guild, else 'generic'
         """
-        return 'generic' if message.channel.type == discord.DMChannel else str(message.guild.id)
+        return 'generic' if isinstance(message.channel, discord.DMChannel) else str(message.guild.id)
 
     def clean_tag_content(self, content):
         return content.replace('@everyone', '@\u200beveryone').replace('@here', '@\u200bhere')

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -440,7 +440,7 @@ class Tags(commands.Cog):
         old = old_name.lower()
 
         tags = self.get_possible_tags(server)
-        db = self.config.get(server.id, {})
+        db = self.config.get(str(server.id), {})
         try:
             original = tags[old]
         except KeyError:
@@ -459,10 +459,10 @@ class Tags(commands.Cog):
             await ctx.send('A tag with this name already exists.')
             return
 
-        db[lookup] = TagAlias(name=new_name, original=old, owner_id=ctx.message.author.id,
+        db[lookup] = TagAlias(name=new_name, original=old, owner_id=str(ctx.author.id),
                               created_at=datetime.datetime.utcnow().timestamp())
 
-        await self.config.put(server.id, db)
+        await self.config.put(str(server.id), db)
         await ctx.send('Tag alias "{}" that points to "{.name}" successfully '
                        'created.'.format(new_name, original))
 

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -185,10 +185,6 @@ class Alias(commands.Cog):
         # At this point we know we need to make a new alias
         #   and that the alias name is valid.
 
-        self.add_alias(ctx, alias_name, command)
-
-    async def add_alias(self, ctx: commands.Context, alias_name: str, command):
-        """Add an alias, potentially from another cog."""
         try:
             await self._aliases.add_alias(ctx, alias_name, command)
         except ArgParseError as e:
@@ -197,15 +193,6 @@ class Alias(commands.Cog):
         await ctx.send(
             _("A new alias with the trigger `{name}` has been created.").format(name=alias_name)
         )
-
-    async def del_alias(self, ctx: commands.Context, alias_name: str):
-        """Delete an alias, potentially from another cog."""
-        if await self._aliases.delete_alias(ctx, alias_name):
-            await ctx.send(
-                _("Alias with the name `{name}` was successfully deleted.").format(name=alias_name)
-            )
-        else:
-            await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
 
     @checks.is_owner()
     @global_.command(name="add")
@@ -299,7 +286,12 @@ class Alias(commands.Cog):
             await ctx.send(_("There are no aliases on this server."))
             return
 
-        self.del_alias(ctx, alias_name)
+        if await self._aliases.delete_alias(ctx, alias_name):
+            await ctx.send(
+                _("Alias with the name `{name}` was successfully deleted.").format(name=alias_name)
+            )
+        else:
+            await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
 
     @checks.is_owner()
     @global_.command(name="delete", aliases=["del", "remove"])

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -299,7 +299,7 @@ class Alias(commands.Cog):
             await ctx.send(_("There are no aliases on this server."))
             return
 
-        await self.del_alias(ctx, alias_name)
+        self.del_alias(ctx, alias_name)
 
     @checks.is_owner()
     @global_.command(name="delete", aliases=["del", "remove"])

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -299,7 +299,7 @@ class Alias(commands.Cog):
             await ctx.send(_("There are no aliases on this server."))
             return
 
-        self.del_alias(ctx, alias_name)
+        await self.del_alias(ctx, alias_name)
 
     @checks.is_owner()
     @global_.command(name="delete", aliases=["del", "remove"])

--- a/redbot/cogs/alias/alias.py
+++ b/redbot/cogs/alias/alias.py
@@ -185,6 +185,10 @@ class Alias(commands.Cog):
         # At this point we know we need to make a new alias
         #   and that the alias name is valid.
 
+        self.add_alias(ctx, alias_name, command)
+
+    async def add_alias(self, ctx: commands.Context, alias_name: str, command):
+        """Add an alias, potentially from another cog."""
         try:
             await self._aliases.add_alias(ctx, alias_name, command)
         except ArgParseError as e:
@@ -193,6 +197,15 @@ class Alias(commands.Cog):
         await ctx.send(
             _("A new alias with the trigger `{name}` has been created.").format(name=alias_name)
         )
+
+    async def del_alias(self, ctx: commands.Context, alias_name: str):
+        """Delete an alias, potentially from another cog."""
+        if await self._aliases.delete_alias(ctx, alias_name):
+            await ctx.send(
+                _("Alias with the name `{name}` was successfully deleted.").format(name=alias_name)
+            )
+        else:
+            await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
 
     @checks.is_owner()
     @global_.command(name="add")
@@ -286,12 +299,7 @@ class Alias(commands.Cog):
             await ctx.send(_("There are no aliases on this server."))
             return
 
-        if await self._aliases.delete_alias(ctx, alias_name):
-            await ctx.send(
-                _("Alias with the name `{name}` was successfully deleted.").format(name=alias_name)
-            )
-        else:
-            await ctx.send(_("Alias with name `{name}` was not found.").format(name=alias_name))
+        self.del_alias(ctx, alias_name)
 
     @checks.is_owner()
     @global_.command(name="delete", aliases=["del", "remove"])


### PR DESCRIPTION
### Type
- [x] Migration

### Description of the changes
Closes #174. Migrates the tags cog (from Rapptz/RoboDanny) to v3.

This [diff](https://github.com/SFUAnime/Ren/compare/03da20137e390932e951f9aa562b718239a507ce..6c37af554954e8218b2a3b0591d50a700df4f1f6?expand=1) may be more useful.

Some notable things:
- Use v2 config (included as an import) to preserve v2 file.

Things to address:
- [x] Fix purge command that appears to not be working.
- [x] Add conditional coupling with Alias cog.
- [x] Add Sensei role check (might do this in another PR).