### PR TITLE
[AfterHours] Do `None`-check for `after.edited_at`

### DIFF
--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -343,7 +343,8 @@ class AfterHours(commands.Cog):
         if after.author.bot:
             return
 
-        await self.saveMessageTimestamp(after, after.edited_at.timestamp())
+        if after.edited_at:
+            await self.saveMessageTimestamp(after, after.edited_at.timestamp())
 
     @commands.group(name="afterhours")
     @commands.guild_only()


### PR DESCRIPTION
## Issue
This fixes #465.

## Summary
Do `None`-check for `after.edited_at` before getting its timestamp since `after.edited_at` can be `None` (e.g., when `handleMessageEdit` is triggered by Discord loading a new embed).