### PR TITLE
[Catgirl] Add ability to use waifupics API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,8 @@ ENV/
 
 # Pre-commit hooks
 /.pre-commit-config.yaml
+cogs/Bank/settings.json
+cogs/catgirl/settings.json
+cogs/CogManager/settings.json
+cogs/ModLog/settings.json
+core/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -143,8 +143,3 @@ ENV/
 
 # Pre-commit hooks
 /.pre-commit-config.yaml
-cogs/Bank/settings.json
-cogs/catgirl/settings.json
-cogs/CogManager/settings.json
-cogs/ModLog/settings.json
-core/settings.json

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -108,27 +108,37 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         """Displays a random, cute catgirl :3"""
         # Send typing indicator, useful when Discord explicit filter is on.
         await ctx.channel.trigger_typing()
-        nekoToggle = await self.config.guild(ctx.guild)()
+        nekoToggle = await self.config.guild(ctx.guild).waifuneko()
 
         if nekoToggle == True:
-            choice = randint(0, 1)
+            choice = random.randint(0, 1)
             if(choice == 0):
                 embed = getImage(self.catgirls, "Catgirl")
+                try:
+                    await ctx.send(embed=embed)
+                except discord.errors.Forbidden:
+                    # No permission to send, ignore.
+                    pass
             else:
                 #
                 URL = "https://api.waifu.pics/sfw/neko"
                 r = requests.get(url = URL)
                 data = r.json()
                 embed = data['url']
+                try:
+                    await ctx.send(embed)
+                except discord.errors.Forbidden:
+                    # No permission to send, ignore.
+                    pass
         else:
             embed = getImage(self.catgirls, "Catgirl")
+            try:
+                await ctx.send(embed=embed)
+            except discord.errors.Forbidden:
+                # No permission to send, ignore.
+                pass
 
 
-        try:
-            await ctx.send(embed=embed)
-        except discord.errors.Forbidden:
-            # No permission to send, ignore.
-            pass
 
     async def catboyCmd(self, ctx):
         """This command says it all (database still WIP)"""
@@ -313,9 +323,10 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         # Send typing indicator, useful when Discord explicit filter is on.
         await ctx.channel.trigger_typing()
 
-        await.config.guild(ctx.guild).waifuneko(False if waifuneko else True)
+        waifuneko_val = await self.config.guild(ctx.guild).waifuneko()
+        await self.config.guild(ctx.guild).waifuneko.set(False if waifuneko_val else True)
 
-        await ctx.send("Using waifupics API for catgirls is now {}".format("on" if waifuneko else "off"))
+        await ctx.send("Using waifupics API for catgirls is now {}".format("off" if waifuneko_val else "on")) #waifuneko_val wasn't updated after setting the thing
 
     async def randomize(self):
         """Shuffles images in the list."""

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -108,7 +108,7 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         await ctx.channel.trigger_typing()
         nekoToggle = await self.config.guild(ctx.guild).waifuneko()
 
-        if nekoToggle == True:
+        if nekoToggle:
             choice = random.randint(0, 1)
             if choice == 0:
                 embed = getImage(self.catgirls, "Catgirl")

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -116,7 +116,7 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
                 embed = getImage(self.catgirls, "Catgirl")
             else:
                 #
-                URL = https://api.waifu.pics/sfw/neko
+                URL = "https://api.waifu.pics/sfw/neko"
                 r = requests.get(url = URL)
                 data = r.json()
                 embed = data['url']

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -17,7 +17,7 @@ KEY_SEIGA_ID = "id"
 PREFIX_PIXIV = "http://www.pixiv.net/member_illust.php?mode=medium&illust_id={}"
 PREFIX_SEIGA = "http://seiga.nicovideo.jp/seiga/im{}"
 SAVE_FOLDER = "data/lui-cogs/catgirl/"  # Path to save folder.
-URL = "https://api.waifu.pics/sfw/neko" # For a random sfw neko image from the waifu.pics API
+URL = "https://api.waifu.pics/sfw/neko"  # For a random sfw neko image from the waifu.pics API
 
 EMPTY = {KEY_CATGIRL: [], KEY_CATBOY: []}
 BASE = {
@@ -362,6 +362,7 @@ def getImage(imageList, title):
     embed.set_image(url=image[KEY_IMAGE_URL])
     return embed
 
+
 """
 Take a passed url from Waifu.pics, and construct a discord.Embed object
 
@@ -374,6 +375,8 @@ Returns:
 embed : discord.embed
     a fully constructed discord.Embed object, ready to be sent as a message.
 """
+
+
 def getImageUrl(image):
     embed = discord.Embed()
     embed.colour = discord.Colour.red()

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -2,7 +2,7 @@
 import asyncio
 import random
 import discord
-from redbot.core import Config, commands
+from redbot.core import checks, Config, commands
 from redbot.core.bot import Red
 
 # Global variables

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -107,8 +107,18 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         """Displays a random, cute catgirl :3"""
         # Send typing indicator, useful when Discord explicit filter is on.
         await ctx.channel.trigger_typing()
+        nekoToggle = await self.config.guild(ctx.guild)()
 
-        embed = getImage(self.catgirls, "Catgirl")
+        if nekoToggle == True:
+            #stuff happens
+            choice = randint(0, 1)
+            if(choice == 0):
+                embed = getImage(self.catgirls, "Catgirl")
+            else:
+                embed = https://api.waifu.pics/sfw/neko
+        else:
+            embed = getImage(self.catgirls, "Catgirl")
+
 
         try:
             await ctx.send(embed=embed)

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -31,9 +31,7 @@ BASE = {
     "pending": EMPTY,
 }
 
-DEFAULT_GUILD = {
-    "waifuneko": False
-}
+DEFAULT_GUILD = {"waifuneko": False}
 
 
 class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
@@ -112,14 +110,14 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
 
         if nekoToggle == True:
             choice = random.randint(0, 1)
-            if(choice == 0):
+            if choice == 0:
                 embed = getImage(self.catgirls, "Catgirl")
             else:
                 #
                 URL = "https://api.waifu.pics/sfw/neko"
-                r = requests.get(url = URL)
+                r = requests.get(url=URL)
                 data = r.json()
-                embed = getImageUrl(data['url'])
+                embed = getImageUrl(data["url"])
         else:
             embed = getImage(self.catgirls, "Catgirl")
 
@@ -128,7 +126,6 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         except discord.errors.Forbidden:
             # No permission to send, ignore.
             pass
-
 
     async def catboyCmd(self, ctx):
         """This command says it all (database still WIP)"""
@@ -316,7 +313,9 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         waifuneko_val = await self.config.guild(ctx.guild).waifuneko()
         await self.config.guild(ctx.guild).waifuneko.set(False if waifuneko_val else True)
 
-        await ctx.send("Using waifupics API for catgirls is now {}".format("off" if waifuneko_val else "on")) #waifuneko_val wasn't updated after setting the thing
+        await ctx.send(
+            "Using waifupics API for catgirls is now {}".format("off" if waifuneko_val else "on")
+        )  # waifuneko_val wasn't updated after setting the thing
 
     async def randomize(self):
         """Shuffles images in the list."""
@@ -363,10 +362,11 @@ def getImage(imageList, title):
     embed.set_image(url=image[KEY_IMAGE_URL])
     return embed
 
+
 def getImageUrl(image):
     embed = discord.Embed()
     embed.colour = discord.Colour.red()
     embed.title = "Catgirl"
     embed.url = image
-    embed.set_image(url = image)
+    embed.set_image(url=image)
     return embed

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -362,7 +362,18 @@ def getImage(imageList, title):
     embed.set_image(url=image[KEY_IMAGE_URL])
     return embed
 
+"""
+Take a passed url from Waifu.pics, and construct a discord.Embed object
 
+Parameters:
+-----------
+image : a URL
+
+Returns:
+-----------
+embed : discord.embed
+    a fully constructed discord.Embed object, ready to be sent as a message.
+"""
 def getImageUrl(image):
     embed = discord.Embed()
     embed.colour = discord.Colour.red()

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -2,6 +2,7 @@
 import asyncio
 import random
 import discord
+import requests
 from redbot.core import checks, Config, commands
 from redbot.core.bot import Red
 
@@ -110,12 +111,15 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         nekoToggle = await self.config.guild(ctx.guild)()
 
         if nekoToggle == True:
-            #stuff happens
             choice = randint(0, 1)
             if(choice == 0):
                 embed = getImage(self.catgirls, "Catgirl")
             else:
-                embed = https://api.waifu.pics/sfw/neko
+                #
+                URL = https://api.waifu.pics/sfw/neko
+                r = requests.get(url = URL)
+                data = r.json()
+                embed = data['url']
         else:
             embed = getImage(self.catgirls, "Catgirl")
 

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -291,6 +291,18 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         else:
             await ctx.send("Added, notified and pending approval. :ok_hand:")
 
+    # [p]nyaa toggle
+    @_nyaa.command(name="toggle")
+    @checks.admin_or_permissions(manage_guild=True)
+    async def toggle(self, ctx):
+        """Toggle using waifu.pics API"""
+        # Send typing indicator, useful when Discord explicit filter is on.
+        await ctx.channel.trigger_typing()
+
+        await.config.guild(ctx.guild).waifuneko(False if waifuneko else True)
+
+        await ctx.send("Using waifupics API for catgirls is now {}".format("on" if waifuneko else "off"))
+
     async def randomize(self):
         """Shuffles images in the list."""
         while self:

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -124,9 +124,9 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
                 URL = "https://api.waifu.pics/sfw/neko"
                 r = requests.get(url = URL)
                 data = r.json()
-                embed = data['url']
+                embed = getImageUrl(data['url'])
                 try:
-                    await ctx.send(embed)
+                    await ctx.send(embed=embed)
                 except discord.errors.Forbidden:
                     # No permission to send, ignore.
                     pass
@@ -371,4 +371,12 @@ def getImage(imageList, title):
     if "character" in image:
         embed.add_field(name="Info", value=image["character"], inline=False)
     embed.set_image(url=image[KEY_IMAGE_URL])
+    return embed
+
+def getImageUrl(image):
+    embed = discord.Embed()
+    embed.colour = discord.Colour.red()
+    embed.title = "Catgirl"
+    embed.url = image
+    embed.set_image(url = image)
     return embed

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -363,21 +363,19 @@ def getImage(imageList, title):
     return embed
 
 
-"""
-Take a passed url from Waifu.pics, and construct a discord.Embed object
-
-Parameters:
------------
-image : a URL
-
-Returns:
------------
-embed : discord.embed
-    a fully constructed discord.Embed object, ready to be sent as a message.
-"""
-
-
 def getImageUrl(image):
+    """
+    Take a passed url from Waifu.pics, and construct a discord.Embed object
+
+    Parameters:
+    -----------
+    image : a URL
+
+    Returns:
+    -----------
+    embed : discord.embed
+        a fully constructed discord.Embed object, ready to be sent as a message.
+    """
     embed = discord.Embed()
     embed.colour = discord.Colour.red()
     embed.title = "Catgirl"

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -30,6 +30,10 @@ BASE = {
     "pending": EMPTY,
 }
 
+DEFAULT_GUILD = {
+    "waifuneko": False
+}
+
 
 class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
     """Display cute nyaas~"""
@@ -86,6 +90,7 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
         self.bot = bot
         self.config = Config.get_conf(self, identifier=5842647)
         self.config.register_global(**BASE)
+        self.config.register_guild(**DEFAULT_GUILD)
         self.catgirls = None
         self.catgirlsLocal = None
         self.catgirlsLocalTrap = None

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -17,6 +17,7 @@ KEY_SEIGA_ID = "id"
 PREFIX_PIXIV = "http://www.pixiv.net/member_illust.php?mode=medium&illust_id={}"
 PREFIX_SEIGA = "http://seiga.nicovideo.jp/seiga/im{}"
 SAVE_FOLDER = "data/lui-cogs/catgirl/"  # Path to save folder.
+URL = "https://api.waifu.pics/sfw/neko" # For a random sfw neko image from the waifu.pics API
 
 EMPTY = {KEY_CATGIRL: [], KEY_CATBOY: []}
 BASE = {
@@ -114,7 +115,6 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
                 embed = getImage(self.catgirls, "Catgirl")
             else:
                 #
-                URL = "https://api.waifu.pics/sfw/neko"
                 r = requests.get(url=URL)
                 data = r.json()
                 embed = getImageUrl(data["url"])

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -114,7 +114,6 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
             if choice == 0:
                 embed = getImage(self.catgirls, "Catgirl")
             else:
-                #
                 r = requests.get(url=URL)
                 data = r.json()
                 embed = getImageUrl(data["url"])

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -114,30 +114,20 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
             choice = random.randint(0, 1)
             if(choice == 0):
                 embed = getImage(self.catgirls, "Catgirl")
-                try:
-                    await ctx.send(embed=embed)
-                except discord.errors.Forbidden:
-                    # No permission to send, ignore.
-                    pass
             else:
                 #
                 URL = "https://api.waifu.pics/sfw/neko"
                 r = requests.get(url = URL)
                 data = r.json()
                 embed = getImageUrl(data['url'])
-                try:
-                    await ctx.send(embed=embed)
-                except discord.errors.Forbidden:
-                    # No permission to send, ignore.
-                    pass
         else:
             embed = getImage(self.catgirls, "Catgirl")
-            try:
-                await ctx.send(embed=embed)
-            except discord.errors.Forbidden:
-                # No permission to send, ignore.
-                pass
 
+        try:
+            await ctx.send(embed=embed)
+        except discord.errors.Forbidden:
+            # No permission to send, ignore.
+            pass
 
 
     async def catboyCmd(self, ctx):

--- a/cogs/catgirl/catgirl.py
+++ b/cogs/catgirl/catgirl.py
@@ -304,7 +304,7 @@ class Catgirl(commands.Cog):  # pylint: disable=too-many-instance-attributes
 
     # [p]nyaa toggle
     @_nyaa.command(name="toggle")
-    @checks.admin_or_permissions(manage_guild=True)
+    @checks.mod_or_permissions(manage_guild=True)
     async def toggle(self, ctx):
         """Toggle using waifu.pics API"""
         # Send typing indicator, useful when Discord explicit filter is on.


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature

### Description of the changes
Added support for the catgirls cog to make use of waifu.pics sfw/neko. Admins can toggle the use of this
It makes use of the Python requests library, so this will need to be installed as well