### PR TITLE
[AfterHours] Fix incorrect logging and log extra user info

### DIFF
--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -173,12 +173,12 @@ class AfterHours(commands.Cog):
             try:
                 async with guildConfig.get_attr(KEY_LAST_MSG_TIMESTAMPS)() as lastMsgTimestamps:
                     for inactiveMember in inactiveMembers:
+                        memberId = str(inactiveMember.id)
                         await inactiveMember.remove_roles(ahRole, reason="AfterHours auto-purge")
                         self.logger.info(
                             "Removed role %s from user %s due to inactivity", ahRole.name, memberId
                         )
                         # clean up dict entry for this member
-                        memberId = str(inactiveMember.id)
                         del lastMsgTimestamps[memberId]
             except discord.Forbidden:
                 self.logger.error(

--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -173,10 +173,18 @@ class AfterHours(commands.Cog):
             try:
                 async with guildConfig.get_attr(KEY_LAST_MSG_TIMESTAMPS)() as lastMsgTimestamps:
                     for inactiveMember in inactiveMembers:
+                        # obtain information
+                        memberName = inactiveMember.name
+                        memberDiscriminator = inactiveMember.discriminator
                         memberId = str(inactiveMember.id)
+                        # purge this inactive member
                         await inactiveMember.remove_roles(ahRole, reason="AfterHours auto-purge")
                         self.logger.info(
-                            "Removed role %s from user %s due to inactivity", ahRole.name, memberId
+                            "Removed role %s from %s#%s (%s) due to inactivity",
+                            ahRole.name,
+                            memberName,
+                            memberDiscriminator,
+                            memberId,
                         )
                         # clean up dict entry for this member
                         del lastMsgTimestamps[memberId]


### PR DESCRIPTION
## Cog
AfterHours.

## Summary
This PR fixes #474 by obtaining inactive users' info before logging lines, not after.
Also, instead of user ID only, the cog now also logs users' names and discriminators in Discord format, i.e., *name*#*discriminator* (*ID*).