### PR TITLE
[Respects] Refactor and remove hardcoded config calls

### DIFF
--- a/cogs/respects/respects.py
+++ b/cogs/respects/respects.py
@@ -195,13 +195,7 @@ class Respects(commands.Cog):
         chConfig = self.config.channel(ctx.channel)
         guildConfig = self.config.guild(ctx.guild)
 
-        oldRespectMsgId = None
-        try:
-            oldRespectMsgId = await chConfig.get_attr(KEY_MSG)()
-        except AttributeError:
-            # the attribute has not been registered
-            # so leave it as is
-            pass
+        oldRespectMsgId = await chConfig.get_attr(KEY_MSG)()
 
         if not oldRespectMsgId:
             return False


### PR DESCRIPTION
- Remove hardcoded config calls by using `get_attr` to resolve #405.
- Refactor:
  - Import error classes from `discord.errors`.
  - Remove unused `TEXT_RESPECTS`.
  - Add `@commands.bot_has_permissions` with `send_messages` and `manage_messages` for `plusF` to help get rid of redundant handling of `discord.Forbidden` later in calls to functions inside `plusF`. This helps #264.
  - Cache configs (including config `Group`s and `Value`s) that are used again and again in functions, using variables prefixed with `conf`.
  - Add type hints to some function signatures.
  - Handle `AttributeError` when doing `get_attr` to get possibly non-existent attributes under constraint `force_registration=True`.