### PR TITLE
[Highlight] Add ability to ignore a channel at the user level

### DIFF
--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -684,6 +684,10 @@ class Highlight(commands.Cog):
         for currentUserId, data in guildData.items():
             self.logger.debug("User ID: %s", currentUserId)
             isWordIgnored = False
+            
+            # Handle case where message was sent in a user denied channel
+            if msg.channel.id in data[KEY_CHANNEL_IGNORE]:
+                continue
 
             # Handle case where user was at-mentioned.
             if currentUserId in [atMention.id for atMention in msg.mentions]:

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -478,13 +478,11 @@ class Highlight(commands.Cog):
         await ctx.send("Timeout set to {} seconds.".format(seconds), delete_after=DELETE_TIME)
         await ctx.message.delete()
 
-
-
     @highlight.group(name="channelDeny", aliases=["cd"])
     @commands.guild_only()
     async def channelDeny(self, ctx: Context):
         """Stops certain channels from triggering your highlight words"""
-    
+
     @channelDeny.command(name="add")
     @commands.guild_only()
     async def channelDenyAdd(self, ctx: Context, channel: discord.TextChannel):
@@ -493,7 +491,7 @@ class Highlight(commands.Cog):
         Parameters:
         -----------
         channel: discord.TextChannel
-            The channel you wish to block highlight triggers from.    
+            The channel you wish to block highlight triggers from.
         """
         guildId = ctx.guild.id
         userId = ctx.author.id
@@ -504,17 +502,16 @@ class Highlight(commands.Cog):
                 await ctx.send("Channel is already being ignored!", delete_after=DELETE_TIME)
                 await ctx.message.delete()
             else:
-                channelList.append(channel.id) 
+                channelList.append(channel.id)
                 await ctx.send("Channel added to ignore list.", delete_after=DELETE_TIME)
                 await ctx.message.delete()
-        
-    
+
     @channelDeny.command(name="remove", aliases=["rm"])
     @commands.guild_only()
     async def channelDenyRemove(self, ctx: Context, channel: discord.TextChannel):
         """Remove a channel that was on the denylist and allow
         the channel to trigger highlights again
-        
+
         Parameters:
         -----------
         channel: discord.TextChannel
@@ -531,8 +528,10 @@ class Highlight(commands.Cog):
             else:
                 channelList.remove(channelId)
                 await ctx.message.delete()
-                await ctx.send("Channel successfully removed from deny list.", delete_after=DELETE_TIME)
-                
+                await ctx.send(
+                    "Channel successfully removed from deny list.", delete_after=DELETE_TIME
+                )
+
     @channelDeny.command(name="list", aliases=["ls"])
     @commands.guild_only()
     async def channelDenyList(self, ctx: Context):
@@ -546,17 +545,17 @@ class Highlight(commands.Cog):
                 serverChList = ctx.guild.channels
                 removedChannels = []
                 for channelId in channelList:
-                    #Flag that allows the bot to append channel Id if name not found
-                    #The channel ID can then be used for removal if they filtered a channel that was removed
+                    # Flag that allows the bot to append channel Id if name not found
+                    # The channel ID can then be used for removal if they filtered a channel that was removed
                     channelExist = False
                     for serverChannel in serverChList:
                         if channelId == serverChannel.id:
                             msg += "{}\n".format(serverChannel.name)
                             channelExist = True
                     if not channelExist:
-                        #save channelId to be removed outside of loop
+                        # save channelId to be removed outside of loop
                         removedChannels.append(channelId)
-                for channelId in removedChannels: 
+                for channelId in removedChannels:
                     channelList.remove(channelId)
                 embed = discord.Embed(description=msg, colour=discord.Colour.red())
                 embed.set_author(
@@ -578,7 +577,7 @@ class Highlight(commands.Cog):
                     "Sorry {}, you have no channels on the deny list currently".format(userName),
                     delete_after=DELETE_TIME,
                 )
-    
+
     def _triggeredRecently(self, msg, uid, timeout=DEFAULT_TIMEOUT):
         """See if a user has been recently triggered.
 
@@ -684,7 +683,7 @@ class Highlight(commands.Cog):
         for currentUserId, data in guildData.items():
             self.logger.debug("User ID: %s", currentUserId)
             isWordIgnored = False
-            
+
             # Handle case where message was sent in a user denied channel
             if msg.channel.id in data[KEY_CHANNEL_IGNORE]:
                 continue

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -30,6 +30,7 @@ BASE_GUILD_MEMBER = {
     KEY_TIMEOUT: DEFAULT_TIMEOUT,
     KEY_WORDS: [],
     KEY_WORDS_IGNORE: [],
+    KEY_CHANNEL_IGNORE: [],
 }
 
 BASE_GUILD = {
@@ -475,6 +476,42 @@ class Highlight(commands.Cog):
 
         await ctx.send("Timeout set to {} seconds.".format(seconds), delete_after=DELETE_TIME)
         await ctx.message.delete()
+
+
+
+    @highlight.command(name="channelDeny", aliases=["cd"])
+    @commands.guild_only()
+    async def channelDeny(self, ctx: Context):
+        """Stops certain channels from triggering your highlight words"""
+    
+    @channelDeny.command(name="add")
+    @commands.guild_only()
+    async def channelDenyAdd(self, ctx: Context, channel: discord.TextChannel):
+        """Add a channel to be blocked from triggering highlights
+
+        Parameters:
+        -----------
+        channel: discord.TextChannel
+            The channel you wish to block highlight triggers from.    
+        """
+    
+    @channelDeny.command(name="remove", aliases=["rm"])
+    @commands.guild_only()
+    async def channelDenyAdd(self, ctx: Context, channel: discord.TextChannel):
+        """Remove a channel that was on the denylist and allow
+        the channel to trigger highlights again
+        
+        Parameters:
+        -----------
+        channel: discord.TextChannel
+            The channel you wish to recieved highlights from again.
+        """
+    @channelDeny.command(name="list", aliases=["ls"])
+    @commands.guild_only()
+    async def channelDenyList(self, ctx: Context):
+        """Sends a DM with all of the channels you've stopped from triggering
+        your highlights"""
+
 
     def _triggeredRecently(self, msg, uid, timeout=DEFAULT_TIMEOUT):
         """See if a user has been recently triggered.

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -499,16 +499,14 @@ class Highlight(commands.Cog):
         userId = ctx.author.id
         channelId = channel.id
 
-        #Check if user ignore list exists
         async with self.config.member(ctx.author).userIgnoreChannelID() as channelList:
             if channelId in channelList:
-                await ctx.message.delete()
                 await ctx.send("Channel is already being ignored!", delete_after=DELETE_TIME)
-                return
-            channelList.append(channel.id) 
-
-        await ctx.send("Channel added to ignore list", delete_after=DELETE_TIME)
-        await ctx.message.delete()
+                await ctx.message.delete()
+            else:
+                channelList.append(channel.id) 
+                await ctx.send("Channel added to ignore list.", delete_after=DELETE_TIME)
+                await ctx.message.delete()
         
     
     @channelDeny.command(name="remove", aliases=["rm"])
@@ -522,7 +520,19 @@ class Highlight(commands.Cog):
         channel: discord.TextChannel
             The channel you wish to recieved highlights from again.
         """
+        guildId = ctx.guild.id
+        userId = ctx.author.id
+        channelId = channel.id
 
+        async with self.config.member(ctx.author).userIgnoreChannelID() as channelList:
+            if channelId not in channelList:
+                await ctx.message.delete()
+                await ctx.send("This channel wasn't previously blocked!", delete_after=DELETE_TIME)
+            else:
+                channelList.remove(channelId)
+                await ctx.message.delete()
+                await ctx.send("Channel successfully removed from deny list.", delete_after=DELETE_TIME)
+                
     @channelDeny.command(name="list", aliases=["ls"])
     @commands.guild_only()
     async def channelDenyList(self, ctx: Context):

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -509,13 +509,12 @@ class Highlight(commands.Cog):
     @channelDeny.command(name="remove", aliases=["rm"])
     @commands.guild_only()
     async def channelDenyRemove(self, ctx: Context, channel: discord.TextChannel):
-        """Remove a channel that was on the denylist and allow
-        the channel to trigger highlights again
+        """Remove a channel that was on the denylist and allow the channel to trigger highlights again
 
         Parameters:
         -----------
         channel: discord.TextChannel
-            The channel you wish to recieved highlights from again.
+            The channel you wish to recieve highlights from again.
         """
         guildId = ctx.guild.id
         userId = ctx.author.id
@@ -535,8 +534,7 @@ class Highlight(commands.Cog):
     @channelDeny.command(name="list", aliases=["ls"])
     @commands.guild_only()
     async def channelDenyList(self, ctx: Context):
-        """Sends a DM with all of the channels you've stopped from triggering
-        your highlights"""
+        """Sends a DM with all of the channels you've stopped from triggering your highlights"""
         userName = ctx.message.author.name
 
         async with self.config.member(ctx.author).userIgnoreChannelID() as channelList:

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -514,7 +514,7 @@ class Highlight(commands.Cog):
         Parameters:
         -----------
         channel: discord.TextChannel
-            The channel you wish to recieve highlights from again.
+            The channel you wish to receive highlights from again.
         """
         guildId = ctx.guild.id
         userId = ctx.author.id

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -523,14 +523,14 @@ class Highlight(commands.Cog):
 
         async with self.config.member(ctx.author).userIgnoreChannelID() as channelList:
             if channelId not in channelList:
-                await ctx.message.delete()
                 await ctx.send("This channel wasn't previously blocked!", delete_after=DELETE_TIME)
+                await ctx.message.delete()
             else:
                 channelList.remove(channelId)
-                await ctx.message.delete()
                 await ctx.send(
                     "Channel successfully removed from deny list.", delete_after=DELETE_TIME
                 )
+                await ctx.message.delete()
 
     @channelDeny.command(name="list", aliases=["ls"])
     @commands.guild_only()


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes

As per issue #377, adds a feature that allows users to stop certain channels from triggering thier highlights
The denied channels are sent through private DM for privacy and the add/remove channel commands behave simlarily to the word add/remove of the original highlight cog.