### PR TITLE
[Tags] Fix silent errors and use Config v3

### DIFF
--- a/cogs/tags/constants.py
+++ b/cogs/tags/constants.py
@@ -1,4 +1,4 @@
-BASE = {"tiers": {}, "useAlias": False}
+BASE = {"dm": False, "tiers": {}, "useAlias": False}
 DEFAULT_MAX = 50  # Default max number of tags per user.
 KEY_MAX = "max"
 DUMP_IN = "data/tags/tags.json"

--- a/cogs/tags/constants.py
+++ b/cogs/tags/constants.py
@@ -1,7 +1,6 @@
 BASE = {"tiers": {}, "useAlias": False}
 DEFAULT_MAX = 50  # Default max number of tags per user.
 KEY_MAX = "max"
-KEY_USE_ALIAS = "useAlias"
 DUMP_IN = "data/tags/tags.json"
 DUMP_OUT = "data/tags/export.csv"
 NO_LIMIT = float("inf")

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -1100,8 +1100,7 @@ class Tags(commands.Cog):
 
         if tags:
             try:
-                self.dm = self.settings.get("dm", False)
-                if self.dm:
+                if await self.configV3.guild(ctx.guild).dm():
                     await ctx.send("Check your DMs.")
                     msg = "Here are a list of tags for {}:\n```".format(ctx.message.author.mention)
                     for item in tags:
@@ -1135,8 +1134,7 @@ class Tags(commands.Cog):
 
         if tags:
             try:
-                self.dm = self.settings.get("dm", False)
-                if self.dm:
+                if await self.configV3.guild(ctx.guild).dm():
                     await ctx.send("Check your DMs.")
                     msg = "Here are a list of tags for {}:\n```".format(ctx.message.guild.name)
                     for item in tags:
@@ -1279,20 +1277,18 @@ class Tags(commands.Cog):
     @settings.command(name="toggledm")
     async def toggledm(self, ctx: Context):
         """Toggle sending DM for list of tags."""
-        self.dm = self.settings.get("dm", False)
-        if self.dm:
-            self.dm = False
-            await self.settings.put("dm", False)
+        if await self.configV3.guild(ctx.guild).dm():
+            dm = False
             await ctx.send(
                 "\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will "
                 "be sent **in the channel they were requested**."
             )
         else:
-            self.dm = True
-            await self.settings.put("dm", True)
+            dm = True
             await ctx.send(
                 "\N{WHITE HEAVY CHECK MARK} **Tags - DM**: Tag lists will " "be sent **in a DM**."
             )
+        await self.configV3.guild(ctx.guild).dm.set(dm)
 
     @tag.command(name="runtests")
     @checks.is_owner()

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -538,7 +538,10 @@ class Tags(commands.Cog):
         elif isinstance(error, commands.UnexpectedQuoteError):
             await ctx.send("Please do not use quotes in the tag name!")
         else:
-            await ctx.send("Something went wrong, please check the logs for details.")
+            await ctx.send(
+                "Something went wrong, please try again or contact the bot owner(s) "
+                "if this continues."
+            )
             raise error
 
     @tag.command(name="generic")
@@ -583,7 +586,10 @@ class Tags(commands.Cog):
         elif isinstance(error, commands.UnexpectedQuoteError):
             await ctx.send("Please do not use quotes in the tag name!")
         else:
-            await ctx.send("Something went wrong, please check the logs for details.")
+            await ctx.send(
+                "Something went wrong, please try again or contact the bot owner(s) "
+                "if this continues."
+            )
             raise error
 
     @tag.command(name="alias")

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -229,7 +229,7 @@ class Tags(commands.Cog):
                 raise RuntimeError("Tag not found.")
             raise RuntimeError("Tag not found. Did you mean...\n" + "\n".join(possible_matches))
 
-    async def user_exceeds_tag_limit(self, server: discord.Guild, user: discord.Member):
+    async def userExceedsTagLimit(self, server: discord.Guild, user: discord.Member):
         """Check to see if user has too many tags.
 
         This check compares against all relevant roles that the member has, and will
@@ -494,7 +494,7 @@ class Tags(commands.Cog):
         except RuntimeError as error:
             return await ctx.send(error)
 
-        exceedsLimit, limit = await self.user_exceeds_tag_limit(ctx.guild, ctx.author)
+        exceedsLimit, limit = await self.userExceedsTagLimit(ctx.guild, ctx.author)
         if exceedsLimit:
             await ctx.send(
                 "You have too many commands. The maximum number of commands "
@@ -652,7 +652,7 @@ class Tags(commands.Cog):
         except RuntimeError as error:
             return await ctx.send(error)
 
-        exceedsLimit, limit = await self.user_exceeds_tag_limit(ctx.guild, ctx.author)
+        exceedsLimit, limit = await self.userExceedsTagLimit(ctx.guild, ctx.author)
         if exceedsLimit:
             await ctx.send(
                 "You have too many commands. The maximum number of commands "
@@ -867,7 +867,7 @@ class Tags(commands.Cog):
             return
 
         # Check if the user to transfer to has exceeded the tag limit
-        exceedsLimit, _ = await self.user_exceeds_tag_limit(ctx.guild, user)
+        exceedsLimit, _ = await self.userExceedsTagLimit(ctx.guild, user)
         if exceedsLimit:
             await ctx.send(
                 "The person you are trying to transfer a tag to is not allowed to have "

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -284,9 +284,9 @@ class Tags(commands.Cog):
             return (True, limit)
         return (False, limit)
 
-    def checkAliasCog(self, name: str = None):
+    async def checkAliasCog(self, ctx: Context, name: str = None):
         aliasCog = None
-        if self.settings.get(KEY_USE_ALIAS, False):
+        if await self.configV3.guild(ctx.guild).useAlias():
             aliasCog = self.bot.get_cog("Alias")
             if not aliasCog:
                 raise RuntimeError("Could not access the Alias cog. Please load it and try again.")
@@ -489,7 +489,7 @@ class Tags(commands.Cog):
         create can only be accessed in the server that it was created in.
         """
         try:
-            aliasCog = self.checkAliasCog(name)
+            aliasCog = await self.checkAliasCog(ctx, name)
             self.checkValidCommandName(name)
         except RuntimeError as error:
             return await ctx.send(error)
@@ -526,7 +526,7 @@ class Tags(commands.Cog):
         await self.config.put(location, db)
         await ctx.send('Tag "{}" successfully created.'.format(name))
 
-        if self.settings.get(KEY_USE_ALIAS, False):
+        if await self.configV3.guild(ctx.guild).useAlias():
             # Alias is already loaded.
             await aliasCog.add_alias(ctx, lookup, "tag {}".format(lookup))
 
@@ -648,7 +648,7 @@ class Tags(commands.Cog):
         create command.
         """
         try:
-            aliasCog = self.checkAliasCog()
+            aliasCog = await self.checkAliasCog(ctx)
         except RuntimeError as error:
             return await ctx.send(error)
 
@@ -701,7 +701,7 @@ class Tags(commands.Cog):
             return
 
         # Alias is already loaded
-        if self.settings.get(KEY_USE_ALIAS, False) and aliasCog.is_command(lookup):
+        if await self.configV3.guild(ctx.guild).useAlias() and aliasCog.is_command(lookup):
             await ctx.send(
                 "This name cannot be used because there is already "
                 "an internal command with this name."
@@ -733,7 +733,7 @@ class Tags(commands.Cog):
         await self.config.put(location, db)
         await ctx.send("Cool. I've made your {0.content} tag.".format(name))
 
-        if self.settings.get(KEY_USE_ALIAS, False):
+        if await self.configV3.guild(ctx.guild).useAlias():
             # Alias is already loaded.
             await aliasCog.add_alias(ctx, lookup, "tag {}".format(lookup))
 
@@ -957,7 +957,7 @@ class Tags(commands.Cog):
         del db[oldName]
 
         await self.config.put(location, db)
-        if self.settings.get(KEY_USE_ALIAS, False):
+        if await self.configV3.guild(ctx.guild).useAlias():
             # Alias is already loaded.
             await aliasCog.add_alias(ctx, newName, "tag {}".format(newName))
             await aliasCog.del_alias(ctx, oldName)
@@ -974,7 +974,7 @@ class Tags(commands.Cog):
         Deleting a tag will delete all of its aliases as well.
         """
         try:
-            aliasCog = self.checkAliasCog()
+            aliasCog = await self.checkAliasCog(ctx)
         except RuntimeError as error:
             return await ctx.send(error)
 
@@ -1025,7 +1025,7 @@ class Tags(commands.Cog):
         await self.config.put(location, db)
         await ctx.send(msg)
 
-        if self.settings.get(KEY_USE_ALIAS, False):
+        if await self.configV3.guild(ctx.guild).useAlias():
             # Alias is already loaded.
             await aliasCog.del_alias(ctx, lookup)
 
@@ -1262,7 +1262,7 @@ class Tags(commands.Cog):
     @settings.command(name="togglealias")
     async def togglealias(self, ctx: Context):
         """Toggle creating aliases for tags."""
-        if self.settings.get(KEY_USE_ALIAS, False):
+        if await self.configV3.guild(ctx.guild).useAlias():
             toAlias = False
             await ctx.send(
                 "\N{WHITE HEAVY CHECK MARK} **Tags - Aliasing**: Tags will "
@@ -1274,7 +1274,7 @@ class Tags(commands.Cog):
                 "\N{WHITE HEAVY CHECK MARK} **Tags - Aliasing**: Tags will "
                 "be created **with an alias**."
             )
-        await self.settings.put(KEY_USE_ALIAS, toAlias)
+        await self.configV3.guild(ctx.guild).useAlias.set(toAlias)
 
     @settings.command(name="toggledm")
     async def toggledm(self, ctx: Context):

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -536,6 +536,8 @@ class Tags(commands.Cog):
             await ctx.send("Tag " + str(error))
         elif isinstance(error, commands.CheckFailure):
             pass
+        elif isinstance(error, commands.UnexpectedQuoteError):
+            await ctx.send("Please do not use quotes in the tag name!")
         else:
             await ctx.send("Something went wrong, please check the logs for details.")
             raise error
@@ -577,7 +579,12 @@ class Tags(commands.Cog):
     async def generic_error(self, ctx: Context, error):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send("Tag " + str(error))
+        elif isinstance(error, commands.CheckFailure):
+            pass
+        elif isinstance(error, commands.UnexpectedQuoteError):
+            await ctx.send("Please do not use quotes in the tag name!")
         else:
+            await ctx.send("Something went wrong, please check the logs for details.")
             raise error
 
     @tag.command(name="alias")
@@ -736,7 +743,10 @@ class Tags(commands.Cog):
             await ctx.send("Please call just {0.prefix}tag make".format(ctx))
         elif isinstance(error, commands.CheckFailure):
             pass
+        elif isinstance(error, commands.UnexpectedQuoteError):
+            await ctx.send("Please do not use quotes in the tag name!")
         else:
+            await ctx.send("Something went wrong, please check the logs for details.")
             raise error
 
     def top_three_tags(self, db):
@@ -1040,6 +1050,7 @@ class Tags(commands.Cog):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send("Missing tag name to get info of.")
         else:
+            await ctx.send("Something went wrong, please check the logs for details.")
             raise error
 
     @tag.command(name="raw")

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -161,7 +161,6 @@ class Tags(commands.Cog):
             loop=bot.loop,
             load_later=True,
         )
-        self.settings = Config(saveFolder, "settings-v2.json")
         self.configV3 = ConfigV3.get_conf(self, identifier=5842647, force_registration=True)
         self.configV3.register_guild(**BASE)  # Register default (empty) settings.
         self.lock = Lock()


### PR DESCRIPTION
### Type
- [x] Bugfix

### Description of the changes
This PR
- Closes #341 by no longer failing silently but instead erroring with a user-visible message.
- Closes #357 by moving the alias and dm toggles to use Config v3.
    - Convert `checkAliasCog` to a coroutine because we need ctx to use Config v3.
- Renames `user_exceeds_tag_limit` to `useExceedsTagLimit`.