### PR TITLE
[Heartbeat] Switch from requests to aiohttp

### DIFF
--- a/cogs/heartbeat/heartbeat.py
+++ b/cogs/heartbeat/heartbeat.py
@@ -40,6 +40,7 @@ class Heartbeat(commands.Cog):
                     LOGGER.debug("Pinging %s", url)
                     async with aiohttp.ClientSession() as session:
                         resp = await session.get(url)
+                        resp.close()
                         if resp.status == 200:
                             LOGGER.debug("Successfully pinged %s", url)
                         else:


### PR DESCRIPTION
This PR closes #397 by doing the following:
- Change to using aiohttp from requests so that we can use async calls and not block the event loop.
- Remove unused imports.