### PR TITLE
[Cogs] Cancel background task on cog unload

### DIFF
--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -47,6 +47,9 @@ class Birthday(commands.Cog):
     def __unload(self):  # pylint: disable=invalid-name
         self.bgTask.cancel()
 
+    def cog_unload(self):
+        self.__unload()
+
     @commands.group(name="birthday")
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)

--- a/cogs/heartbeat/heartbeat.py
+++ b/cogs/heartbeat/heartbeat.py
@@ -50,6 +50,9 @@ class Heartbeat(commands.Cog):
         LOGGER.info("Cancelling heartbeat")
         self.bgTask.cancel()
 
+    def cog_unload(self):
+        self.__unload()
+
     @commands.command(name="heartbeat", aliases=["hb"])
     @commands.guild_only()
     async def _check(self, ctx: Context):

--- a/cogs/tempchannels/tempchannels.py
+++ b/cogs/tempchannels/tempchannels.py
@@ -43,6 +43,9 @@ class TempChannels(commands.Cog):
     def __unload(self):  # pylint: disable=invalid-name
         self.bgTask.cancel()
 
+    def cog_unload(self):
+        self.__unload()
+
     async def _syncSettings(self):
         """Force settings to file and reload."""
         await self.config.put(KEY_SETTINGS, self.settings)


### PR DESCRIPTION
### Type
- [x] Bugfix

### Description of the changes
This PR cleans up background tasks on cog unload by cancelling them. It covers Birthday, TempChannels, and Heartbeat.