### PR TITLE
Updated source cog's description and hopefully deal with null stirng …

### DIFF
--- a/cogs/source/source.py
+++ b/cogs/source/source.py
@@ -4,9 +4,7 @@ from tracemoepy.errors import EmptyImage, EntityTooLarge, ServerError, TooManyRe
 
 
 def messageBuilder(titleEnglish: str, anilistID: str, episode: str, similarity: int):
-    """
-    Builds the message that is sent in response
-    """
+    """Builds the message that is sent in response"""
     # If the title isn't found, just return no matching anime found
     if titleEnglish == "No Title Found":
         return "No matching anime found.\nThis could be because provided picture isn't a screenshot of an anime, or the episode it's from is too new"

--- a/cogs/source/source.py
+++ b/cogs/source/source.py
@@ -3,6 +3,15 @@ import tracemoepy
 from tracemoepy.errors import EmptyImage, EntityTooLarge, ServerError, TooManyRequests
 
 
+async def assignDefaultStringValue(stringVar, val):
+    """
+    Assigns default value to string if string is null
+    """
+    if stringVar == None:
+        stringVar = val
+    return
+
+
 async def postSourceFunction(ctx, imageURL):
     """helper method"""
     try:
@@ -12,15 +21,22 @@ async def postSourceFunction(ctx, imageURL):
         anilistID = f"{result.docs[0].anilist_id}"
         episode = f"{result.docs[0].episode}"
         similarity = float(result.docs[0].similarity)
+
+        assignDefaultStringValue(titleEnglish, "No Title Found")
+        assignDefaultStringValue(anilistID, "No anilistID Found")
+        assignDefaultStringValue(episode, "No Episode Found")
+
         URL = "https://anilist.co/anime/" + anilistID
 
-        if similarity < 0.8:
+        if similarity < 0.9:
             await ctx.send(
                 "Anime: "
                 + titleEnglish
                 + "\nEpisode: "
                 + episode
-                + "\nWARNING: Similarity less than 80%, result may not be accurate"
+                + "\nSimilarity: "
+                + ("%.3f" % ((similarity) * 100))
+                + "\nWARNING: Similarity less than 90%, result may not be accurate"
                 + "\n"
                 + URL
             )
@@ -53,7 +69,7 @@ async def postSourceFunction(ctx, imageURL):
 class Source(commands.Cog):
     @commands.group(name="source", invoke_without_command=True)
     async def sourceCommand(self, ctx):
-        """Looks for source of image
+        """Looks for source of a screenshot from anime, using trace.moe
 
         Parameters:
         -----------
@@ -70,7 +86,7 @@ class Source(commands.Cog):
 
     @sourceCommand.command(name="url")
     async def urlSource(self, ctx, imageURL):
-        """Looks for source of image
+        """Looks for source of a screenshot from anime, using trace.moe
 
         Parameters:
         -----------

--- a/cogs/source/source.py
+++ b/cogs/source/source.py
@@ -3,11 +3,13 @@ import tracemoepy
 from tracemoepy.errors import EmptyImage, EntityTooLarge, ServerError, TooManyRequests
 
 
-# TODO: ask if we should just provide a standalone message if no anime title is found, possibly with a warning that it only works on anime screenshots or the episode might be too new
 def messageBuilder(titleEnglish: str, anilistID: str, episode: str, similarity: int):
     """
     Builds the message that is sent in response
     """
+    # If the title isn't found, just return no matching anime found
+    if titleEnglish == "No Title Found":
+        return "No matching anime found.\nThis could be because provided picture isn't a screenshot of an anime, or the episode it's from is too new"
     # Title of anime
     message = "Anime: " + titleEnglish
     # episode number

--- a/cogs/source/source.py
+++ b/cogs/source/source.py
@@ -11,17 +11,17 @@ def messageBuilder(titleEnglish: str, anilistID: str, episode: str, similarity: 
     if titleEnglish == "No Title Found":
         return "No matching anime found.\nThis could be because provided picture isn't a screenshot of an anime, or the episode it's from is too new"
     # Title of anime
-    message = "Anime: " + titleEnglish
+    message = f"Anime: {titleEnglish}"
     # episode number
-    message += "\nEpisode: " + episode
+    message += f"\nEpisode: {episode}"
     # How similar message is
-    message += "\nSimilarity: " + ("%.3f" % ((similarity) * 100))
+    message += f"\nSimilarity: {similarity*100:.3f}%"
     if similarity * 100 < 90:
         # warning if similarity is less than 90%
         message += "\nWARNING: Similarity less than 90%, result may not be accurate"
     if anilistID != "No anilistID Found":
         # URL
-        message += "\nhttps://anilist.co/anime/" + anilistID
+        message += f"\nhttps://anilist.co/anime/{anilistID}"
     return message
 
 

--- a/cogs/source/source.py
+++ b/cogs/source/source.py
@@ -3,55 +3,65 @@ import tracemoepy
 from tracemoepy.errors import EmptyImage, EntityTooLarge, ServerError, TooManyRequests
 
 
-async def assignDefaultStringValue(stringVar, val):
-    """
-    Assigns default value to string if string is null
-    """
-    if stringVar == None:
-        stringVar = val
-    return
-
-
 async def postSourceFunction(ctx, imageURL):
     """helper method"""
     try:
         tracemoe = tracemoepy.tracemoe.TraceMoe()
         result = tracemoe.search(imageURL.strip("<>"), is_url=True)
-        titleEnglish = result.docs[0].title_english
-        anilistID = f"{result.docs[0].anilist_id}"
-        episode = f"{result.docs[0].episode}"
-        similarity = float(result.docs[0].similarity)
-
-        assignDefaultStringValue(titleEnglish, "No Title Found")
-        assignDefaultStringValue(anilistID, "No anilistID Found")
-        assignDefaultStringValue(episode, "No Episode Found")
+        titleEnglish = result.docs[0].title_english or "No Title Found"
+        anilistID = f"{result.docs[0].anilist_id}" or "No anilistID Found"
+        episode = f"{result.docs[0].episode}" or "No Episode Found"
+        similarity = float(result.docs[0].similarity) or 0
 
         URL = "https://anilist.co/anime/" + anilistID
 
         if similarity < 0.9:
-            await ctx.send(
-                "Anime: "
-                + titleEnglish
-                + "\nEpisode: "
-                + episode
-                + "\nSimilarity: "
-                + ("%.3f" % ((similarity) * 100))
-                + "\nWARNING: Similarity less than 90%, result may not be accurate"
-                + "\n"
-                + URL
-            )
+            if anilistID == "No anilistID Found":
+                await ctx.send(
+                    "Anime: "
+                    + titleEnglish
+                    + "\nEpisode: "
+                    + episode
+                    + "\nSimilarity: "
+                    + ("%.3f" % ((similarity) * 100))
+                    + "\nWARNING: Similarity less than 90%, result may not be accurate"
+                )
+            else:
+                await ctx.send(
+                    "Anime: "
+                    + titleEnglish
+                    + "\nEpisode: "
+                    + episode
+                    + "\nSimilarity: "
+                    + ("%.3f" % ((similarity) * 100))
+                    + "\nWARNING: Similarity less than 90%, result may not be accurate"
+                    + "\n"
+                    + URL
+                )
         else:
-            await ctx.send(
-                "Anime: "
-                + titleEnglish
-                + "\nSimilarity: "
-                + ("%.3f" % ((similarity) * 100))
-                + "%"
-                + "\nEpisode: "
-                + episode
-                + "\n"
-                + URL
-            )
+            if anilistID == "No anilistID Found":
+                if anilistID == "No anilistID Found":
+                    await ctx.send(
+                        "Anime: "
+                        + titleEnglish
+                        + "\nEpisode: "
+                        + episode
+                        + "\nSimilarity: "
+                        + ("%.3f" % ((similarity) * 100))
+                        + "\nWARNING: Similarity less than 90%, result may not be accurate"
+                    )
+            else:
+                await ctx.send(
+                    "Anime: "
+                    + titleEnglish
+                    + "\nSimilarity: "
+                    + ("%.3f" % ((similarity) * 100))
+                    + "%"
+                    + "\nEpisode: "
+                    + episode
+                    + "\n"
+                    + URL
+                )
     except TooManyRequests:
         await ctx.send("Please try again later")
     except EntityTooLarge:


### PR DESCRIPTION
…values returned from trace.moe api

### Type

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
Edited source.py to deal with null string return values from the trace.moe api, as well as updating the description to specify it's for looking up anime screenshots.
Also changed warning to warn when similarity is less than 90% as similarity ratings between the old 80% warning and 90% were often wrong.
Removed url link if the anilist ID can't be found.