### PR TITLE
[Respects] Add references to Respects' messages to resolve #401

### DIFF
--- a/cogs/respects/respects.py
+++ b/cogs/respects/respects.py
@@ -195,7 +195,7 @@ class Respects(commands.Cog):
                     ' Message" permissions to allow this feature to work!'
                 )
             except discord.HTTPException:
-                self.logger.debug("Could not retrieve the old respect")
+                self.logger.error("Could not retrieve the old respect", exc_info=True)
             else:
                 oldReference = oldRespect.reference if oldRespect else None
                 currentRespect = ctx.message

--- a/cogs/respects/respects.py
+++ b/cogs/respects/respects.py
@@ -261,5 +261,9 @@ class Respects(commands.Cog):
                         users = "{}, {}".format(userObj.name, users)
                 message = "**{}** have paid their respects {}".format(users, choice(HEARTS))
 
-            messageObj = await ctx.send(message)
+            messageObj = await ctx.send(
+                message,
+                reference=ctx.message.reference,
+                mention_author=False,
+            )
             chData[KEY_MSG] = messageObj.id


### PR DESCRIPTION
By setting a non-null `reference` when sending, the message could be treated as a reply to the referenced. A null `reference` does not impact the message.
Setting `mention_author` to `False` prevents pinging the referenced message's author.
This should resolve 2 numbered points in #401.

Reference: https://discordpy.readthedocs.io/en/v1.7.3/api.html#discord.Message.reference