### PR TITLE
[Highlight] Add guild-wide channel denylist

### DIFF
--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -10,7 +10,7 @@ from threading import Lock
 import asyncio
 import aiohttp
 import discord
-from redbot.core import Config, commands, data_manager
+from redbot.core import Config, checks, commands, data_manager
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
 from redbot.core.utils import chat_formatting
@@ -73,6 +73,36 @@ class Highlight(commands.Cog):
     async def highlight(self, ctx):
         """Slack-like feature to be notified based on specific words outside of
         at-mentions."""
+
+    @highlight.group(name="guild")
+    @commands.guild_only()
+    @checks.mod_or_permissions()
+    async def guildSettings(self, ctx: Context):
+        """Guild-wide settings"""
+
+    @guildSettings.group(name="channel", aliases=["ch"])
+    async def guildChannels(self, ctx: Context):
+        """Channel denylist.
+
+        Channels on this list will NOT trigger user highlights.
+        """
+
+    @guildChannels.command(name="show", aliases=["ls"])
+    async def guildChannelsDenyList(self, ctx: Context):
+        """List the channels in the denylist."""
+
+    @guildChannels.command(name="add")
+    async def guildChannelsDenyAdd(self, ctx: Context):
+        """Add a channel to the denylist.
+
+        Channels in this list will NOT trigger user highlights.
+        """
+
+    @guildChannels.command(name="del", aliases=["delete", "remove", "rm"])
+    async def guildChannelsDenyDelete(self, ctx: Context):
+        """Remove a channel from the denylist.
+
+        """
 
     @highlight.command(name="add")
     @commands.guild_only()

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -68,39 +68,6 @@ class Highlight(commands.Cog):
         await asyncio.sleep(time)  # pylint: disable=no-member
         await msg.delete()
 
-    def _registerUser(self, guildId, userId):
-        """Checks to see if user is registered, and if not, registers the user.
-        If the user is already registered, this method will do nothing. If the
-        user is not, they will be initialized to contain an empty words list.
-
-        Parameters:
-        -----------
-        guildId: int
-            The guild ID for the user.
-        userId: int
-            The user ID.
-
-        Returns:
-        --------
-            None.
-        """
-        if guildId not in self.highlights.keys():
-            self.highlights[guildId] = {}
-
-        if userId not in self.highlights[guildId].keys():
-            self.highlights[guildId][userId] = {
-                KEY_WORDS: [],
-                KEY_BLACKLIST: [],
-                KEY_TIMEOUT: DEFAULT_TIMEOUT,
-            }
-            return
-
-        if KEY_BLACKLIST not in self.highlights[guildId][userId].keys():
-            self.highlights[guildId][userId][KEY_BLACKLIST] = []
-
-        if KEY_TIMEOUT not in self.highlights[guildId][userId].keys():
-            self.highlights[guildId][userId][KEY_TIMEOUT] = DEFAULT_TIMEOUT
-
     @commands.group(name="highlight", aliases=["hl"])
     @commands.guild_only()
     async def highlight(self, ctx):

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -71,6 +71,39 @@ class Highlight(commands.Cog):
         await asyncio.sleep(time)  # pylint: disable=no-member
         await msg.delete()
 
+    def _registerUser(self, guildId, userId):
+        """Checks to see if user is registered, and if not, registers the user.
+        If the user is already registered, this method will do nothing. If the
+        user is not, they will be initialized to contain an empty words list.
+
+        Parameters:
+        -----------
+        guildId: int
+            The guild ID for the user.
+        userId: int
+            The user ID.
+
+        Returns:
+        --------
+            None.
+        """
+        if guildId not in self.highlights.keys():
+            self.highlights[guildId] = {}
+
+        if userId not in self.highlights[guildId].keys():
+            self.highlights[guildId][userId] = {
+                KEY_WORDS: [],
+                KEY_BLACKLIST: [],
+                KEY_TIMEOUT: DEFAULT_TIMEOUT,
+            }
+            return
+
+        if KEY_BLACKLIST not in self.highlights[guildId][userId].keys():
+            self.highlights[guildId][userId][KEY_BLACKLIST] = []
+
+        if KEY_TIMEOUT not in self.highlights[guildId][userId].keys():
+            self.highlights[guildId][userId][KEY_TIMEOUT] = DEFAULT_TIMEOUT
+
     @commands.group(name="highlight", aliases=["hl"])
     @commands.guild_only()
     async def highlight(self, ctx):

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -129,9 +129,7 @@ class Highlight(commands.Cog):
         async with self.config.guild(ctx.guild).denylistChannels() as dlChannels:
             if channelName in dlChannels:
                 dlChannels.remove(channelName)
-                await ctx.send(
-                    f"**{channelName}** removed from the denylist."
-                )
+                await ctx.send(f"**{channelName}** removed from the denylist.")
             else:
                 await ctx.send(f"**{channelName}** is not on the denylist.")
 

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -158,7 +158,13 @@ class Highlight(commands.Cog):
 
     @guildChannels.command(name="del", aliases=["delete", "remove", "rm"])
     async def guildChannelsDenyDelete(self, ctx: Context, channelName: str):
-        """Remove a channel from the denylist."""
+        """Remove a channel from the denylist.
+
+        Parameters:
+        -----------
+        channelName: str
+            The channel name you wish to remove from the denylist.
+        """
         async with self.config.guild(ctx.guild).denylistChannels() as dlChannels:
             if channelName in dlChannels:
                 dlChannels.remove(channelName)

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -511,15 +511,18 @@ class Highlight(commands.Cog):
             return
 
         user = msg.author
-        channelBlId = await self.config.guild(msg.channel.guild).ignoreChannelID()
 
         # Prevent messages from being sent in after hours
         if msg.channel.name == "after-hours":
             return
 
-        # Prevent messages in a blacklisted channel from triggering highlight word
         # Prevent bots from triggering your highlight word.
-        if channelBlId and msg.channel.id == channelBlId or user.bot:
+        if user.bot:
+            return
+
+        # Prevent messages in a denylist channel from triggering highlight words
+        if msg.channel.name in await self.config.guild(msg.channel.guild).denylistChannels():
+            self.logger.debug("Message is from a denylist channel, returning")
             return
 
         # Don't send notification for filtered messages

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -684,22 +684,6 @@ class Highlight(commands.Cog):
         """Background listener to check messages for highlight DMs."""
         await self.checkHighlights(msg)
 
-    @commands.Cog.listener("on_guild_channel_create")
-    async def onGuildChannelCreate(self, channel: discord.abc.GuildChannel):
-        """Background listener to check if dark-hour has been created."""
-        self.logger.info(
-            "New Channel creation has been detected. Name: %s, ID: %s", channel.name, channel.id
-        )
-        if channel.name == "dark-hour":
-            await self.config.guild(channel.guild).ignoreChannelID.set(channel.id)
-            self.logger.info(
-                "Dark hour has been detected and channel id %s "
-                "will be blacklisted from highlights.",
-                channel.id,
-            )
-        else:
-            self.logger.info("New channel is not called dark hour and will not be " "blacklisted")
-
     def _isWordMatch(self, word, string):
         """See if the word/regex matches anything in string.
 

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -549,10 +549,6 @@ class Highlight(commands.Cog):
 
         user = msg.author
 
-        # Prevent messages from being sent in after hours
-        if msg.channel.name == "after-hours":
-            return
-
         # Prevent bots from triggering your highlight word.
         if user.bot:
             return

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -663,20 +663,6 @@ class Highlight(commands.Cog):
         else:
             self.logger.info("New channel is not called dark hour and will not be " "blacklisted")
 
-    @commands.Cog.listener("on_guild_channel_delete")
-    async def onGuildChannelDelete(self, channel: discord.abc.GuildChannel):
-        """Background listener to check if dark-hour has been deleted."""
-        channelBlId = await self.config.guild(channel.guild).ignoreChannelID()
-        if channelBlId and channel.id == channelBlId:
-            await self.config.guild(channel.guild).ignoreChannelID.set(None)
-            self.logger.info(
-                "Dark hour deletion has been detected and channelBlId has " "been reset"
-            )
-        else:
-            self.logger.info(
-                "Deleted channel is not dark hour so dark hour ID remains " "unchanged"
-            )
-
     def _isWordMatch(self, word, string):
         """See if the word/regex matches anything in string.
 


### PR DESCRIPTION
### Type
- [x] Enhancement

### Description of the changes
This PR:
- Closes #328 by adding a new command group called `highlight guild channel` to add/remove channel names from notifying users.
- Removes the listener that checks for a newly created channel named `after-hours` in favour of the new command.