### PR TITLE
[Tags] Sync roles when bot connects and has all info

### DIFF
--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -166,7 +166,14 @@ class Tags(commands.Cog):
         self.lock = Lock()
         tagGroup = self.get_commands()[0]
         self.tagCommands = tagGroup.all_commands.keys()
-        self.bot.loop.create_task(self.syncAllowedRoles())
+        self.syncLoopCreated = False
+
+    @commands.Cog.listener("on_ready")
+    async def initialSyncLoop(self):
+        if not self.syncLoopCreated:
+            # TODO Add logger here.
+            self.bot.loop.create_task(self.syncAllowedRoles())
+            self.syncLoopCreated = True
 
     async def syncAllowedRoles(self):
         guildIds = await self.configV3.all_guilds()


### PR DESCRIPTION
### Type
- [x] Bugfix

### Description of the changes
This PR closes #368 by syncing roles when the bot has guild and role data available after it connects to Discord.