### PR TITLE
[Respects] Disable errors for non-existent message reference

### DIFF
--- a/cogs/respects/respects.py
+++ b/cogs/respects/respects.py
@@ -323,7 +323,7 @@ class Respects(commands.Cog):
                         users = "{}, {}".format(userObj.name, users)
                 message = "**{}** have paid their respects {}".format(users, choice(HEARTS))
 
-            newReference = oldReference if oldReference else ctx.message.reference
+            newReference = ctx.message.reference if ctx.message.reference else oldReference
 
             messageObj = await ctx.send(
                 message,

--- a/cogs/respects/respects.py
+++ b/cogs/respects/respects.py
@@ -324,6 +324,8 @@ class Respects(commands.Cog):
                 message = "**{}** have paid their respects {}".format(users, choice(HEARTS))
 
             newReference = ctx.message.reference if ctx.message.reference else oldReference
+            if newReference:
+                newReference.fail_if_not_exists = False
 
             messageObj = await ctx.send(
                 message,


### PR DESCRIPTION
Resolve #412 by setting `newReference.fail_if_not_exists` to `False` as discussed to avoid Ren raising exceptions when the reference does not exist (e.g., the referenced message does not exist, which invalidates the reference), in which case the new respect message would not have a reference anymore and become a no-ref message.