### PR TITLE
[Tags] Use V3 cog data path in V2 config

### DIFF
--- a/cogs/tags/config.py
+++ b/cogs/tags/config.py
@@ -12,10 +12,9 @@ all credit goes to the author of RoboDanny: https://github.com/Rapptz/RoboDanny/
 class Config:
     """The "database" object. Internally based on ``json``."""
 
-    def __init__(self, name, **options):
+    def __init__(self, directory, name, **options):
         self.name = name
-        self.cogname = options.pop("cogname", None)
-        self.directory = "data/{}/".format(self.cogname)
+        self.directory = "{}/".format(directory)
         self.object_hook = options.pop("object_hook", None)
         self.encoder = options.pop("encoder", None)
         self.loop = options.pop("loop", asyncio.get_event_loop())

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -19,7 +19,7 @@ import asyncio
 import discord
 import logging
 
-from redbot.core import Config as ConfigV3, checks, commands
+from redbot.core import Config as ConfigV3, checks, commands, data_manager
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
 from redbot.core.utils.paginator import Pages
@@ -125,15 +125,16 @@ class Tags(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
+        saveFolder = data_manager.cog_data_path(cog_instance=self)
         self.config = Config(
+            saveFolder,
             "tags.json",
-            cogname="tags",
             encoder=TagEncoder,
             object_hook=tag_decoder,
             loop=bot.loop,
             load_later=True,
         )
-        self.settings = Config("settings.json", cogname="tags")
+        self.settings = Config(saveFolder, "settings-v2.json")
         self.configV3 = ConfigV3.get_conf(self, identifier=5842647, force_registration=True)
         self.configV3.register_guild(**BASE)  # Register default (empty) settings.
         self.lock = Lock()


### PR DESCRIPTION
When upgrading from Red v2 to v3, we directly ported Config v2 over. One of the underlying assumptions made by Config V2 is that the bot data is stored relative to where the bot is started. This is no longer the case: the bot can be started anywhere we invoke `redbot <instanceName>`, so the bot's data is stored at a specific path we specify. This breaks the Config V2 assumption.

This PR:
- Closes #316 by using the V3 `cog_data_path` function to get the data path and passing that into Config V2 so that it is not dependent on the current working directory.
- Removes unused cogname attribute, since Config V2 is not being used anywhere else.
