### PR TITLE
[Tags] Fix incorrect debug log message

### DIFF
--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -195,7 +195,11 @@ class Tags(commands.Cog):
             guild = discord.utils.get(self.bot.guilds, id=guildId)
             async with self.configV3.guild(guild).tiers() as tiers:
                 self.allowed_roles[guildId] = set(tiers.keys())
-                self.logger.debug("Roles allowed to create commands on %s: %s", guildId, ", ".join(map(str, tiers)))
+                self.logger.debug(
+                    "Roles allowed to create commands on %s: %s",
+                    guildId,
+                    ", ".join(map(str, tiers)),
+                )
 
     def get_database_location(self, message: discord.Message):
         """Get the database of tags.

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -196,7 +196,7 @@ class Tags(commands.Cog):
             async with self.configV3.guild(guild).tiers() as tiers:
                 self.allowed_roles[guildId] = set(tiers.keys())
         self.logger.debug(
-            "Roles allowed to create commands: %s", ", ".join(self.allowed_roles.keys())
+            "Roles allowed to create commands: %s", ", ".join(map(str, self.allowed_roles.keys()))
         )
 
     def get_database_location(self, message: discord.Message):

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -195,9 +195,7 @@ class Tags(commands.Cog):
             guild = discord.utils.get(self.bot.guilds, id=guildId)
             async with self.configV3.guild(guild).tiers() as tiers:
                 self.allowed_roles[guildId] = set(tiers.keys())
-        self.logger.debug(
-            "Roles allowed to create commands: %s", ", ".join(map(str, self.allowed_roles.keys()))
-        )
+                self.logger.debug("Roles allowed to create commands on %s: %s", guildId, ", ".join(map(str, tiers)))
 
     def get_database_location(self, message: discord.Message):
         """Get the database of tags.


### PR DESCRIPTION
Keys could be non-`str` while `str.join` requires a `str` iterable. Mapping all keys to their `str` forms before doing `str`-joining should resolve #400.