### PR TITLE
[ServerManage] Remove sm alias for base command

### DIFF
--- a/cogs/servermanage/commands.py
+++ b/cogs/servermanage/commands.py
@@ -10,7 +10,7 @@ from .meta import ServerManageMeta
 
 
 class ServerManageCommands(ABC, metaclass=ServerManageMeta):
-    @commands.group(name="servermanage", aliases=["sm"])
+    @commands.group(name="servermanage")
     @commands.guild_only()
     @checks.mod_or_permissions()
     async def serverManage(self, ctx: Context):


### PR DESCRIPTION
As per title. This PR removes the alias so that we can load it without colliding with other cogs. We can use the Alias to add it back later if we decide to not use the cogs that collide with this one.