### PR TITLE
[Tags] Use built-in menus

### DIFF
--- a/cogs/tags/helpers.py
+++ b/cogs/tags/helpers.py
@@ -1,0 +1,55 @@
+from .constants import COLOUR_BLURPLE
+
+import discord
+from redbot.core.utils import AsyncIter, chat_formatting
+
+
+async def createSimplePages(
+    items: [str], embedTitle: str = "", embedAuthor: discord.Member = None
+):
+    """Create embed pages for the redbot menu coroutine.
+
+    It features the following:
+    - Each entry is numbered.
+    - The total number of items is visible.
+    - The total number of pages is visible.
+
+    Parameters
+    ----------
+    items: [ str ]
+        A list of strings you wish to display to the user.
+    embedTitle: Optional[ str ]
+        The title for all the embed pages
+    embedAuthor : Optional[ discord.Member ]
+        The author. If passed in, it will set the footer author's name and
+        avatar
+
+    Returns
+    -------
+    [ discord.Embed ]
+        A list of `discord.Embed`s, which can be passed directly into Red's
+        menu coroutine.
+    """
+    if embedAuthor and not isinstance(embedAuthor, discord.Member):
+        raise RuntimeError("Please pass in a discord.Member object")
+    display = []
+    pageList = []
+    for num, theItem in enumerate(items, start=1):
+        display.append(f"{num}. {theItem}")
+    msg = "\n".join(display)
+    pages = list(chat_formatting.pagify(msg, page_length=300))
+    totalPages = len(pages)
+    totalEntries = len(display)
+
+    async for pageNumber, page in AsyncIter(pages).enumerate(start=1):
+        embed = discord.Embed(title=embedTitle, description=page)
+        embed.set_footer(text=f"Page {pageNumber}/{totalPages} ({totalEntries} entries)")
+        embed.colour = COLOUR_BLURPLE
+        if embedAuthor:
+            embed.set_author(
+                name=embedAuthor.display_name,
+                icon_url=embedAuthor.avatar_url or embedAuthor.default_avatar_url,
+            )
+        pageList.append(embed)
+
+    return pageList

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -6,6 +6,7 @@
 from .config import Config
 from .constants import *
 from .exceptions import *
+from .helpers import createSimplePages
 from .rolecheck import roles_or_mod_or_permissions
 
 from copy import deepcopy
@@ -26,7 +27,7 @@ import logging
 from redbot.core import Config as ConfigV3, checks, commands, data_manager
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
-from redbot.core.utils.paginator import Pages
+from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 
 
 class TagInfo:
@@ -1119,13 +1120,8 @@ class Tags(commands.Cog):
         tags.sort()
 
         if tags:
-            p = Pages(ctx=ctx, entries=tags, show_entry_count=True)
-            p.embed.colour = COLOUR_BLURPLE
-            p.embed.set_author(
-                name=owner.display_name,
-                icon_url=owner.avatar_url or owner.default_avatar_url,
-            )
-            await p.paginate()
+            pageList = await createSimplePages(items=tags, embedAuthor=owner)
+            await menu(ctx, pageList, DEFAULT_CONTROLS)
         else:
             await ctx.send("{0.name} has no tags.".format(owner))
 
@@ -1138,9 +1134,11 @@ class Tags(commands.Cog):
         tags.sort()
 
         if tags:
-            p = Pages(ctx=ctx, entries=tags, per_page=15, show_entry_count=True)
-            p.embed.colour = COLOUR_BLURPLE
-            await p.paginate()
+            pageList = await createSimplePages(
+                items=tags,
+                embedTitle="All Tags",
+            )
+            await menu(ctx, pageList, DEFAULT_CONTROLS)
         else:
             await ctx.send("This server has no server-specific tags.")
 
@@ -1232,9 +1230,11 @@ class Tags(commands.Cog):
 
         if results:
             try:
-                p = Pages(ctx=ctx, entries=results, per_page=15, show_entry_count=True)
-                p.embed.colour = COLOUR_BLURPLE
-                await p.paginate()
+                pageList = await createSimplePages(
+                    items=results,
+                    embedTitle="Search Results",
+                )
+                await menu(ctx, pageList, DEFAULT_CONTROLS)
             except Exception as e:
                 await ctx.send(e)
         else:

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -9,20 +9,18 @@ from .exceptions import *
 from .helpers import createSimplePages
 from .rolecheck import roles_or_mod_or_permissions
 
+from collections import defaultdict
 from copy import deepcopy
 import csv
-import json
-import re
 import datetime
-import discord
 import difflib
+import json
+import logging
 from threading import Lock
-from collections import defaultdict
 
 import asyncio
 import discord
 from os.path import isfile, join
-import logging
 
 from redbot.core import Config as ConfigV3, checks, commands, data_manager
 from redbot.core.bot import Red
@@ -136,7 +134,7 @@ class Tags(commands.Cog):
     def removeAllowedRole(self, guild: discord.Guild, role: discord.Role):
         self.allowed_roles[guild.id].discard(str(role.id))
 
-    def __init__(self, bot):
+    def __init__(self, bot: Red):
         self.bot = bot
         saveFolder = data_manager.cog_data_path(cog_instance=self)
         self.logger = logging.getLogger("red.luicogs.Tags")


### PR DESCRIPTION
This PR does two things:
1. Close #437 by doing the following
    - Create a helper function since we're doing the same thing more than once.
    - Change `search`, `all`, and `list` to use the built-in menus.
    - Remove the paginator import.
2. Reorder some imports to be in alphabetical order.
    - Remove a duplicate `discord` import.