### PR TITLE
[SFU] Handle missing start or end times for classes

### DIFF
--- a/cogs/sfu/api.py
+++ b/cogs/sfu/api.py
@@ -183,11 +183,14 @@ def _extract(data: dict):
 
     classtimes = ""
     for time in schedule:
-        classtimes += "[{}] {} {} - {}, {} {}, {}\n".format(
+        if "startTime" not in time or "endTime" not in time:
+            sectionTime = "Unknown Time"
+        else:
+            sectionTime = "{} - {}".format(time["startTime"], time["endTime"])
+        classtimes += "[{}] {} {}, {} {}, {}\n".format(
             time["sectionCode"],
             time["days"],
-            time["startTime"],
-            time["endTime"],
+            sectionTime,
             time["buildingCode"],
             time["roomNumber"],
             time["campus"],


### PR DESCRIPTION
This PR resolves #442 by displaying `Unknown Time` if we are missing the start or end times for a particular section.