### PR TITLE
[AfterHours] Move `ctx.invoke` calls into `try/catch/else`

### DIFF
--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -231,14 +231,13 @@ class AfterHours(commands.Cog):
 
         try:
             starboard = sbCog.starboards[ctx.guild.id]["highlights"]
-            if remove:
-                await ctx.invoke(
-                    sbCog.blacklist_remove, starboard=starboard, channel_or_role=channel
-                )
-            else:
-                await ctx.invoke(sbCog.blacklist_add, starboard=starboard, channel_or_role=channel)
         except KeyError:
             self.logger.error("Cannot get the starboard!")
+        else:
+            if remove:
+                await ctx.invoke(sbCog.blacklist_remove, starboard=starboard, channel_or_role=channel)
+            else:
+                await ctx.invoke(sbCog.blacklist_add, starboard=starboard, channel_or_role=channel)
 
     async def notifyChannel(self, ctx, remove=False):
         if remove:

--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -231,13 +231,12 @@ class AfterHours(commands.Cog):
 
         try:
             starboard = sbCog.starboards[ctx.guild.id]["highlights"]
+            if remove:
+                await ctx.invoke(sbCog.blacklist_remove, starboard=starboard, channel_or_role=channel)
+            else:
+                await ctx.invoke(sbCog.blacklist_add, starboard=starboard, channel_or_role=channel)
         except KeyError:
             self.logger.error("Cannot get the starboard!")
-
-        if remove:
-            await ctx.invoke(sbCog.blacklist_remove, starboard=starboard, channel_or_role=channel)
-        else:
-            await ctx.invoke(sbCog.blacklist_add, starboard=starboard, channel_or_role=channel)
 
     async def notifyChannel(self, ctx, remove=False):
         if remove:

--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -235,7 +235,9 @@ class AfterHours(commands.Cog):
             self.logger.error("Cannot get the starboard!")
         else:
             if remove:
-                await ctx.invoke(sbCog.blacklist_remove, starboard=starboard, channel_or_role=channel)
+                await ctx.invoke(
+                    sbCog.blacklist_remove, starboard=starboard, channel_or_role=channel
+                )
             else:
                 await ctx.invoke(sbCog.blacklist_add, starboard=starboard, channel_or_role=channel)
 

--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -232,7 +232,9 @@ class AfterHours(commands.Cog):
         try:
             starboard = sbCog.starboards[ctx.guild.id]["highlights"]
             if remove:
-                await ctx.invoke(sbCog.blacklist_remove, starboard=starboard, channel_or_role=channel)
+                await ctx.invoke(
+                    sbCog.blacklist_remove, starboard=starboard, channel_or_role=channel
+                )
             else:
                 await ctx.invoke(sbCog.blacklist_add, starboard=starboard, channel_or_role=channel)
         except KeyError:


### PR DESCRIPTION
This PR fixes #458 by having `ctx.invoke` calls inside the `try/catch` block.