### PR TITLE
[Waifu] Add new cog

### DIFF
--- a/cogs/waifu/__init__.py
+++ b/cogs/waifu/__init__.py
@@ -1,0 +1,8 @@
+"""Wafu cog.  Send waifu.pics to a channel."""
+
+from redbot.core.bot import Red
+from .waifu import Waifu
+
+def setup(bot: Red):
+    """Add the cog to the bot."""
+    bot.add_cog(Waifu(bot))

--- a/cogs/waifu/__init__.py
+++ b/cogs/waifu/__init__.py
@@ -3,6 +3,7 @@
 from redbot.core.bot import Red
 from .waifu import Waifu
 
+
 def setup(bot: Red):
     """Add the cog to the bot."""
     bot.add_cog(Waifu(bot))

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -31,13 +31,14 @@ class Waifu(commands.cog):
         await self.waifuCmd(ctx, "neko")
 
 
-    def getImageUrl(image, title):
+    def getImage(image, title):
         """
         Take a passed url from Waifu.pics, and construct a discord.Embed object
 
         Parameters:
         -----------
         image : a URL
+        title: a string
 
         Returns:
         -----------

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -67,7 +67,7 @@ class Waifu(commands.Cog):
         """Display a random waifu"""
         if not imageType:
             # Display about this module if no command passed
-            waifuAbout(ctx)
+            await self.waifuAbout(ctx)
             return
         elif imageType.lower() not in IMAGE_CATEGORIES:
             imageType = "waifu"
@@ -93,23 +93,23 @@ class Waifu(commands.Cog):
         embed.set_footer(text="cogs/waifu")
         await ctx.send(embed=embed)
 
-    def getImage(image, title):
-        """
-        Take a passed url from Waifu.pics, and construct a discord.Embed object
 
-        Parameters:
-        -----------
-        image : a URL
-        title: a string
+def getImage(image, title):
+    """
+    Take a passed url from Waifu.pics, and construct a discord.Embed object
+    Parameters:
+    -----------
+    image : a URL
+    title: a string
 
-        Returns:
-        -----------
-        embed : discord.embed
-            a fully constructed discord.Embed object, ready to be sent as a message.
-        """
-        embed = discord.Embed()
-        embed.colour = discord.Colour.red()
-        embed.title = title
-        embed.url = image
-        embed.set_image(url=image)
-        return embed
+    Returns:
+    -----------
+    embed : discord.embed
+        a fully constructed discord.Embed object, ready to be sent as a message.
+    """
+    embed = discord.Embed()
+    embed.colour = discord.Colour.red()
+    embed.title = title
+    embed.url = image
+    embed.set_image(url=image)
+    return embed

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -30,8 +30,9 @@ class Waifu(commands.cog):
             #Display about this module if no command passed
             waifuAbout(ctx)
             return
-
-
+        elif imageType.lower() not in IMAGE_CATEGORIES:
+            imageType = "waifu"
+        
         await self.waifuCmd(ctx, imageType)
 
     async def waifuAbout(self, ctx):

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -1,0 +1,12 @@
+"""Wafu cog.  Send waifu.pics to a channel."""
+import asyncio
+import discord
+import requests
+from redbot.core import checks, Config, commands
+from redbot.core.bot import Red
+
+class Waifu(commands.cog):
+    """Display waifu.pic pictures"""
+
+    def __init__(self, bot: Red):
+        self.bot = bot

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -42,6 +42,12 @@ class Waifu(commands.cog):
         """Display a random megumin"""
         await self.waifuCmd(ctx, "megumin")
 
+    # [p]bully
+    @commands.command(name="bully")
+    async def _bully(self, ctx):
+        """Display a random bully"""
+        await self.waifuCmd(ctx, "bully")
+
 
     def getImage(image, title):
         """

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -24,8 +24,8 @@ class Waifu(commands.cog):
         """Display a random waifu"""
         if not imageType:
             imageType = "waifu"
-        
-        await self.waifuCmd(ctx, )
+
+        await self.waifuCmd(ctx, imageType)
 
 
     def getImage(image, title):

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -7,6 +7,10 @@ from redbot.core.bot import Red
 
 #Global variables
 URL = "https://api.waifu.pics/sfw/"
+IMAGE_CATEGORIES = [ "waifu", "neko", "shinobu", "megumin", "bully", "cuddle", "cry",
+"hug", "awoo", "kiss", "lick", "pat", "smug", "bonk", "yeet", "blush", "smile", "wave",
+"highfive", "handhold", "nom", "bite", "glomp", "slap", "kill", "happy", "wink", "poke",
+"dance", "cringe" ]
 
 class Waifu(commands.cog):
     """Display waifu.pic pictures"""
@@ -23,9 +27,31 @@ class Waifu(commands.cog):
     async def _waifu(self, ctx, imageType: str = None):
         """Display a random waifu"""
         if not imageType:
-            imageType = "waifu"
+            #Display about this module if no command passed
+            waifuAbout(ctx)
+            return
+
 
         await self.waifuCmd(ctx, imageType)
+
+    async def waifuAbout(self, ctx):
+        """Displays information about the waifu module"""
+        customAuthor = "@西木野 真姫#4354"
+        embed = discord.Embed()
+        embed.title = "About this module"
+        embed.add_field(name="Name", value="Waifu Module")
+        embed.add_field(name="Author", value=customAuthor)
+        embed.add_field(name="Initial Version Date", value="2021-06-08")
+        embed.add_field(
+            name="Description",
+            value="A module to display images from waifu.pics."
+            "Valid commands are as follows: waifu, neko, shinobu, megumin, bully"
+            "cuddle, cry, hug, awoo, kiss, lick, pat, smug, bonk, yeet, blush, smile"
+            "wave, highfive, handhold, nom, bite, glomp, slap, kill, happy, wink, poke"
+            "dance, cringe",
+        )
+        embed.set_footer(text="cogs/waifu")
+        await ctx.send(embed=embed)
 
 
     def getImage(image, title):

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -14,12 +14,12 @@ class Waifu(commands.cog):
     def __init__(self, bot: Red):
         self.bot = bot
 
-    def waifuCmd(self, ctx):
+    def waifuCmd(self, ctx, imageType):
         """Display a waifu.pic picture"""
         await ctx.channel.trigger_typing()
 
 
-    def getImageUrl(image):
+    def getImageUrl(image, title):
         """
         Take a passed url from Waifu.pics, and construct a discord.Embed object
 
@@ -34,7 +34,7 @@ class Waifu(commands.cog):
         """
         embed = discord.Embed()
         embed.colour = discord.Colour.red()
-        embed.title = "Catgirl"
+        embed.title = title
         embed.url = image
         embed.set_image(url=image)
         return embed

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -20,75 +20,12 @@ class Waifu(commands.cog):
 
     # [p]waifu
     @commands.command(name="waifu")
-    async def _waifu(self, ctx):
+    async def _waifu(self, ctx, imageType: str = None):
         """Display a random waifu"""
-        await self.waifuCmd(ctx, "waifu")
-
-    # [p]neko
-    @commands.command(name="neko")
-    async def _neko(self, ctx):
-        """Display a random neko"""
-        await self.waifuCmd(ctx, "neko")
-
-    # [p]shinobu
-    @commands.command(name="shinobu")
-    async def _shinobu(self, ctx):
-        """Display a random shinobu"""
-        await self.waifuCmd(ctx, "shinobu")
-
-    # [p]megumin
-    @commands.command(name="megumin")
-    async def _megumin(self, ctx):
-        """Display a random megumin"""
-        await self.waifuCmd(ctx, "megumin")
-
-    # [p]bully
-    @commands.command(name="bully")
-    async def _bully(self, ctx):
-        """Display a random bully"""
-        await self.waifuCmd(ctx, "bully")
-
-    # [p]cuddle
-    @commands.command(name="cuddle")
-    async def _cuddle(self, ctx):
-        """Display a random cuddle"""
-        await self.waifuCmd(ctx, "cuddle")
-
-    # [p]cry
-    @commands.command(name="cry")
-    async def _cry(self, ctx):
-        """Display a random cry"""
-        await self.waifuCmd(ctx, "cry")
-
-    # [p]hug
-    @commands.command(name="hug")
-    async def _hug(self, ctx):
-        """Display a random hug"""
-        await self.waifuCmd(ctx, "hug")
-
-    # [p]awoo
-    @commands.command(name="awoo")
-    async def _awoo(self, ctx):
-        """Display a random awoo"""
-        await self.waifuCmd(ctx, "awoo")
-
-    # [p]kiss
-    @commands.command(name="kiss")
-    async def _kiss(self, ctx):
-        """Display a random kiss"""
-        await self.waifuCmd(ctx, "kiss")
-
-    # [p]lick
-    @commands.command(name="lick")
-    async def _lick(self, ctx):
-        """Display a random lick"""
-        await self.waifuCmd(ctx, "lick")
-
-    # [p]pat
-    @commands.command(name="pat")
-    async def _pat(self, ctx):
-        """Display a random pat"""
-        await self.waifuCmd(ctx, "pat")
+        if not imageType:
+            imageType = "waifu"
+        
+        await self.waifuCmd(ctx, )
 
 
     def getImage(image, title):

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -24,11 +24,17 @@ class Waifu(commands.cog):
         """Display a random waifu"""
         await self.waifuCmd(ctx, "waifu")
 
-    # [p]waifu
+    # [p]neko
     @commands.command(name="neko")
     async def _neko(self, ctx):
         """Display a random neko"""
         await self.waifuCmd(ctx, "neko")
+
+    # [p]shinobu
+    @commands.command(name="shinobu")
+    async def _shinobu(self, ctx):
+        """Display a random shinobu"""
+        await self.waifuCmd(ctx, "shinobu")
 
 
     def getImage(image, title):

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -4,7 +4,6 @@ import discord
 import requests
 from redbot.core import checks, Config, commands
 from redbot.core.bot import Red
-from .catgirl import Catgirl #For access to the getImageURL function
 
 #Global variables
 URL = "https://api.waifu.pics/sfw/"
@@ -16,4 +15,26 @@ class Waifu(commands.cog):
         self.bot = bot
 
     def waifuCmd(self, ctx):
+        """Display a waifu.pic picture"""
         await ctx.channel.trigger_typing()
+
+
+    def getImageUrl(image):
+        """
+        Take a passed url from Waifu.pics, and construct a discord.Embed object
+
+        Parameters:
+        -----------
+        image : a URL
+
+        Returns:
+        -----------
+        embed : discord.embed
+            a fully constructed discord.Embed object, ready to be sent as a message.
+        """
+        embed = discord.Embed()
+        embed.colour = discord.Colour.red()
+        embed.title = "Catgirl"
+        embed.url = image
+        embed.set_image(url=image)
+        return embed

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -54,6 +54,24 @@ class Waifu(commands.cog):
         """Display a random cuddle"""
         await self.waifuCmd(ctx, "cuddle")
 
+    # [p]cry
+    @commands.command(name="cry")
+    async def _cry(self, ctx):
+        """Display a random cry"""
+        await self.waifuCmd(ctx, "cry")
+
+    # [p]hug
+    @commands.command(name="hug")
+    async def _hug(self, ctx):
+        """Display a random hug"""
+        await self.waifuCmd(ctx, "hug")
+
+    # [p]awoo
+    @commands.command(name="awoo")
+    async def _awoo(self, ctx):
+        """Display a random awoo"""
+        await self.waifuCmd(ctx, "awoo")
+
 
     def getImage(image, title):
         """

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -36,6 +36,12 @@ class Waifu(commands.cog):
         """Display a random shinobu"""
         await self.waifuCmd(ctx, "shinobu")
 
+    # [p]megumin
+    @commands.command(name="megumin")
+    async def _megumin(self, ctx):
+        """Display a random megumin"""
+        await self.waifuCmd(ctx, "megumin")
+
 
     def getImage(image, title):
         """

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -4,9 +4,16 @@ import discord
 import requests
 from redbot.core import checks, Config, commands
 from redbot.core.bot import Red
+from .catgirl import Catgirl #For access to the getImageURL function
+
+#Global variables
+URL = "https://api.waifu.pics/sfw/"
 
 class Waifu(commands.cog):
     """Display waifu.pic pictures"""
 
     def __init__(self, bot: Red):
         self.bot = bot
+
+    def waifuCmd(self, ctx):
+        await ctx.channel.trigger_typing()

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -21,6 +21,16 @@ class Waifu(commands.cog):
     def waifuCmd(self, ctx, imageType):
         """Display a waifu.pic picture"""
         await ctx.channel.trigger_typing()
+        requestURL = URL + imageType
+        r = requests.get(url=requestURL)
+        data = r.json()
+        embed = getImage(data["url"], imageType)
+
+        try:
+            await ctx.send(embed=embed)
+        except discord.errors.Forbidden:
+            # No permission to send, ignore.
+            pass
 
     # [p]waifu
     @commands.command(name="waifu")
@@ -32,7 +42,7 @@ class Waifu(commands.cog):
             return
         elif imageType.lower() not in IMAGE_CATEGORIES:
             imageType = "waifu"
-        
+
         await self.waifuCmd(ctx, imageType)
 
     async def waifuAbout(self, ctx):

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -5,12 +5,41 @@ import requests
 from redbot.core import checks, Config, commands
 from redbot.core.bot import Red
 
-#Global variables
+# Global variables
 URL = "https://api.waifu.pics/sfw/"
-IMAGE_CATEGORIES = [ "waifu", "neko", "shinobu", "megumin", "bully", "cuddle", "cry",
-"hug", "awoo", "kiss", "lick", "pat", "smug", "bonk", "yeet", "blush", "smile", "wave",
-"highfive", "handhold", "nom", "bite", "glomp", "slap", "kill", "happy", "wink", "poke",
-"dance", "cringe" ]
+IMAGE_CATEGORIES = [
+    "waifu",
+    "neko",
+    "shinobu",
+    "megumin",
+    "bully",
+    "cuddle",
+    "cry",
+    "hug",
+    "awoo",
+    "kiss",
+    "lick",
+    "pat",
+    "smug",
+    "bonk",
+    "yeet",
+    "blush",
+    "smile",
+    "wave",
+    "highfive",
+    "handhold",
+    "nom",
+    "bite",
+    "glomp",
+    "slap",
+    "kill",
+    "happy",
+    "wink",
+    "poke",
+    "dance",
+    "cringe",
+]
+
 
 class Waifu(commands.Cog):
     """Display waifu.pic pictures"""
@@ -37,7 +66,7 @@ class Waifu(commands.Cog):
     async def _waifu(self, ctx, imageType: str = None):
         """Display a random waifu"""
         if not imageType:
-            #Display about this module if no command passed
+            # Display about this module if no command passed
             waifuAbout(ctx)
             return
         elif imageType.lower() not in IMAGE_CATEGORIES:
@@ -63,7 +92,6 @@ class Waifu(commands.Cog):
         )
         embed.set_footer(text="cogs/waifu")
         await ctx.send(embed=embed)
-
 
     def getImage(image, title):
         """

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -12,13 +12,13 @@ IMAGE_CATEGORIES = [ "waifu", "neko", "shinobu", "megumin", "bully", "cuddle", "
 "highfive", "handhold", "nom", "bite", "glomp", "slap", "kill", "happy", "wink", "poke",
 "dance", "cringe" ]
 
-class Waifu(commands.cog):
+class Waifu(commands.Cog):
     """Display waifu.pic pictures"""
 
     def __init__(self, bot: Red):
         self.bot = bot
 
-    def waifuCmd(self, ctx, imageType):
+    async def waifuCmd(self, ctx, imageType):
         """Display a waifu.pic picture"""
         await ctx.channel.trigger_typing()
         requestURL = URL + imageType

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -72,6 +72,24 @@ class Waifu(commands.cog):
         """Display a random awoo"""
         await self.waifuCmd(ctx, "awoo")
 
+    # [p]kiss
+    @commands.command(name="kiss")
+    async def _kiss(self, ctx):
+        """Display a random kiss"""
+        await self.waifuCmd(ctx, "kiss")
+
+    # [p]lick
+    @commands.command(name="lick")
+    async def _lick(self, ctx):
+        """Display a random lick"""
+        await self.waifuCmd(ctx, "lick")
+
+    # [p]pat
+    @commands.command(name="pat")
+    async def _pat(self, ctx):
+        """Display a random pat"""
+        await self.waifuCmd(ctx, "pat")
+
 
     def getImage(image, title):
         """

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -18,6 +18,12 @@ class Waifu(commands.cog):
         """Display a waifu.pic picture"""
         await ctx.channel.trigger_typing()
 
+    # [p]waifu
+    @commands.command(name="waifu")
+    async def _waifu(self, ctx):
+        """Display a random waifu"""
+        await self.waifuCmd(ctx, "waifu")
+
 
     def getImageUrl(image, title):
         """

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -48,6 +48,12 @@ class Waifu(commands.cog):
         """Display a random bully"""
         await self.waifuCmd(ctx, "bully")
 
+    # [p]cuddle
+    @commands.command(name="cuddle")
+    async def _cuddle(self, ctx):
+        """Display a random cuddle"""
+        await self.waifuCmd(ctx, "cuddle")
+
 
     def getImage(image, title):
         """

--- a/cogs/waifu/waifu.py
+++ b/cogs/waifu/waifu.py
@@ -24,6 +24,12 @@ class Waifu(commands.cog):
         """Display a random waifu"""
         await self.waifuCmd(ctx, "waifu")
 
+    # [p]waifu
+    @commands.command(name="neko")
+    async def _neko(self, ctx):
+        """Display a random neko"""
+        await self.waifuCmd(ctx, "neko")
+
 
     def getImageUrl(image, title):
         """


### PR DESCRIPTION
### Type

- [ ] Bugfix
- [ ] Enhancement
- [x] New feature

### Description of the changes
Added a new cog, waifu (renwaifu), that makes a call to the waifu.pics API. Can accept all image categories available in the API in the sfw category. Not passing any argument has ren post info about the cog