### PR TITLE
[SFU] Add Surrey Central camera

### DIFF
--- a/cogs/sfu/roads.py
+++ b/cogs/sfu/roads.py
@@ -60,6 +60,7 @@ class SFURoads(commands.Cog):  # pylint: disable=too-few-public-methods
         self.bot = bot
         self.cameras = {
             "aqpond": WEBCAM_AQPOND,
+            "gag": WEBCAM_GAGLARDI,
             "sub": WEBCAM_SUB,
             "sur": WEBCAM_SUR,
             "tff": WEBCAM_TFF,
@@ -73,13 +74,14 @@ class SFURoads(commands.Cog):  # pylint: disable=too-few-public-methods
     @commands.command(name="cam")
     @commands.guild_only()
     async def cam(self, ctx: Context, cam: str = ""):
-        """SFU webcam, defaults to Gaglardi.
+        """Show a SFU webcam image.
 
         Parameters:
         -----------
         cam: str
             One of the following short strings:
             aqpond: AQ Pond
+            gag:    Gaglardi intersection
             sub:    AQ overlooking student union building
             sur:    Surrey Central intersection
             tff:    Terry Fox Field

--- a/cogs/sfu/roads.py
+++ b/cogs/sfu/roads.py
@@ -37,6 +37,7 @@ WEBCAM_SUB = (
     "http://ns-webcams.its.sfu.ca/public/images/aqsw-current.jpg"
     "?nocache=0.3346598630889852&update=15000&timeout=1800000"
 )
+WEBCAM_SUR = "https://cosmos.surrey.ca/TrafficCameraImages/enc_102_cityparkway_cam1.jpg"
 WEBCAM_TFF = (
     "http://ns-webcams.its.sfu.ca/public/images/terryfox-current.jpg"
     "?nocache=1&update=15000&timeout=1800000"
@@ -69,6 +70,7 @@ class SFURoads(commands.Cog):  # pylint: disable=too-few-public-methods
             One of the following short strings:
             aqpond: AQ Pond
             sub:    AQ overlooking student union building
+            sur:    Surrey Central intersection
             tff:    Terry Fox Field
             trn:    Tower Road North
             trs:    Tower Road South
@@ -87,6 +89,8 @@ class SFURoads(commands.Cog):  # pylint: disable=too-few-public-methods
                 return
             elif cam.lower() == "sub":
                 fetchedData = requests.get(WEBCAM_SUB, headers=headers)
+            elif cam.lower() == "sur":
+                fetchedData = requests.get(WEBCAM_SUR, headers=headers)
             elif cam.lower() == "tff":
                 fetchedData = requests.get(WEBCAM_TFF, headers=headers)
             elif cam.lower() == "trn":

--- a/cogs/sfu/roads.py
+++ b/cogs/sfu/roads.py
@@ -58,6 +58,17 @@ class SFURoads(commands.Cog):  # pylint: disable=too-few-public-methods
 
     def __init__(self, bot: Red):
         self.bot = bot
+        self.cameras = {
+            "aqpond": WEBCAM_AQPOND,
+            "sub": WEBCAM_SUB,
+            "sur": WEBCAM_SUR,
+            "tff": WEBCAM_TFF,
+            "trn": WEBCAM_TRN,
+            "trs": WEBCAM_TRS,
+            "udn": WEBCAM_UDN,
+        }
+        # We need a custom header or else we get a HTTP 403 Unauthorized
+        self.headers = {"User-agent": "Mozilla/5.0"}
 
     @commands.command(name="cam")
     @commands.guild_only()
@@ -78,29 +89,13 @@ class SFURoads(commands.Cog):  # pylint: disable=too-few-public-methods
         """
         await ctx.trigger_typing()
 
-        # We need a custom header or else we get a HTTP 403 Unauthorized
-        headers = {"User-agent": "Mozilla/5.0"}
+        camera = self.cameras.get(cam.lower(), "help")
+        if camera == "help":
+            await self.bot.send_help_for(ctx, self.cam)
+            return
 
         try:
-            if cam.lower() == "aqpond":
-                fetchedData = requests.get(WEBCAM_AQPOND, headers=headers)
-            elif cam.lower() == "help":
-                await self.bot.send_help_for(ctx, self.cam)
-                return
-            elif cam.lower() == "sub":
-                fetchedData = requests.get(WEBCAM_SUB, headers=headers)
-            elif cam.lower() == "sur":
-                fetchedData = requests.get(WEBCAM_SUR, headers=headers)
-            elif cam.lower() == "tff":
-                fetchedData = requests.get(WEBCAM_TFF, headers=headers)
-            elif cam.lower() == "trn":
-                fetchedData = requests.get(WEBCAM_TRN, headers=headers)
-            elif cam.lower() == "trs":
-                fetchedData = requests.get(WEBCAM_TRS, headers=headers)
-            elif cam.lower() == "udn":
-                fetchedData = requests.get(WEBCAM_UDN, headers=headers)
-            else:
-                fetchedData = requests.get(WEBCAM_GAGLARDI, headers=headers)
+            fetchedData = requests.get(camera, headers=self.headers)
             fetchedData.raise_for_status()
         except requests.exceptions.HTTPError:
             await ctx.send(":warning: This webcam is currently unavailable!")


### PR DESCRIPTION
This PR:
- Adds the Surrey Central intersection camera for SFU.
- Refactors the camera command to use a dict for camera lookup.
- Modifies the default camera to be nothing, and instead print the help message out.