### PR TITLE
Address issue #337 by bumping paginator.py to its latest version

### DIFF
--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -279,10 +279,10 @@ class Birthday(commands.Cog):
             text = "{0:%B} {0:%d}: {1}".format(userBirthday, userObject.name)
             display.append(text)
 
-        page = paginator.Pages(ctx=ctx, entries=display, show_entry_count=True)
+        page = paginator.SimplePages(entries=display)
         page.embed.title = "Birthdays in **{}**".format(ctx.message.guild.name)
         page.embed.colour = discord.Colour.red()
-        await page.paginate()
+        await page.start(ctx)
 
     @_birthday.command(name="unassign")
     @commands.guild_only()

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -131,10 +131,10 @@ class Highlight(commands.Cog):
         dlChannels = await self.config.guild(ctx.guild).denylistChannels()
 
         if dlChannels:
-            page = paginator.Pages(ctx=ctx, entries=dlChannels, show_entry_count=True)
+            page = paginator.SimplePages(entries=dlChannels)
             page.embed.title = "Denylist channels for: **{}**".format(ctx.guild.name)
             page.embed.colour = discord.Colour.red()
-            await page.paginate()
+            await page.start(ctx)
         else:
             await ctx.send(f"There are no channels on the denylist for **{ctx.guild.name}**!")
 

--- a/cogs/smartreact/smartreact.py
+++ b/cogs/smartreact/smartreact.py
@@ -105,10 +105,10 @@ class SmartReact(commands.Cog):
         if not display:
             await ctx.send("There are no smart reacts configured in this server.")
         else:
-            page = paginator.Pages(ctx=ctx, entries=display, show_entry_count=True)
+            page = paginator.SimplePages(entries=display)
             page.embed.title = "Smart React emojis for: **{}**".format(ctx.guild.name)
             page.embed.colour = discord.Colour.red()
-            await page.paginate()
+            await page.start(ctx)
 
     def fix_custom_emoji(self, emoji: str):
         self.logger.debug("Emoji: %s", emoji)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -26,7 +26,7 @@ import logging
 from redbot.core import Config as ConfigV3, checks, commands, data_manager
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
-from redbot.core.utils.paginator import Pages
+from redbot.core.utils.paginator import SimplePages
 
 
 class TagInfo:
@@ -1134,13 +1134,13 @@ class Tags(commands.Cog):
                     msg += "```"
                     await ctx.author.send(msg)
                 else:
-                    p = Pages(ctx=ctx, entries=tags, show_entry_count=True)
+                    p = SimplePages(entries=tags)
                     p.embed.colour = 0x738BD7  # blurple
                     p.embed.set_author(
                         name=owner.display_name,
                         icon_url=owner.avatar_url or owner.default_avatar_url,
                     )
-                    await p.paginate()
+                    await p.start(ctx)
             except Exception as e:
                 await ctx.send(e)
         else:
@@ -1168,9 +1168,9 @@ class Tags(commands.Cog):
                     msg += "```"
                     await ctx.author.send(msg)
                 else:
-                    p = Pages(ctx=ctx, entries=tags, per_page=15, show_entry_count=True)
+                    p = SimplePages(entries=tags, per_page=15)
                     p.embed.colour = 0x738BD7  # blurple
-                    await p.paginate()
+                    await p.start(ctx)
             except Exception as e:
                 await ctx.send(e)
         else:
@@ -1264,9 +1264,9 @@ class Tags(commands.Cog):
 
         if results:
             try:
-                p = Pages(ctx=ctx, entries=results, per_page=15, show_entry_count=True)
+                p = SimplePages(entries=results, per_page=15)
                 p.embed.colour = 0x738BD7  # blurple
-                await p.paginate()
+                await p.start(ctx)
             except Exception as e:
                 await ctx.send(e)
         else:

--- a/cogs/tempchannels/__init__.py
+++ b/cogs/tempchannels/__init__.py
@@ -1,8 +1,6 @@
 """tempchannels module.
 
 DM users based on a set of words that they are listening for.
-
-This cog requires paginator.py, obtainable from Rapptz/RoboDanny.
 """
 
 from redbot.core.bot import Red

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -11,8 +11,8 @@ import asyncio
 import random
 import discord
 from redbot.core import Config, checks, commands, data_manager
-from redbot.core.utils import paginator
 from redbot.core.bot import Red
+from redbot.core.utils import paginator
 
 COLOUR = discord.Colour
 COLOURS = [COLOUR.purple(), COLOUR.red(), COLOUR.blue(), COLOUR.orange(), COLOUR.green()]
@@ -134,10 +134,10 @@ class WordFilter(commands.Cog):  # pylint: disable=too-many-instance-attributes
             for regex in filters:
                 display.append("`{}`".format(regex))
 
-            page = paginator.Pages(ctx=ctx, entries=display, show_entry_count=True)
+            page = paginator.SimplePages(entries=display)
             page.embed.title = "Filtered words for: **{}**".format(guildName)
             page.embed.colour = discord.Colour.red()
-            await page.paginate()
+            await page.start(ctx)
         else:
             await user.send("Sorry you have no filtered words in **{}**".format(guildName))
 
@@ -247,10 +247,10 @@ class WordFilter(commands.Cog):  # pylint: disable=too-many-instance-attributes
             for cmd in cmdDenied:
                 display.append("`{}`".format(cmd))
 
-            page = paginator.Pages(ctx=ctx, entries=display, show_entry_count=True)
+            page = paginator.SimplePages(entries=display)
             page.embed.title = f"Denylist commands for: **{guildName}**"
             page.embed.colour = discord.Colour.red()
-            await page.paginate()
+            await page.start(ctx)
         else:
             await ctx.send(f"Sorry, there are no commands on the denylist for **{guildName}**")
 
@@ -344,10 +344,10 @@ class WordFilter(commands.Cog):  # pylint: disable=too-many-instance-attributes
                     continue
                 display.append("`{}`".format(channelTemp.name))
 
-            page = paginator.Pages(ctx=ctx, entries=display, show_entry_count=True)
+            page = paginator.SimplePages(entries=display)
             page.embed.title = f"Allowlist channels for: **{guildName}**"
             page.embed.colour = discord.Colour.red()
-            await page.paginate()
+            await page.start(ctx)
         else:
             await ctx.send(f"Sorry, there are no channels in the allowlist for **{guildName}**")
 

--- a/redbot/core/utils/paginator.py
+++ b/redbot/core/utils/paginator.py
@@ -6,6 +6,7 @@ import discord
 from discord.ext.commands import Paginator as CommandPaginator
 from discord.ext import menus
 
+
 class RoboPages(menus.MenuPages):
     def __init__(self, source):
         super().__init__(source=source, check_embeds=True)
@@ -20,16 +21,20 @@ class RoboPages(menus.MenuPages):
         except discord.HTTPException:
             pass
 
-    @menus.button('\N{INFORMATION SOURCE}\ufe0f', position=menus.Last(3))
+    @menus.button("\N{INFORMATION SOURCE}\ufe0f", position=menus.Last(3))
     async def show_help(self, payload):
         """shows this message"""
-        embed = discord.Embed(title='Paginator help', description='Hello! Welcome to the help page.')
+        embed = discord.Embed(
+            title="Paginator help", description="Hello! Welcome to the help page."
+        )
         messages = []
         for (emoji, button) in self.buttons.items():
-            messages.append(f'{emoji}: {button.action.__doc__}')
+            messages.append(f"{emoji}: {button.action.__doc__}")
 
-        embed.add_field(name='What are these reactions for?', value='\n'.join(messages), inline=False)
-        embed.set_footer(text=f'We were on page {self.current_page + 1} before this message.')
+        embed.add_field(
+            name="What are these reactions for?", value="\n".join(messages), inline=False
+        )
+        embed.set_footer(text=f"We were on page {self.current_page + 1} before this message.")
         await self.message.edit(content=None, embed=embed)
 
         async def go_back_to_current_page():
@@ -38,7 +43,7 @@ class RoboPages(menus.MenuPages):
 
         self.bot.loop.create_task(go_back_to_current_page())
 
-    @menus.button('\N{INPUT SYMBOL FOR NUMBERS}', position=menus.Last(1.5), lock=False)
+    @menus.button("\N{INPUT SYMBOL FOR NUMBERS}", position=menus.Last(1.5), lock=False)
     async def numbered_page(self, payload):
         """lets you type a page number to go to"""
         if self.input_lock.locked():
@@ -48,17 +53,15 @@ class RoboPages(menus.MenuPages):
             channel = self.message.channel
             author_id = payload.user_id
             to_delete = []
-            to_delete.append(await channel.send('What page do you want to go to?'))
+            to_delete.append(await channel.send("What page do you want to go to?"))
 
             def message_check(m):
-                return m.author.id == author_id and \
-                       channel == m.channel and \
-                       m.content.isdigit()
+                return m.author.id == author_id and channel == m.channel and m.content.isdigit()
 
             try:
-                msg = await self.bot.wait_for('message', check=message_check, timeout=30.0)
+                msg = await self.bot.wait_for("message", check=message_check, timeout=30.0)
             except asyncio.TimeoutError:
-                to_delete.append(await channel.send('Took too long.'))
+                to_delete.append(await channel.send("Took too long."))
                 await asyncio.sleep(5)
             else:
                 page = int(msg.content)
@@ -70,8 +73,10 @@ class RoboPages(menus.MenuPages):
             except Exception:
                 pass
 
+
 class FieldPageSource(menus.ListPageSource):
     """A page source that requires (field_name, field_value) tuple items."""
+
     def __init__(self, entries, *, per_page=12):
         super().__init__(entries, per_page=per_page)
         self.embed = discord.Embed(colour=discord.Colour.blurple())
@@ -85,15 +90,16 @@ class FieldPageSource(menus.ListPageSource):
 
         maximum = self.get_max_pages()
         if maximum > 1:
-            text = f'Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)'
+            text = f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
             self.embed.set_footer(text=text)
 
         return self.embed
 
+
 class TextPageSource(menus.ListPageSource):
-    def __init__(self, text, *, prefix='```', suffix='```', max_size=2000):
+    def __init__(self, text, *, prefix="```", suffix="```", max_size=2000):
         pages = CommandPaginator(prefix=prefix, suffix=suffix, max_size=max_size - 200)
-        for line in text.split('\n'):
+        for line in text.split("\n"):
             pages.add_line(line)
 
         super().__init__(entries=pages.pages, per_page=1)
@@ -101,8 +107,9 @@ class TextPageSource(menus.ListPageSource):
     async def format_page(self, menu, content):
         maximum = self.get_max_pages()
         if maximum > 1:
-            return f'{content}\nPage {menu.current_page + 1}/{maximum}'
+            return f"{content}\nPage {menu.current_page + 1}/{maximum}"
         return content
+
 
 class SimplePageSource(menus.ListPageSource):
     def __init__(self, entries, *, per_page=12):
@@ -112,20 +119,21 @@ class SimplePageSource(menus.ListPageSource):
     async def format_page(self, menu, entries):
         pages = []
         for index, entry in enumerate(entries, start=menu.current_page * self.per_page):
-            pages.append(f'{index + 1}. {entry}')
+            pages.append(f"{index + 1}. {entry}")
 
         maximum = self.get_max_pages()
         if maximum > 1:
-            footer = f'Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)'
+            footer = f"Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)"
             menu.embed.set_footer(text=footer)
 
         if self.initial_page and self.is_paginating():
-            pages.append('')
-            pages.append('Confused? React with \N{INFORMATION SOURCE} for more info.')
+            pages.append("")
+            pages.append("Confused? React with \N{INFORMATION SOURCE} for more info.")
             self.initial_page = False
 
-        menu.embed.description = '\n'.join(pages)
+        menu.embed.description = "\n".join(pages)
         return menu.embed
+
 
 class SimplePages(RoboPages):
     """A simple pagination session reminiscent of the old Pages interface.

--- a/redbot/core/utils/paginator.py
+++ b/redbot/core/utils/paginator.py
@@ -1,506 +1,138 @@
-# Fetched from github.com/Rapptz/RoboDanny on 2019-02-07.
-# At commit 6fd39e7.
+# Fetched from github.com/Rapptz/RoboDanny on 2021-06-15.
+# At commit e1d5da9.
 
 import asyncio
 import discord
+from discord.ext.commands import Paginator as CommandPaginator
+from discord.ext import menus
 
+class RoboPages(menus.MenuPages):
+    def __init__(self, source):
+        super().__init__(source=source, check_embeds=True)
+        self.input_lock = asyncio.Lock()
 
-class CannotPaginate(Exception):
-    pass
-
-
-class Pages:
-    """Implements a paginator that queries the user for the
-    pagination interface.
-
-    Pages are 1-index based, not 0-index based.
-
-    If the user does not reply within 2 minutes then the pagination
-    interface exits automatically.
-
-    Parameters
-    ------------
-    ctx: Context
-        The context of the command.
-    entries: List[str]
-        A list of entries to paginate.
-    per_page: int
-        How many entries show up per page.
-    show_entry_count: bool
-        Whether to show an entry count in the footer.
-
-    Attributes
-    -----------
-    embed: discord.Embed
-        The embed object that is being used to send pagination info.
-        Feel free to modify this externally. Only the description,
-        footer fields, and colour are internally modified.
-    permissions: discord.Permissions
-        Our permissions for the channel.
-    """
-
-    def __init__(self, ctx, *, entries, per_page=12, show_entry_count=True):
-        self.bot = ctx.bot
-        self.entries = entries
-        self.message = ctx.message
-        self.channel = ctx.channel
-        self.author = ctx.author
-        self.per_page = per_page
-        pages, left_over = divmod(len(self.entries), self.per_page)
-        if left_over:
-            pages += 1
-        self.maximum_pages = pages
-        self.embed = discord.Embed(colour=discord.Colour.blurple())
-        self.paginating = len(entries) > per_page
-        self.show_entry_count = show_entry_count
-        self.reaction_emojis = [
-            ("\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}", self.first_page),
-            ("\N{BLACK LEFT-POINTING TRIANGLE}", self.previous_page),
-            ("\N{BLACK RIGHT-POINTING TRIANGLE}", self.next_page),
-            ("\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}", self.last_page),
-            ("\N{INPUT SYMBOL FOR NUMBERS}", self.numbered_page),
-            ("\N{BLACK SQUARE FOR STOP}", self.stop_pages),
-            ("\N{INFORMATION SOURCE}", self.show_help),
-        ]
-
-        if ctx.guild is not None:
-            self.permissions = self.channel.permissions_for(ctx.guild.me)
-        else:
-            self.permissions = self.channel.permissions_for(ctx.bot.user)
-
-        if not self.permissions.embed_links:
-            raise CannotPaginate("Bot does not have embed links permission.")
-
-        if not self.permissions.send_messages:
-            raise CannotPaginate("Bot cannot send messages.")
-
-        if self.paginating:
-            # verify we can actually use the pagination session
-            if not self.permissions.add_reactions:
-                raise CannotPaginate("Bot does not have add reactions permission.")
-
-            if not self.permissions.read_message_history:
-                raise CannotPaginate("Bot does not have Read Message History permission.")
-
-    def get_page(self, page):
-        base = (page - 1) * self.per_page
-        return self.entries[base : base + self.per_page]
-
-    def prepare_embed(self, entries, page, *, first=False):
-        p = []
-        for index, entry in enumerate(entries, 1 + ((page - 1) * self.per_page)):
-            p.append(f"{index}. {entry}")
-
-        if self.maximum_pages > 1:
-            if self.show_entry_count:
-                text = f"Page {page}/{self.maximum_pages} ({len(self.entries)} entries)"
-            else:
-                text = f"Page {page}/{self.maximum_pages}"
-
-            self.embed.set_footer(text=text)
-
-        if self.paginating and first:
-            p.append("")
-            p.append("Confused? React with \N{INFORMATION SOURCE} for more info.")
-
-        self.embed.description = "\n".join(p)
-
-    async def show_page(self, page, *, first=False):
-        self.current_page = page
-        entries = self.get_page(page)
-        self.prepare_embed(entries, page, first=first)
-
-        if not self.paginating:
-            return await self.channel.send(embed=self.embed)
-
-        if not first:
-            await self.message.edit(embed=self.embed)
-            return
-
-        self.message = await self.channel.send(embed=self.embed)
-        for (reaction, _) in self.reaction_emojis:
-            if self.maximum_pages == 2 and reaction in ("\u23ed", "\u23ee"):
-                # no |<< or >>| buttons if we only have two pages
-                # we can't forbid it if someone ends up using it but remove
-                # it from the default set
-                continue
-
-            await self.message.add_reaction(reaction)
-
-    async def checked_show_page(self, page):
-        if page != 0 and page <= self.maximum_pages:
-            await self.show_page(page)
-
-    async def first_page(self):
-        """goes to the first page"""
-        await self.show_page(1)
-
-    async def last_page(self):
-        """goes to the last page"""
-        await self.show_page(self.maximum_pages)
-
-    async def next_page(self):
-        """goes to the next page"""
-        await self.checked_show_page(self.current_page + 1)
-
-    async def previous_page(self):
-        """goes to the previous page"""
-        await self.checked_show_page(self.current_page - 1)
-
-    async def show_current_page(self):
-        if self.paginating:
-            await self.show_page(self.current_page)
-
-    async def numbered_page(self):
-        """lets you type a page number to go to"""
-        to_delete = []
-        to_delete.append(await self.channel.send("What page do you want to go to?"))
-
-        def message_check(m):
-            return m.author == self.author and self.channel == m.channel and m.content.isdigit()
-
+    async def finalize(self, timed_out):
         try:
-            msg = await self.bot.wait_for("message", check=message_check, timeout=30.0)
-        except asyncio.TimeoutError:
-            to_delete.append(await self.channel.send("Took too long."))
-            await asyncio.sleep(5)
-        else:
-            page = int(msg.content)
-            to_delete.append(msg)
-            if page != 0 and page <= self.maximum_pages:
-                await self.show_page(page)
+            if timed_out:
+                await self.message.clear_reactions()
             else:
-                to_delete.append(
-                    await self.channel.send(f"Invalid page given. ({page}/{self.maximum_pages})")
-                )
-                await asyncio.sleep(5)
-
-        try:
-            await self.channel.delete_messages(to_delete)
-        except Exception:
+                await self.message.delete()
+        except discord.HTTPException:
             pass
 
-    async def show_help(self):
+    @menus.button('\N{INFORMATION SOURCE}\ufe0f', position=menus.Last(3))
+    async def show_help(self, payload):
         """shows this message"""
-        messages = ["Welcome to the interactive paginator!\n"]
-        messages.append(
-            "This interactively allows you to see pages of text by navigating with "
-            "reactions. They are as follows:\n"
-        )
+        embed = discord.Embed(title='Paginator help', description='Hello! Welcome to the help page.')
+        messages = []
+        for (emoji, button) in self.buttons.items():
+            messages.append(f'{emoji}: {button.action.__doc__}')
 
-        for (emoji, func) in self.reaction_emojis:
-            messages.append(f"{emoji} {func.__doc__}")
-
-        self.embed.description = "\n".join(messages)
-        self.embed.clear_fields()
-        self.embed.set_footer(text=f"We were on page {self.current_page} before this message.")
-        await self.message.edit(embed=self.embed)
+        embed.add_field(name='What are these reactions for?', value='\n'.join(messages), inline=False)
+        embed.set_footer(text=f'We were on page {self.current_page + 1} before this message.')
+        await self.message.edit(content=None, embed=embed)
 
         async def go_back_to_current_page():
-            await asyncio.sleep(60.0)
-            await self.show_current_page()
+            await asyncio.sleep(30.0)
+            await self.show_page(self.current_page)
 
         self.bot.loop.create_task(go_back_to_current_page())
 
-    async def stop_pages(self):
-        """stops the interactive pagination session"""
-        await self.message.delete()
-        self.paginating = False
+    @menus.button('\N{INPUT SYMBOL FOR NUMBERS}', position=menus.Last(1.5), lock=False)
+    async def numbered_page(self, payload):
+        """lets you type a page number to go to"""
+        if self.input_lock.locked():
+            return
 
-    def react_check(self, reaction, user):
-        if user is None or user.id != self.author.id:
-            return False
+        async with self.input_lock:
+            channel = self.message.channel
+            author_id = payload.user_id
+            to_delete = []
+            to_delete.append(await channel.send('What page do you want to go to?'))
 
-        if reaction.message.id != self.message.id:
-            return False
+            def message_check(m):
+                return m.author.id == author_id and \
+                       channel == m.channel and \
+                       m.content.isdigit()
 
-        for (emoji, func) in self.reaction_emojis:
-            if reaction.emoji == emoji:
-                self.match = func
-                return True
-        return False
-
-    async def paginate(self):
-        """Actually paginate the entries and run the interactive loop if necessary."""
-        first_page = self.show_page(1, first=True)
-        if not self.paginating:
-            await first_page
-        else:
-            # allow us to react to reactions right away if we're paginating
-            self.bot.loop.create_task(first_page)
-
-        while self.paginating:
             try:
-                reaction, user = await self.bot.wait_for(
-                    "reaction_add", check=self.react_check, timeout=120.0
-                )
+                msg = await self.bot.wait_for('message', check=message_check, timeout=30.0)
             except asyncio.TimeoutError:
-                self.paginating = False
-                try:
-                    await self.message.clear_reactions()
-                except:
-                    pass
-                finally:
-                    break
+                to_delete.append(await channel.send('Took too long.'))
+                await asyncio.sleep(5)
+            else:
+                page = int(msg.content)
+                to_delete.append(msg)
+                await self.show_checked_page(page - 1)
 
             try:
-                await self.message.remove_reaction(reaction, user)
-            except:
-                pass  # can't remove it so don't bother doing so
+                await channel.delete_messages(to_delete)
+            except Exception:
+                pass
 
-            await self.match()
+class FieldPageSource(menus.ListPageSource):
+    """A page source that requires (field_name, field_value) tuple items."""
+    def __init__(self, entries, *, per_page=12):
+        super().__init__(entries, per_page=per_page)
+        self.embed = discord.Embed(colour=discord.Colour.blurple())
 
-
-class FieldPages(Pages):
-    """Similar to Pages except entries should be a list of
-    tuples having (key, value) to show as embed fields instead.
-    """
-
-    def prepare_embed(self, entries, page, *, first=False):
+    async def format_page(self, menu, entries):
         self.embed.clear_fields()
         self.embed.description = discord.Embed.Empty
 
         for key, value in entries:
             self.embed.add_field(name=key, value=value, inline=False)
 
-        if self.maximum_pages > 1:
-            if self.show_entry_count:
-                text = f"Page {page}/{self.maximum_pages} ({len(self.entries)} entries)"
-            else:
-                text = f"Page {page}/{self.maximum_pages}"
-
+        maximum = self.get_max_pages()
+        if maximum > 1:
+            text = f'Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)'
             self.embed.set_footer(text=text)
 
+        return self.embed
 
-import itertools
-import inspect
-import re
+class TextPageSource(menus.ListPageSource):
+    def __init__(self, text, *, prefix='```', suffix='```', max_size=2000):
+        pages = CommandPaginator(prefix=prefix, suffix=suffix, max_size=max_size - 200)
+        for line in text.split('\n'):
+            pages.add_line(line)
 
-# ?help
-# ?help Cog
-# ?help command
-#   -> could be a subcommand
+        super().__init__(entries=pages.pages, per_page=1)
 
-_mention = re.compile(r"<@\!?([0-9]{1,19})>")
+    async def format_page(self, menu, content):
+        maximum = self.get_max_pages()
+        if maximum > 1:
+            return f'{content}\nPage {menu.current_page + 1}/{maximum}'
+        return content
 
+class SimplePageSource(menus.ListPageSource):
+    def __init__(self, entries, *, per_page=12):
+        super().__init__(entries, per_page=per_page)
+        self.initial_page = True
 
-def cleanup_prefix(bot, prefix):
-    m = _mention.match(prefix)
-    if m:
-        user = bot.get_user(int(m.group(1)))
-        if user:
-            return f"@{user.name} "
-    return prefix
+    async def format_page(self, menu, entries):
+        pages = []
+        for index, entry in enumerate(entries, start=menu.current_page * self.per_page):
+            pages.append(f'{index + 1}. {entry}')
 
+        maximum = self.get_max_pages()
+        if maximum > 1:
+            footer = f'Page {menu.current_page + 1}/{maximum} ({len(self.entries)} entries)'
+            menu.embed.set_footer(text=footer)
 
-async def _can_run(cmd, ctx):
-    try:
-        return await cmd.can_run(ctx)
-    except:
-        return False
+        if self.initial_page and self.is_paginating():
+            pages.append('')
+            pages.append('Confused? React with \N{INFORMATION SOURCE} for more info.')
+            self.initial_page = False
 
+        menu.embed.description = '\n'.join(pages)
+        return menu.embed
 
-def _command_signature(cmd):
-    # this is modified from discord.py source
-    # which I wrote myself lmao
+class SimplePages(RoboPages):
+    """A simple pagination session reminiscent of the old Pages interface.
 
-    result = [cmd.qualified_name]
-    if cmd.usage:
-        result.append(cmd.usage)
-        return " ".join(result)
+    Basically an embed with some normal formatting.
+    """
 
-    params = cmd.clean_params
-    if not params:
-        return " ".join(result)
-
-    for name, param in params.items():
-        if param.default is not param.empty:
-            # We don't want None or '' to trigger the [name=value] case and instead it should
-            # do [name] since [name=None] or [name=] are not exactly useful for the user.
-            should_print = (
-                param.default if isinstance(param.default, str) else param.default is not None
-            )
-            if should_print:
-                result.append(f"[{name}={param.default!r}]")
-            else:
-                result.append(f"[{name}]")
-        elif param.kind == param.VAR_POSITIONAL:
-            result.append(f"[{name}...]")
-        else:
-            result.append(f"<{name}>")
-
-    return " ".join(result)
-
-
-class HelpPaginator(Pages):
-    def __init__(self, ctx, entries, *, per_page=4):
-        super().__init__(ctx, entries=entries, per_page=per_page)
-        self.reaction_emojis.append(("\N{WHITE QUESTION MARK ORNAMENT}", self.show_bot_help))
-        self.total = len(entries)
-
-    @classmethod
-    async def from_cog(cls, ctx, cog):
-        cog_name = cog.__class__.__name__
-
-        # get the commands
-        entries = sorted(ctx.bot.get_cog_commands(cog_name), key=lambda c: c.name)
-
-        # remove the ones we can't run
-        entries = [cmd for cmd in entries if (await _can_run(cmd, ctx)) and not cmd.hidden]
-
-        self = cls(ctx, entries)
-        self.title = f"{cog_name} Commands"
-        self.description = inspect.getdoc(cog)
-        self.prefix = cleanup_prefix(ctx.bot, ctx.prefix)
-
-        # no longer need the database
-        await ctx.release()
-
-        return self
-
-    @classmethod
-    async def from_command(cls, ctx, command):
-        try:
-            entries = sorted(command.commands, key=lambda c: c.name)
-        except AttributeError:
-            entries = []
-        else:
-            entries = [cmd for cmd in entries if (await _can_run(cmd, ctx)) and not cmd.hidden]
-
-        self = cls(ctx, entries)
-        self.title = command.signature
-
-        if command.description:
-            self.description = f"{command.description}\n\n{command.help}"
-        else:
-            self.description = command.help or "No help given."
-
-        self.prefix = cleanup_prefix(ctx.bot, ctx.prefix)
-        await ctx.release()
-        return self
-
-    @classmethod
-    async def from_bot(cls, ctx):
-        def key(c):
-            return c.cog_name or "\u200bMisc"
-
-        entries = sorted(ctx.bot.commands, key=key)
-        nested_pages = []
-        per_page = 9
-
-        # 0: (cog, desc, commands) (max len == 9)
-        # 1: (cog, desc, commands) (max len == 9)
-        # ...
-
-        for cog, commands in itertools.groupby(entries, key=key):
-            plausible = [cmd for cmd in commands if (await _can_run(cmd, ctx)) and not cmd.hidden]
-            if len(plausible) == 0:
-                continue
-
-            description = ctx.bot.get_cog(cog)
-            if description is None:
-                description = discord.Embed.Empty
-            else:
-                description = inspect.getdoc(description) or discord.Embed.Empty
-
-            nested_pages.extend(
-                (cog, description, plausible[i : i + per_page])
-                for i in range(0, len(plausible), per_page)
-            )
-
-        self = cls(ctx, nested_pages, per_page=1)  # this forces the pagination session
-        self.prefix = cleanup_prefix(ctx.bot, ctx.prefix)
-        await ctx.release()
-
-        # swap the get_page implementation with one that supports our style of pagination
-        self.get_page = self.get_bot_page
-        self._is_bot = True
-
-        # replace the actual total
-        self.total = sum(len(o) for _, _, o in nested_pages)
-        return self
-
-    def get_bot_page(self, page):
-        cog, description, commands = self.entries[page - 1]
-        self.title = f"{cog} Commands"
-        self.description = description
-        return commands
-
-    def prepare_embed(self, entries, page, *, first=False):
-        self.embed.clear_fields()
-        self.embed.description = self.description
-        self.embed.title = self.title
-
-        if hasattr(self, "_is_bot"):
-            value = (
-                "For more help, join the official bot support server: https://discord.gg/DWEaqMy"
-            )
-            self.embed.add_field(name="Support", value=value, inline=False)
-
-        self.embed.set_footer(text=f'Use "{self.prefix}help command" for more info on a command.')
-
-        signature = _command_signature
-
-        for entry in entries:
-            self.embed.add_field(
-                name=signature(entry), value=entry.short_doc or "No help given", inline=False
-            )
-
-        if self.maximum_pages:
-            self.embed.set_author(name=f"Page {page}/{self.maximum_pages} ({self.total} commands)")
-
-    async def show_help(self):
-        """shows this message"""
-
-        self.embed.title = "Paginator help"
-        self.embed.description = "Hello! Welcome to the help page."
-
-        messages = [f"{emoji} {func.__doc__}" for emoji, func in self.reaction_emojis]
-        self.embed.clear_fields()
-        self.embed.add_field(
-            name="What are these reactions for?", value="\n".join(messages), inline=False
-        )
-
-        self.embed.set_footer(text=f"We were on page {self.current_page} before this message.")
-        await self.message.edit(embed=self.embed)
-
-        async def go_back_to_current_page():
-            await asyncio.sleep(30.0)
-            await self.show_current_page()
-
-        self.bot.loop.create_task(go_back_to_current_page())
-
-    async def show_bot_help(self):
-        """shows how to use the bot"""
-
-        self.embed.title = "Using the bot"
-        self.embed.description = "Hello! Welcome to the help page."
-        self.embed.clear_fields()
-
-        entries = (
-            ("<argument>", "This means the argument is __**required**__."),
-            ("[argument]", "This means the argument is __**optional**__."),
-            ("[A|B]", "This means the it can be __**either A or B**__."),
-            (
-                "[argument...]",
-                "This means you can have multiple arguments.\n"
-                "Now that you know the basics, it should be noted that...\n"
-                "__**You do not type in the brackets!**__",
-            ),
-        )
-
-        self.embed.add_field(
-            name="How do I use this bot?", value="Reading the bot signature is pretty simple."
-        )
-
-        for name, value in entries:
-            self.embed.add_field(name=name, value=value, inline=False)
-
-        self.embed.set_footer(text=f"We were on page {self.current_page} before this message.")
-        await self.message.edit(embed=self.embed)
-
-        async def go_back_to_current_page():
-            await asyncio.sleep(30.0)
-            await self.show_current_page()
-
-        self.bot.loop.create_task(go_back_to_current_page())
+    def __init__(self, entries, *, per_page=12):
+        super().__init__(SimplePageSource(entries, per_page=per_page))
+        self.embed = discord.Embed(colour=discord.Colour.blurple())


### PR DESCRIPTION
The latest version of `paginator.py` makes extensive use of `discord.ext.menus`, which should address issue #337 while still maintaining the resemblance of the menu messages displayed in Discord between `paginator.py`s before and after this commit, unless the aim is to be exclusively dependent upon `discord.ext.menus` only, in which case this pull request shall be rejected. Detailed descriptions for this commit are written below.

- Fetch the latest version of `paginator.py` from `Rapptz/RoboDanny` at commit `6fd39e7`. This version uses `discord.ext.menus` extensively. After clicking reaction buttons, user reactions do not get removed in this version. The author's explanation on this change is present in `paginator.py`.
- Use `paginator.SimplePages` instead of `paginator.Pages` in cogs `birthday`, `highlight`, `smartreact`, `tags`, `wordfilter`.
- `tempchannels` does not use `redbot.core.utils.paginator`.