### PR TITLE
[Birthday] At-mention members on their birthday

### DIFF
--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -111,6 +111,13 @@ class Birthday(commands.Cog):
             "as the birthday role!".format(role.name)
         )
 
+    @_birthday.command(name="test")
+    @commands.guild_only()
+    async def test(self, ctx):
+        """Test at-mentions."""
+        for msg in CANNED_MESSAGES:
+            await ctx.send(msg.format(ctx.author.mention))
+
     @_birthday.command(name="add")
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -456,6 +456,7 @@ class Birthday(commands.Cog):
                 # Make sure the guild is configured with birthday role.
                 # If it's not, skip over it.
                 bdayRoleId = await self.config.guild(guild).birthdayRole()
+                bdayChannelId = await self.config.guild(guild).birthdayChannel()
                 if not bdayRoleId:
                     continue
 
@@ -474,6 +475,7 @@ class Birthday(commands.Cog):
                         # Get the necessary Discord objects.
                         role = discord.utils.get(guild.roles, id=bdayRoleId)
                         member = discord.utils.get(guild.members, id=memberId)
+                        channel = discord.utils.get(guild.channels, id=bdayChannelId)
 
                         # Skip if member is no longer in server.
                         if not member:
@@ -499,5 +501,15 @@ class Birthday(commands.Cog):
                                     member.name,
                                     member.discriminator,
                                     member.id,
+                                    exc_info=True,
+                                )
+                            if not channel:
+                                continue
+                            try:
+                                msg = choice(CANNED_MESSAGES)
+                                await channel.send(msg.format(member.mention))
+                            except discord.Forbidden:
+                                self.logger.error(
+                                    "Could not send message!",
                                     exc_info=True,
                                 )

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -56,7 +56,7 @@ class Birthday(commands.Cog):
     @_birthday.command(name="setchannel", aliases=["ch"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
-    async def setChannel(self, ctx, channel: discord.TextChannel=None):
+    async def setChannel(self, ctx, channel: discord.TextChannel = None):
         """Set the channel to mention members on their birthday.
 
         Parameters:
@@ -81,8 +81,7 @@ class Birthday(commands.Cog):
         else:
             await self.config.guild(ctx.message.guild).birthdayChannel.set(None)
             await ctx.send(
-                ":white_check_mark: **Birthday - Channel**: Birthday mentions "
-                "are now disabled."
+                ":white_check_mark: **Birthday - Channel**: Birthday mentions are now disabled."
             )
 
     @_birthday.command(name="setrole")
@@ -510,6 +509,5 @@ class Birthday(commands.Cog):
                                 await channel.send(msg.format(member.mention))
                             except discord.Forbidden:
                                 self.logger.error(
-                                    "Could not send message!",
-                                    exc_info=True,
+                                    "Could not send message!", exc_info=True,
                                 )

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -1,6 +1,7 @@
 """Birthday cog Automatically add users to a specified birthday role on their
 birthday."""
 import logging
+from random import choice
 import time  # To auto remove birthday role on the next day.
 import asyncio
 from datetime import datetime, timedelta
@@ -51,6 +52,38 @@ class Birthday(commands.Cog):
     @checks.mod_or_permissions(administrator=True)
     async def _birthday(self, ctx: Context):
         """Birthday role assignment settings."""
+
+    @_birthday.command(name="setchannel", aliases=["ch"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def setChannel(self, ctx, channel: discord.TextChannel=None):
+        """Set the channel to mention members on their birthday.
+
+        Parameters:
+        -----------
+        channel: Optional[discord.TextChannel]
+            A text channel to mention a member's birthday.
+        """
+
+        if channel:
+            await self.config.guild(ctx.message.guild).birthdayChannel.set(channel.id)
+            self.logger.info(
+                "%s#%s (%s) set the birthday channel to %s",
+                ctx.message.author.name,
+                ctx.message.author.discriminator,
+                ctx.message.author.id,
+                channel.name,
+            )
+            await ctx.send(
+                ":white_check_mark: **Birthday - Channel**: **{}** has been set "
+                "as the birthday mention channel!".format(channel.name)
+            )
+        else:
+            await self.config.guild(ctx.message.guild).birthdayChannel.set(None)
+            await ctx.send(
+                ":white_check_mark: **Birthday - Channel**: Birthday mentions "
+                "are now disabled."
+            )
 
     @_birthday.command(name="setrole")
     @commands.guild_only()

--- a/cogs/birthday/constants.py
+++ b/cogs/birthday/constants.py
@@ -15,15 +15,12 @@ BASE_GUILD_MEMBER = {
     KEY_IS_ASSIGNED: False,
 }
 
-BASE_GUILD = {
-    KEY_BDAY_CHANNEL: None,
-    KEY_BDAY_ROLE: None
-}
+BASE_GUILD = {KEY_BDAY_CHANNEL: None, KEY_BDAY_ROLE: None}
 
 CANNED_MESSAGES = [
     "Wow look, it's {}'s birthday today! Happy birthday, hope you have a good one!",
     "お誕生日おめでとう、{}! (TL note: Happy birthday!)",
     "Wow, would you look at that, it's {}'s birthday. Time to wish them a happy birthday!",
     "Hey everyone! it's {} birthday, come and wish them a happy birthday!",
-    "Wow {}, happy birthday! How does it feel to be more boomer than you were yesterday?"
+    "Wow {}, happy birthday! How does it feel to be more boomer than you were yesterday?",
 ]

--- a/cogs/birthday/constants.py
+++ b/cogs/birthday/constants.py
@@ -1,3 +1,4 @@
+KEY_BDAY_CHANNEL = "birthdayChannel"
 KEY_BDAY_ROLE = "birthdayRole"
 KEY_BDAY_USERS = "birthdayUsers"
 KEY_BDAY_MONTH = "birthdateMonth"
@@ -14,4 +15,15 @@ BASE_GUILD_MEMBER = {
     KEY_IS_ASSIGNED: False,
 }
 
-BASE_GUILD = {KEY_BDAY_ROLE: None}
+BASE_GUILD = {
+    KEY_BDAY_CHANNEL: None,
+    KEY_BDAY_ROLE: None
+}
+
+CANNED_MESSAGES = [
+    "Wow look, it's {}'s birthday today! Happy birthday, hope you have a good one!",
+    "お誕生日おめでとう、{}! (TL note: Happy birthday!)",
+    "Wow, would you look at that, it's {}'s birthday. Time to wish them a happy birthday!",
+    "Hey everyone! it's {} birthday, come and wish them a happy birthday!",
+    "Wow {}, happy birthday! How does it feel to be more boomer than you were yesterday?"
+]

--- a/cogs/birthday/constants.py
+++ b/cogs/birthday/constants.py
@@ -21,6 +21,6 @@ CANNED_MESSAGES = [
     "Wow look, it's {}'s birthday today! Happy birthday, hope you have a good one!",
     "お誕生日おめでとう、{}! (TL note: Happy birthday!)",
     "Wow, would you look at that, it's {}'s birthday. Time to wish them a happy birthday!",
-    "Hey everyone! it's {} birthday, come and wish them a happy birthday!",
+    "Hey everyone! It's {} birthday, come and wish them a happy birthday!",
     "Wow {}, happy birthday! How does it feel to be more boomer than you were yesterday?",
 ]


### PR DESCRIPTION
This PR:
- Closes #268.
- Adds a command `setchannel` that allows server admins to set a channel to use to at-mentions users on their birthday
- Adds some canned messages, of which one is randomly selected. This can be added via Discord later.