### PR TITLE
[Birthday] Add warning if re-adding user

### DIFF
--- a/cogs/birthday/constants.py
+++ b/cogs/birthday/constants.py
@@ -1,3 +1,4 @@
+KEY_ADDED_BEFORE = "addedBefore"
 KEY_BDAY_CHANNEL = "birthdayChannel"
 KEY_BDAY_ROLE = "birthdayRole"
 KEY_BDAY_USERS = "birthdayUsers"
@@ -6,6 +7,7 @@ KEY_BDAY_DAY = "birthdateDay"
 KEY_IS_ASSIGNED = "isAssigned"
 
 BASE_GUILD_MEMBER = {
+    KEY_ADDED_BEFORE: False,
     KEY_BDAY_DAY: None,
     KEY_BDAY_MONTH: None,
     KEY_IS_ASSIGNED: False,


### PR DESCRIPTION
### Type
- [x] Enhancement

### Description of the changes
This PR closes #353. It will:
- Add a new variable to store whether we've removed this person's birthday before.
- Warn the user if they're adding someone's birthday we've removed before.
- Add a check to see if we're updating the person's birthday, and if so, then update the message being returned back to the person adding the birthday.
