### PR TITLE
[Birthday] Remove hardcoded config calls and refactor

### DIFF
--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -70,12 +70,12 @@ class Birthday(commands.Cog):
         """
 
         if channel:
-            await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_CHANNEL).set(channel.id)
+            await self.config.guild(ctx.guild).get_attr(KEY_BDAY_CHANNEL).set(channel.id)
             self.logger.info(
                 "%s#%s (%s) set the birthday channel to %s",
-                ctx.message.author.name,
-                ctx.message.author.discriminator,
-                ctx.message.author.id,
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
                 channel.name,
             )
             await ctx.send(
@@ -83,7 +83,7 @@ class Birthday(commands.Cog):
                 "as the birthday mention channel!".format(channel.name)
             )
         else:
-            await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_CHANNEL).set(None)
+            await self.config.guild(ctx.guild).get_attr(KEY_BDAY_CHANNEL).set(None)
             await ctx.send(
                 ":white_check_mark: **Birthday - Channel**: Birthday mentions are now disabled."
             )
@@ -102,12 +102,12 @@ class Birthday(commands.Cog):
             A role (name or mention) to set as the birthday role.
         """
 
-        await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_ROLE).set(role.id)
+        await self.config.guild(ctx.guild).get_attr(KEY_BDAY_ROLE).set(role.id)
         self.logger.info(
             "%s#%s (%s) set the birthday role to %s",
-            ctx.message.author.name,
-            ctx.message.author.discriminator,
-            ctx.message.author.id,
+            ctx.author.name,
+            ctx.author.discriminator,
+            ctx.author.id,
             role.name,
         )
         await ctx.send(
@@ -142,7 +142,7 @@ class Birthday(commands.Cog):
         day: int (optional)
             The birthday day, range between 1 and 31 inclusive, depending on month.
         """
-        rid = await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_ROLE)()
+        rid = await self.config.guild(ctx.guild).get_attr(KEY_BDAY_ROLE)()
 
         # Check if guild is initialized.
         if not rid:
@@ -176,7 +176,7 @@ class Birthday(commands.Cog):
             return
 
         def check(msg: discord.Message):
-            return msg.author == ctx.message.author and msg.channel == ctx.message.channel
+            return msg.author == ctx.author and msg.channel == ctx.channel
 
         async with self.config.member(member).all() as userConfig:
             addedBefore = userConfig[KEY_ADDED_BEFORE]
@@ -222,9 +222,9 @@ class Birthday(commands.Cog):
 
         self.logger.info(
             "%s#%s (%s) added the birthday of %s#%s (%s) as %s",
-            ctx.message.author.name,
-            ctx.message.author.discriminator,
-            ctx.message.author.id,
+            ctx.author.name,
+            ctx.author.discriminator,
+            ctx.author.id,
             member.name,
             member.discriminator,
             member.id,
@@ -242,7 +242,7 @@ class Birthday(commands.Cog):
         display = []  # List of text for paginator to use.  Will be constructed from sortedList.
 
         # Add only the users we care about (e.g. the ones that have birthdays set).
-        membersData = await self.config.all_members(ctx.message.guild)
+        membersData = await self.config.all_members(ctx.guild)
         for memberId, memberDetails in membersData.items():
             # Check if the birthdate keys exist, and they are not null.
             # If true, add an ID key and append to list.
@@ -268,7 +268,7 @@ class Birthday(commands.Cog):
 
         for user in sortedList:
             # Get the associated user Discord object.
-            userObject = discord.utils.get(ctx.message.guild.members, id=user["ID"])
+            userObject = discord.utils.get(ctx.guild.members, id=user["ID"])
 
             # Skip if user is no longer in server.
             if not userObject:
@@ -280,7 +280,7 @@ class Birthday(commands.Cog):
             display.append(text)
 
         page = paginator.Pages(ctx=ctx, entries=display, show_entry_count=True)
-        page.embed.title = "Birthdays in **{}**".format(ctx.message.guild.name)
+        page.embed.title = "Birthdays in **{}**".format(ctx.guild.name)
         page.embed.colour = discord.Colour.red()
         await page.paginate()
 
@@ -295,7 +295,7 @@ class Birthday(commands.Cog):
         member: discord.Member
             The guild member that you want to remove the birthday role from.
         """
-        rid = await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_ROLE)()
+        rid = await self.config.guild(ctx.guild).get_attr(KEY_BDAY_ROLE)()
         if not rid:
             await ctx.send(
                 ":negative_squared_cross_mark: **Birthday - Unassign**: This "
@@ -305,7 +305,7 @@ class Birthday(commands.Cog):
 
         try:
             # Find the Role object to remove from the member.
-            role = discord.utils.get(ctx.message.guild.roles, id=rid)
+            role = discord.utils.get(ctx.guild.roles, id=rid)
 
             # Remove role from the user.
             await member.remove_roles(role)
@@ -336,9 +336,9 @@ class Birthday(commands.Cog):
 
         self.logger.info(
             "%s#%s (%s) unassigned %s#%s (%s) from the birthday role",
-            ctx.message.author.name,
-            ctx.message.author.discriminator,
-            ctx.message.author.id,
+            ctx.author.name,
+            ctx.author.discriminator,
+            ctx.author.id,
             member.name,
             member.discriminator,
             member.id,
@@ -356,7 +356,7 @@ class Birthday(commands.Cog):
         member: discord.Member
             The guild member whose birthday role and saved birthday you want to remove.
         """
-        rid = await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_ROLE)()
+        rid = await self.config.guild(ctx.guild).get_attr(KEY_BDAY_ROLE)()
         if not rid:
             await ctx.send(
                 ":negative_squared_cross_mark: **Birthday - Delete**: This "
@@ -366,7 +366,7 @@ class Birthday(commands.Cog):
 
         try:
             # Find the Role object to remove from the member.
-            role = discord.utils.get(ctx.message.guild.roles, id=rid)
+            role = discord.utils.get(ctx.guild.roles, id=rid)
 
             # Remove role from the user.
             await member.remove_roles(role)
@@ -402,9 +402,9 @@ class Birthday(commands.Cog):
 
         self.logger.info(
             "%s#%s (%s) deleted the birthday of %s#%s (%s)",
-            ctx.message.author.name,
-            ctx.message.author.discriminator,
-            ctx.message.author.id,
+            ctx.author.name,
+            ctx.author.discriminator,
+            ctx.author.id,
             member.name,
             member.discriminator,
             member.id,

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -60,7 +60,7 @@ class Birthday(commands.Cog):
     @_birthday.command(name="channel", aliases=["ch"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
-    async def setChannel(self, ctx, channel: discord.TextChannel = None):
+    async def setChannel(self, ctx: Context, channel: discord.TextChannel = None):
         """Set the channel to mention members on their birthday.
 
         Parameters:
@@ -91,7 +91,7 @@ class Birthday(commands.Cog):
     @_birthday.command(name="role")
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
-    async def setRole(self, ctx, role: discord.Role):
+    async def setRole(self, ctx: Context, role: discord.Role):
         """Set the role to assign to a birthday user. Make sure this role can
         be assigned and removed by the bot by placing it in the correct
         hierarchy location.
@@ -117,7 +117,7 @@ class Birthday(commands.Cog):
 
     @_birthday.command(name="test")
     @commands.guild_only()
-    async def test(self, ctx):
+    async def test(self, ctx: Context):
         """Test at-mentions."""
         for msg in CANNED_MESSAGES:
             await ctx.send(msg.format(ctx.author.mention))

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -70,7 +70,7 @@ class Birthday(commands.Cog):
         """
 
         if channel:
-            await self.config.guild(ctx.message.guild).birthdayChannel.set(channel.id)
+            await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_CHANNEL).set(channel.id)
             self.logger.info(
                 "%s#%s (%s) set the birthday channel to %s",
                 ctx.message.author.name,
@@ -83,7 +83,7 @@ class Birthday(commands.Cog):
                 "as the birthday mention channel!".format(channel.name)
             )
         else:
-            await self.config.guild(ctx.message.guild).birthdayChannel.set(None)
+            await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_CHANNEL).set(None)
             await ctx.send(
                 ":white_check_mark: **Birthday - Channel**: Birthday mentions are now disabled."
             )
@@ -102,7 +102,7 @@ class Birthday(commands.Cog):
             A role (name or mention) to set as the birthday role.
         """
 
-        await self.config.guild(ctx.message.guild).birthdayRole.set(role.id)
+        await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_ROLE).set(role.id)
         self.logger.info(
             "%s#%s (%s) set the birthday role to %s",
             ctx.message.author.name,
@@ -142,7 +142,7 @@ class Birthday(commands.Cog):
         day: int (optional)
             The birthday day, range between 1 and 31 inclusive, depending on month.
         """
-        rid = await self.config.guild(ctx.message.guild).birthdayRole()
+        rid = await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_ROLE)()
 
         # Check if guild is initialized.
         if not rid:
@@ -295,7 +295,7 @@ class Birthday(commands.Cog):
         member: discord.Member
             The guild member that you want to remove the birthday role from.
         """
-        rid = await self.config.guild(ctx.message.guild).birthdayRole()
+        rid = await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_ROLE)()
         if not rid:
             await ctx.send(
                 ":negative_squared_cross_mark: **Birthday - Unassign**: This "
@@ -357,7 +357,7 @@ class Birthday(commands.Cog):
         member: discord.Member
             The guild member whose birthday role and saved birthday you want to remove.
         """
-        rid = await self.config.guild(ctx.message.guild).birthdayRole()
+        rid = await self.config.guild(ctx.message.guild).get_attr(KEY_BDAY_ROLE)()
         if not rid:
             await ctx.send(
                 ":negative_squared_cross_mark: **Birthday - Delete**: This "
@@ -439,7 +439,7 @@ class Birthday(commands.Cog):
             for guild in guilds:
                 # Make sure the guild is configured with birthday role.
                 # If it's not, skip over it.
-                bdayRoleId = await self.config.guild(guild).birthdayRole()
+                bdayRoleId = await self.config.guild(guild).get_atr(KEY_BDAY_ROLE)()
                 if not bdayRoleId:
                     continue
 
@@ -478,7 +478,7 @@ class Birthday(commands.Cog):
                             continue
 
                         # Update the list.
-                        await self.config.member(member).isAssigned.set(False)
+                        await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(False)
 
     async def _dailyAdd(self):  # pylint: disable=too-many-branches
         """Add guild members to the birthday role."""
@@ -494,8 +494,8 @@ class Birthday(commands.Cog):
             for guild in guilds:
                 # Make sure the guild is configured with birthday role.
                 # If it's not, skip over it.
-                bdayRoleId = await self.config.guild(guild).birthdayRole()
-                bdayChannelId = await self.config.guild(guild).birthdayChannel()
+                bdayRoleId = await self.config.guild(guild).get_attr(KEY_BDAY_ROLE)()
+                bdayChannelId = await self.config.guild(guild).get_attr(KEY_BDAY_CHANNEL)()
                 if not bdayRoleId:
                     continue
 

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -153,7 +153,7 @@ class Birthday(commands.Cog):
             return
 
         # Check if both the inputs are empty, for this case set the birthday as current day
-        # If one of the parameters are missing, then raise error
+        # If one of the parameters are missing, then send error message
         if month == None and day == None:
             day = int(time.strftime("%d"))
             month = int(time.strftime("%m"))
@@ -235,7 +235,7 @@ class Birthday(commands.Cog):
     @_birthday.command(name="list", aliases=["ls"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
-    async def list(self, ctx: Context):
+    async def listBirthdays(self, ctx: Context):
         """Lists the birthdays of users in the server."""
 
         sortedList = []  # List to sort by month, day.
@@ -327,8 +327,7 @@ class Birthday(commands.Cog):
             )
             return
 
-        async with self.config.member(member).all() as userConfig:
-            userConfig[KEY_IS_ASSIGNED] = False
+        await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(False)
 
         await ctx.send(
             ":white_check_mark: **Birthday - Unassign**: Successfully "
@@ -530,8 +529,9 @@ class Birthday(commands.Cog):
                                     member.id,
                                 )
                                 # Update the list.
-                                async with self.config.member(member).all() as memberConfig:
-                                    memberConfig[KEY_IS_ASSIGNED] = True
+                                await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(
+                                    True
+                                )
 
                             except discord.Forbidden:
                                 self.logger.error(

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -439,7 +439,7 @@ class Birthday(commands.Cog):
             for guild in guilds:
                 # Make sure the guild is configured with birthday role.
                 # If it's not, skip over it.
-                bdayRoleId = await self.config.guild(guild).get_atr(KEY_BDAY_ROLE)()
+                bdayRoleId = await self.config.guild(guild).get_attr(KEY_BDAY_ROLE)()
                 if not bdayRoleId:
                     continue
 


### PR DESCRIPTION
This PR will:
- Close #414 by using `get_attr` instead of hardcoding.
- Remove context manager use for single attribute changes: just use the set method directly.
- Update an incorrect comment.
- Replace `ctx.message.*` with the shortcut form `ctx.*`

There are no changes to existing behaviour.