### PR TITLE
[Tags] Add rename command

### DIFF
--- a/cogs/tags/exceptions.py
+++ b/cogs/tags/exceptions.py
@@ -1,0 +1,6 @@
+class ReservedTagNameError(RuntimeError):
+    pass
+
+
+class SpaceInTagNameError(RuntimeError):
+    pass

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -146,6 +146,8 @@ class Tags(commands.Cog):
         self.configV3 = ConfigV3.get_conf(self, identifier=5842647, force_registration=True)
         self.configV3.register_guild(**BASE)  # Register default (empty) settings.
         self.lock = Lock()
+        tagGroup = self.get_commands()[0]
+        self.tagCommands = tagGroup.all_commands.keys()
 
     def get_database_location(self, message: discord.Message):
         """Get the database of tags.
@@ -265,6 +267,13 @@ class Tags(commands.Cog):
                     "This name cannot be used because there is already an internal command with this name."
                 )
         return aliasCog
+
+    def checkValidCommandName(self, name: str):
+        """Check to see if we can use the name as a tag"""
+        if name in self.tagCommands:
+            raise RuntimeError("This tag name is reserved, please use a different name!")
+        if any(char.isspace() for char in name):
+            raise RuntimeError("There is a space in the tag name, please use a different name!")
 
     async def canModifyTag(self, tag, member: discord.Member, guild: discord.Guild):
         """Check to see if a user can modify a given tag.
@@ -450,6 +459,7 @@ class Tags(commands.Cog):
         """
         try:
             aliasCog = self.checkAliasCog(name)
+            self.checkValidCommandName(name)
         except RuntimeError as error:
             return await ctx.send(error)
 
@@ -638,6 +648,13 @@ class Tags(commands.Cog):
             return
 
         lookup = name.content.lower()
+
+        try:
+            self.checkValidCommandName(lookup)
+        except RuntimeError as error:
+            await ctx.send(f"{error}")
+            return
+
         if lookup in db:
             fmt = (
                 "Sorry. A tag with that name exists already. Redo the command {0.prefix}tag make."

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -5,6 +5,7 @@
 
 from .config import Config
 from .constants import *
+from .exceptions import *
 from .rolecheck import role_or_mod_or_permissions
 
 import csv
@@ -271,9 +272,11 @@ class Tags(commands.Cog):
     def checkValidCommandName(self, name: str):
         """Check to see if we can use the name as a tag"""
         if name in self.tagCommands:
-            raise RuntimeError("This tag name is reserved, please use a different name!")
+            raise ReservedTagNameError("This tag name is reserved, please use a different name!")
         if any(char.isspace() for char in name):
-            raise RuntimeError("There is a space in the tag name, please use a different name!")
+            raise SpaceInTagNameError(
+                "There is a space in the tag name, please use a different name!"
+            )
 
     async def canModifyTag(self, tag, member: discord.Member, guild: discord.Guild):
         """Check to see if a user can modify a given tag.
@@ -1190,3 +1193,23 @@ class Tags(commands.Cog):
             await ctx.send(
                 "\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will " "be sent **in a DM**."
             )
+
+    @tag.command(name="runtests")
+    @checks.is_owner()
+    async def runTests(self, ctx: Context):
+        """Run tests."""
+        # Test checkValidCommandName
+        name = "validtagname"
+        self.checkValidCommandName(name)
+        name = "add"
+        try:
+            self.checkValidCommandName(name)
+        except ReservedTagNameError:
+            pass
+
+        name = "name with space"
+        try:
+            self.checkValidCommandName(name)
+        except SpaceInTagNameError:
+            pass
+        await ctx.send("Tests passed!")

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -1270,4 +1270,28 @@ class Tags(commands.Cog):
             self.checkValidCommandName(name)
         except SpaceInTagNameError:
             pass
+
+        # Test rename command after creating
+        await ctx.invoke(self.create, name="runTestCommandTest1", content="This is a test tag")
+        location = self.get_database_location(ctx.message)
+        db = self.config.get(location, {})
+        assert "runTestCommandTest1".lower() in db
+        await ctx.invoke(self.rename, oldName="runTestCommandTest1", newName="runTestCommandTest2")
+        db = self.config.get(location, {})
+        assert "runTestCommandTest1".lower() not in db
+        assert "runTestCommandTest2".lower() in db
+
+        # Test renaming to a command, this should not work.
+        await ctx.invoke(self.rename, oldName="runTestCommandTest2", newName="add")
+        db = self.config.get(location, {})
+        assert "runTestCommandTest2".lower() in db
+        assert "add".lower() not in db
+        await ctx.invoke(self.remove, name="runTestCommandTest2")
+
+        # Test renaming a non-existent command
+        await ctx.invoke(self.rename, oldName="runTestCommandTest1", newName="runTestCommandTest2")
+        db = self.config.get(location, {})
+        assert "runTestCommandTest1".lower() not in db
+        assert "runTestCommandTest2".lower() not in db
+
         await ctx.send("Tests passed!")

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -884,16 +884,17 @@ class Tags(commands.Cog):
         except RuntimeError as error:
             return await ctx.send(error)
 
-        lookup = newName.lower().strip()
+        newName = newName.lower().strip()
+        oldName = oldName.lower()
         try:
-            self.verify_lookup(lookup)
-            tag = self.get_tag(ctx.guild, oldName.lower(), redirect=False)
+            self.verify_lookup(newName)
+            tag = self.get_tag(ctx.guild, oldName, redirect=False)
         except RuntimeError as e:
             return await ctx.send(e)
 
         location = self.get_database_location(ctx.message)
         db = self.config.get(location, {})
-        if lookup in db:
+        if newName in db:
             await ctx.send('A tag with the name of "{}" already exists.'.format(newName))
             return
 
@@ -917,8 +918,8 @@ class Tags(commands.Cog):
         await self.config.put(location, db)
         if self.settings.get(KEY_USE_ALIAS, False):
             # Alias is already loaded.
-            await aliasCog.add_alias(ctx, lookup, "tag {}".format(lookup))
-            await aliasCog.del_alias(ctx, oldName.lower())
+            await aliasCog.add_alias(ctx, newName, "tag {}".format(newName))
+            await aliasCog.del_alias(ctx, oldName)
         await ctx.send('Tag "{}" successfully renamed to "{}".'.format(oldName, newName))
 
     @tag.command(name="delete", aliases=["del", "remove", "rm"])

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -8,6 +8,7 @@ from .constants import *
 from .exceptions import *
 from .rolecheck import role_or_mod_or_permissions
 
+from copy import deepcopy
 import csv
 import json
 import re
@@ -863,6 +864,69 @@ class Tags(commands.Cog):
             await ctx.send(
                 "Tag has been rejected by {}. Transfer has been " "cancelled.".format(user.name)
             )
+
+    @tag.command(name="rename")
+    async def rename(self, ctx: Context, oldName: str, newName: str):
+        """Renames a tag.
+
+        This is useful to help preserve tag statistics.
+
+        Parameters
+        ----------
+        oldName: str
+            The old tag name.
+        newName: str
+            The new tag name.
+        """
+        # TODO Consolidate into helper method later.
+        if self.settings.get(KEY_USE_ALIAS, False):
+            aliasCog = self.bot.get_cog("Alias")
+            if not aliasCog:
+                await ctx.send("Could not access the Alias cog. Please load it and " "try again.")
+                return
+            elif aliasCog.is_command(newName):
+                await ctx.send(
+                    "This name cannot be used because there is already "
+                    "an internal command with this name."
+                )
+                return
+
+        lookup = newName.lower().strip()
+        try:
+            self.verify_lookup(lookup)
+            tag = self.get_tag(ctx.guild, oldName.lower(), redirect=False)
+        except RuntimeError as e:
+            return await ctx.send(e)
+
+        location = self.get_database_location(ctx.message)
+        db = self.config.get(location, {})
+        if lookup in db:
+            await ctx.send('A tag with the name of "{}" already exists.'.format(newName))
+            return
+
+        mod_roles = await self.bot.get_mod_roles(ctx.guild)
+        admin_roles = await self.bot.get_admin_roles(ctx.guild)
+        roles = ctx.author.roles
+
+        # Check and see if the user is not the tag owner, or is not a mod, or is not an admin.
+        if (
+            tag.owner_id != str(ctx.message.author.id)
+            and not list(set(admin_roles) & set(roles))
+            and not list(set(mod_roles) & set(roles))
+            and not await self.bot.is_owner(ctx.author)
+        ):
+            await ctx.send("Only the tag owner can rename this tag.")
+            return
+
+        db[newName] = deepcopy(db[oldName])
+        del db[oldName]
+
+        await self.config.put(location, db)
+        if self.settings.get(KEY_USE_ALIAS, False):
+            # Alias is already loaded.
+            await aliasCog.add_alias(ctx, lookup, "tag {}".format(lookup))
+            await aliasCog.del_alias(ctx, oldName.lower())
+        await ctx.send('Tag "{}" successfully renamed to "{}".'.format(oldName, newName))
 
     @tag.command(name="delete", aliases=["del", "remove", "rm"])
     @role_or_mod_or_permissions(role=ALLOWED_ROLE, manage_messages=True)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -878,18 +878,11 @@ class Tags(commands.Cog):
         newName: str
             The new tag name.
         """
-        # TODO Consolidate into helper method later.
-        if self.settings.get(KEY_USE_ALIAS, False):
-            aliasCog = self.bot.get_cog("Alias")
-            if not aliasCog:
-                await ctx.send("Could not access the Alias cog. Please load it and " "try again.")
-                return
-            elif aliasCog.is_command(newName):
-                await ctx.send(
-                    "This name cannot be used because there is already "
-                    "an internal command with this name."
-                )
-                return
+        try:
+            aliasCog = self.checkAliasCog(newName)
+            self.checkValidCommandName(newName)
+        except RuntimeError as error:
+            return await ctx.send(error)
 
         lookup = newName.lower().strip()
         try:


### PR DESCRIPTION
### Type
- [x] New feature

### Description of the changes
This PR closes #293 by adding a rename command. This command will allow a user to change a tag's name without losing the statistics behind it.