### PR TITLE
[Tags] Add tiered roles

### DIFF
--- a/cogs/tags/constants.py
+++ b/cogs/tags/constants.py
@@ -5,4 +5,4 @@ KEY_USE_ALIAS = "useAlias"
 DUMP_IN = "data/tags/tags.json"
 DUMP_OUT = "data/tags/export.csv"
 ALLOWED_ROLE = "Sensei"
-NO_LIMIT = -1
+NO_LIMIT = float("inf")

--- a/cogs/tags/constants.py
+++ b/cogs/tags/constants.py
@@ -1,3 +1,4 @@
+BASE = {"max": {}, "useAlias": False}
 DEFAULT_MAX = 50  # Default max number of tags per user.
 KEY_MAX = "max"
 KEY_USE_ALIAS = "useAlias"

--- a/cogs/tags/constants.py
+++ b/cogs/tags/constants.py
@@ -1,7 +1,8 @@
-BASE = {"max": {}, "useAlias": False}
+BASE = {"tiers": {}, "useAlias": False}
 DEFAULT_MAX = 50  # Default max number of tags per user.
 KEY_MAX = "max"
 KEY_USE_ALIAS = "useAlias"
 DUMP_IN = "data/tags/tags.json"
 DUMP_OUT = "data/tags/export.csv"
 ALLOWED_ROLE = "Sensei"
+NO_LIMIT = -1

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -19,7 +19,7 @@ import asyncio
 import discord
 import logging
 
-from redbot.core import checks, commands
+from redbot.core import Config as ConfigV3, checks, commands
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
 from redbot.core.utils.paginator import Pages
@@ -134,6 +134,8 @@ class Tags(commands.Cog):
             load_later=True,
         )
         self.settings = Config("settings.json", cogname="tags")
+        self.configV3 = ConfigV3.get_conf(self, identifier=5842647, force_registration=True)
+        self.configV3.register_guild(**BASE)  # Register default (empty) settings.
         self.lock = Lock()
 
     def get_database_location(self, message: discord.Message):
@@ -228,7 +230,13 @@ class Tags(commands.Cog):
                 for tag in self.config.get(str(server.id), {}).values()
                 if tag.owner_id == str(user.id)
             )
-        limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
+        tiers = await self.configV3.guild(server).max()
+        # Convert role IDs to string since keys are stored as strings.
+        roleIds = [str(r.id) for r in user.roles]
+        relevantTiers = list(set(tiers.keys()) & set(roleIds))
+        if not relevantTiers:
+            return True
+        limit = max([tiers[key] for key in relevantTiers])
         if len(tags) >= limit:
             return True
         return False
@@ -274,26 +282,30 @@ class Tags(commands.Cog):
     @tag.command(name="max")
     @commands.guild_only()
     @checks.mod_or_permissions()
-    async def max(self, ctx: Context, num_tags: int = None):
-        """Set the max number of tags per user. Leave blank to show current setting.
+    async def max(self, ctx: Context, role: discord.Role, num_tags: int):
+        """Set the max number of tags per member per role.
+
+        For each member of the specified role, each member will have a maximum
+        number of tags they can create. If the member is part of more than one
+        role, then they will take the MAXIMUM number from the roles that they
+        have.
 
         This limit does not apply to admins or mods.
 
         Parameters:
         -----------
+        role: discord.Role
+            The role to set a maximum for.
         num_tags: int
-            The maximum number of tags per user.
+            The maximum number of tags per member for that role.
         """
-        if not num_tags:
-            limit = self.settings.get(KEY_MAX, DEFAULT_MAX)
-            await ctx.send("The current tag limit per user is {}.".format(limit))
-            return
         if num_tags < 0:
             await ctx.send("Please set a value greater than 0.")
             return
 
-        await self.settings.put(KEY_MAX, num_tags)
-        await ctx.send("The tag limit was set to {}".format(num_tags))
+        async with self.configV3.guild(ctx.guild).max() as tiers:
+            tiers[role.id] = num_tags
+        await ctx.send(f"The tag limit for {role.name} was set to {num_tags}.")
 
     @tag.command(name="dump")
     @commands.guild_only()

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -283,9 +283,13 @@ class Tags(commands.Cog):
         if len(lookup) > 100:
             raise RuntimeError("Tag name is a maximum of 100 characters.")
 
-    @tag.command(name="max")
+    @tag.group("settings")
     @commands.guild_only()
     @checks.mod_or_permissions()
+    async def settings(self, ctx: Context):
+        """Tag settings."""
+
+    @settings.command(name="max")
     async def max(self, ctx: Context, role: discord.Role, num_tags: int):
         """Set the max number of tags per member per role.
 
@@ -317,9 +321,7 @@ class Tags(commands.Cog):
                 tiers[role.id] = num_tags
                 await ctx.send(f"The tag limit for {role.name} was set to {num_tags}.")
 
-    @tag.command(name="tiers")
-    @commands.guild_only()
-    @checks.mod_or_permissions()
+    @settings.command(name="tiers")
     async def tiers(self, ctx: Context):
         """Show the tiers and their respective max tags."""
         tiers = await self.configV3.guild(ctx.guild).tiers()
@@ -339,9 +341,7 @@ class Tags(commands.Cog):
             msg = "There are no tiers configured."
         await ctx.send(msg)
 
-    @tag.command(name="dump")
-    @commands.guild_only()
-    @checks.mod_or_permissions()
+    @settings.command(name="dump")
     async def dump(self, ctx: Context):
         """Dumps server-specific tags to a CSV file, sorted by number of uses."""
         sid = str(ctx.guild.id)
@@ -1109,9 +1109,7 @@ class Tags(commands.Cog):
         else:
             raise error
 
-    @tag.command(name="togglealias")
-    @commands.guild_only()
-    @checks.mod_or_permissions(manage_messages=True)
+    @settings.command(name="togglealias")
     async def togglealias(self, ctx: Context):
         """Toggle creating aliases for tags."""
         if self.settings.get(KEY_USE_ALIAS, False):
@@ -1128,9 +1126,7 @@ class Tags(commands.Cog):
             )
         await self.settings.put(KEY_USE_ALIAS, toAlias)
 
-    @tag.command(name="toggledm")
-    @commands.guild_only()
-    @checks.mod_or_permissions(manage_messages=True)
+    @settings.command(name="toggledm")
     async def toggledm(self, ctx: Context):
         """Toggle sending DM for list of tags."""
         self.dm = self.settings.get("dm", False)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -207,8 +207,8 @@ class Tags(commands.Cog):
         --------
         (bool, int)
             bool: True if user has too many tags, else False.
-            int: The maximum number of tags this user can have. -1 if they
-            have no limit.
+            int: The maximum number of tags this user can have. If unlimited, then this
+            will be float("inf").
         """
         if await self.bot.is_owner(user):
             # No limit for bot owner
@@ -333,10 +333,11 @@ class Tags(commands.Cog):
                 continue
             validTiers.append((role, maxTags))
         if validTiers:
-            msg = "Below is a list of roles and their tag limits:\n"
+            msgList = ["Below is a list of roles and their tag limits:"]
             validTiers.sort(key=lambda x: x[1])
             for role, maxTags in validTiers:
-                msg += f"{role.name}: {maxTags}\n"
+                msgList.append(f"{role.name}: {maxTags}")
+            msg = "\n".join(msgList)
         else:
             msg = "There are no tiers configured."
         await ctx.send(msg)


### PR DESCRIPTION
### Type
- [x] Enhancement

### Description of the changes
Closes #292 . Add tag tiers, where each role can have a maximum number of tags. If a user has multiple roles that are tiered, then the user takes the maximum of those roles.

- Use Config V3 for storing the tier settings.
- Nest server settings commands in a new `settings` group, accessible via `[p]tag settings`.
- Add `tiers` command to show each role and their relevant max tags.
- Modify `max` command to accept both a role and maximum number of tags.
- Modify messages that are sent to the user if they are over the maximum to reflect their tiers.