### PR TITLE
[Welcome] Remove hardcoded config calls

### DIFF
--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -10,7 +10,7 @@ import random
 from redbot.core import Config, checks, commands
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
-from redbot.core.utils.chat_formatting import error, pagify, warning
+from redbot.core.utils.chat_formatting import pagify, warning
 from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils import AsyncIter
 
@@ -55,8 +55,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         self.config.register_guild(**DEFAULT_GUILD)
 
     async def getRandomMessage(self, guild):
-        greetings = await self.config.guild(guild).greetings()
-        numGreetings = len(greetings)
+        greetings = await self.config.guild(guild).get_attr(KEY_GREETINGS)()
         if not greetings:
             return "Welcome to the server {USER}"
         else:
@@ -79,17 +78,17 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
             return
         guild = removedChannel.guild
         # the channel to post welcome stuff in
-        welcomeIDSet = await self.config.guild(guild).welcomeChannelSet()
-        welcomeID = await self.config.guild(guild).welcomeChannel()
+        welcomeIDSet = await self.config.guild(guild).get_attr(KEY_WELCOME_CHANNEL_ENABLED)()
+        welcomeID = await self.config.guild(guild).get_attr(KEY_WELCOME_CHANNEL)()
         if welcomeIDSet and removedChannel.id == welcomeID:
-            await self.config.guild(guild).welcomeChannelSet.set(False)
+            await self.config.guild(guild).get_attr(KEY_WELCOME_CHANNEL_ENABLED).set(False)
             LOGGER.info("Changed guild's welcomeChannelSetFlag to false as channel was deleted")
         return
 
     async def sendWelcomeMessageChannel(self, newUser: discord.Member):
         guild = newUser.guild
-        channelID = await self.config.guild(guild).welcomeChannel()
-        isSet = await self.config.guild(guild).welcomeChannelSet()
+        channelID = await self.config.guild(guild).get_attr(KEY_WELCOME_CHANNEL)()
+        isSet = await self.config.guild(guild).get_attr(KEY_WELCOME_CHANNEL_ENABLED)()
         # if channel isn't set
         if not isSet:
             return
@@ -97,7 +96,6 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         rawMessage = await self.getRandomMessage(guild)
 
         message = rawMessage.replace("{USER}", newUser.mention)
-        splitMessage = rawMessage.split("{USER}")
 
         try:
             await channel.send(message)
@@ -163,7 +161,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
                         "joined. DM sent."
                     )
                     LOGGER.info(
-                        "User %s#%s (%s) has joined.  DM sent.",
+                        "User %s#%s (%s) has joined. DM sent.",
                         newUser.name,
                         newUser.discriminator,
                         newUser.id,
@@ -219,12 +217,12 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         """
         if not channel:
             # channel == None
-            await self.config.guild(ctx.guild).welcomeChannelSet.set(False)
+            await self.config.guild(ctx.guild).get_attr(KEY_WELCOME_CHANNEL_ENABLED).set(False)
             await ctx.send("Welcome channel has been removed")
             return
 
-        await self.config.guild(ctx.guild).welcomeChannel.set(channel.id)
-        await self.config.guild(ctx.guild).welcomeChannelSet.set(True)
+        await self.config.guild(ctx.guild).get_attr(KEY_WELCOME_CHANNEL).set(channel.id)
+        await self.config.guild(ctx.guild).get_attr(KEY_WELCOME_CHANNEL_ENABLED).set(True)
         await ctx.send(f"Channel set to {channel}")
 
         return
@@ -258,7 +256,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
             await ctx.send("Your message is too long!")
             return
 
-        greetings = await self.config.guild(ctx.guild).greetings()
+        greetings = await self.config.guild(ctx.guild).get_attr(KEY_GREETINGS)()
 
         if name in greetings:
             await ctx.send(
@@ -279,7 +277,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         # save the greetings
         greetings[name] = greeting.content
         await greeting.add_reaction("✅")
-        await self.config.guild(ctx.guild).greetings.set(greetings)
+        await self.config.guild(ctx.guild).get_attr(KEY_GREETINGS).set(greetings)
         return
 
     @checks.mod_or_permissions()
@@ -296,7 +294,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         def check(message: discord.Message):
             return message.author == ctx.message.author and message.channel == ctx.message.channel
 
-        greetings = await self.config.guild(ctx.guild).greetings()
+        greetings = await self.config.guild(ctx.guild).get_attr(KEY_GREETINGS)()
         if name in greetings:
             await ctx.send(
                 warning("Are you sure you wish to delete this greeting? Respond with 'yes' if yes")
@@ -314,7 +312,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
             # delete the greeting
             del greetings[name]
             await ctx.send(f"{name} removed from list")
-            await self.config.guild(ctx.guild).greetings.set(greetings)
+            await self.config.guild(ctx.guild).get_attr(KEY_GREETINGS).set(greetings)
         else:
             ctx.send(f"{name} not in list of greetings")
         return
@@ -325,7 +323,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         """
         List all greetings on the server
         """
-        greetings = await self.config.guild(ctx.guild).greetings()
+        greetings = await self.config.guild(ctx.guild).get_attr(KEY_GREETINGS)()
 
         if not greetings:
             await ctx.send("There are no greetings, please add some first!")
@@ -366,7 +364,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
             await ctx.send("Your message is too long!")
             return
 
-        await self.config.guild(ctx.guild).message.set(message.content)
+        await self.config.guild(ctx.guild).get_attr(KEY_MESSAGE).set(message.content)
         await ctx.send("Message set to:")
         await ctx.send(f"```{message.content}```")
         LOGGER.info(
@@ -488,7 +486,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
             await ctx.send("The title is too long!")
             return
 
-        await self.config.guild(ctx.guild).title.set(title.content)
+        await self.config.guild(ctx.guild).get_attr(KEY_TITLE).set(title.content)
         await ctx.send("Title set to:")
         await ctx.send(f"```{title.content}```")
         LOGGER.info(
@@ -512,7 +510,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         if imageUrl == "":
             imageUrl = None
 
-        await self.config.guild(ctx.guild).image.set(imageUrl)
+        await self.config.guild(ctx.guild).get_attr(KEY_IMAGE).set(imageUrl)
         if imageUrl:
             await ctx.send(f"Welcome image set to `{imageUrl}`. Be sure to test it!")
         else:


### PR DESCRIPTION
Fixes #421:
- Replace hardcoded parts with `get_attr(KEY_###)`.

Refactors & nits:
- Remove unused import `redbot.core.utils.chat_formatting.error`.
- Remove unused variables `numGreetings` & `splitMessage`.
- Remove a whitespace in "DM sent" log line.

**There should be no changes to any existing functionalities.**