### PR TITLE
[Highlight] Use built-in menus

### DIFF
--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -190,7 +190,7 @@ class Highlight(commands.Cog):
     @highlight.command(name="list", aliases=["ls"])
     @commands.guild_only()
     async def listHighlight(self, ctx: Context):
-        """List your highighted words for the current guild."""
+        """List your highlighted words for the current guild."""
         userName = ctx.message.author.name
 
         async with self.config.member(ctx.author).words() as userWords:


### PR DESCRIPTION
This PR resolves #440:
- Remove dependency on paginator, as that was a v2 utility that was imported. This dependency meant that we could not use this cog in other Red installations.