### PR TITLE
[Tags] Clean up hardcoded usage of Config v3

### DIFF
--- a/cogs/tags/constants.py
+++ b/cogs/tags/constants.py
@@ -1,7 +1,11 @@
-BASE = {"dm": False, "tiers": {}, "useAlias": False}
 COLOUR_BLURPLE = 0x738BD7
-DEFAULT_MAX = 50  # Default max number of tags per user.
-KEY_MAX = "max"
+
+KEY_DM = "dm"
+KEY_TIERS = "tiers"
+KEY_USE_ALIAS = "useAlias"
+BASE_GUILD = {KEY_DM: False, KEY_TIERS: {}, KEY_USE_ALIAS: False}
+
 DUMP_IN = "data/tags/tags.json"
 DUMP_OUT = "data/tags/export.csv"
+
 NO_LIMIT = float("inf")

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -166,7 +166,7 @@ class Tags(commands.Cog):
             load_later=True,
         )
         self.configV3 = ConfigV3.get_conf(self, identifier=5842647, force_registration=True)
-        self.configV3.register_guild(**BASE)  # Register default (empty) settings.
+        self.configV3.register_guild(**BASE_GUILD)  # Register default (empty) settings.
         self.lock = Lock()
         tagGroup = self.get_commands()[0]
         self.tagCommands = tagGroup.all_commands.keys()


### PR DESCRIPTION
This PR closes #407 by doing the following:
- Remove unused constants.
- Remove commented out methods.
- Add KEY_* constants.
- Replace hardcoded Config v3 calls with get_attr and KEY lookups.

There are no changes to existing behaviour.