### PR TITLE
[Triggered] Use bytes IO instead of file IO to create "triggered" images

### DIFF
--- a/cogs/triggered/triggered.py
+++ b/cogs/triggered/triggered.py
@@ -3,7 +3,7 @@
 """
 
 import logging
-import os
+import io
 import aiohttp
 import discord
 from redbot.core import commands, data_manager
@@ -71,8 +71,9 @@ class Triggered(commands.Cog):
                 return
             await ctx.send(file=discord.File(savePath))
 
-    async def _createTrigger(self, user, mode=Modes.triggered):
+    async def _createTrigger(self, user: discord.User, mode=Modes.triggered):
         """Fetches the user's avatar, and creates a triggered GIF, applies additional PIL image transformations based on specified mode
+
         Parameters:
         -----------
         user: discord.Member
@@ -80,7 +81,7 @@ class Triggered(commands.Cog):
 
         Returns:
         --------
-        savePath: str, or None
+        A io.BytesIO object containing the data for the generated trigger image
         """
         avatarData: bytes
 

--- a/cogs/triggered/triggered.py
+++ b/cogs/triggered/triggered.py
@@ -78,12 +78,12 @@ class Triggered(commands.Cog):
 
         Parameters:
         -----------
-        user: discord.Member
-        mode: Mode
+        user: discord.User
+        mode: Modes
 
         Returns:
         --------
-        A io.BytesIO object containing the data for the generated trigger image
+        An io.BytesIO object containing the data for the generated trigger image
         """
         avatarData: bytes
 

--- a/cogs/triggered/triggered.py
+++ b/cogs/triggered/triggered.py
@@ -14,6 +14,7 @@ from enum import Enum
 Modes = Enum("Modes", "triggered reallytriggered hypertriggered")
 
 AVATAR_URL = "https://cdn.discordapp.com/avatars/{0.id}/{0.avatar}.png?size=512"
+AVATAR_FILE_NAME = "{0.id}-triggered.gif"
 
 
 class Triggered(commands.Cog):
@@ -39,11 +40,11 @@ class Triggered(commands.Cog):
             user = ctx.message.author
         async with ctx.typing():
             # bot is typing here...
-            savePath = await self._createTrigger(user, mode=Modes.triggered)
-            if not savePath:
+            data = await self._createTrigger(user, mode=Modes.triggered)
+            if not data:
                 await self.bot.say("Something went wrong, try again.")
                 return
-            await ctx.send(file=discord.File(savePath))
+            await ctx.send(file=discord.File(data, filename=AVATAR_FILE_NAME.format(user)))
 
     @commands.command(name="reallytriggered")
     async def hypertriggered(self, ctx, user: discord.Member = None):
@@ -52,11 +53,11 @@ class Triggered(commands.Cog):
             user = ctx.message.author
         async with ctx.typing():
             # bot is typing here...
-            savePath = await self._createTrigger(user, mode=Modes.reallytriggered)
-            if not savePath:
+            data = await self._createTrigger(user, mode=Modes.reallytriggered)
+            if not data:
                 await self.bot.say("Something went wrong, try again.")
                 return
-            await ctx.send(file=discord.File(savePath))
+            await ctx.send(file=discord.File(data, filename=AVATAR_FILE_NAME.format(user)))
 
     @commands.command(name="hypertriggered")
     async def deepfry(self, ctx, user: discord.Member = None):
@@ -65,11 +66,11 @@ class Triggered(commands.Cog):
             user = ctx.message.author
         async with ctx.typing():
             # bot is typing here...
-            savePath = await self._createTrigger(user, mode=Modes.hypertriggered)
-            if not savePath:
+            data = await self._createTrigger(user, mode=Modes.hypertriggered)
+            if not data:
                 await self.bot.say("Something went wrong, try again.")
                 return
-            await ctx.send(file=discord.File(savePath))
+            await ctx.send(file=discord.File(data, filename=AVATAR_FILE_NAME.format(user)))
 
     async def _createTrigger(self, user: discord.User, mode=Modes.triggered):
         """Fetches the user's avatar, and creates a triggered GIF, applies additional PIL image transformations based on specified mode

--- a/cogs/triggered/triggered.py
+++ b/cogs/triggered/triggered.py
@@ -8,6 +8,7 @@ import aiohttp
 import discord
 from redbot.core import commands, data_manager
 from redbot.core.bot import Red
+from redbot.core.commands import Context
 from PIL import Image, ImageChops, ImageOps, ImageFilter, ImageEnhance
 from enum import Enum
 
@@ -34,7 +35,7 @@ class Triggered(commands.Cog):
         self.bot.loop.run_until_complete(self.session.close())
 
     @commands.command(name="triggered")
-    async def triggered(self, ctx, user: discord.Member = None):
+    async def triggered(self, ctx: Context, user: discord.Member = None):
         """Are you triggered? Say no more."""
         if not user:
             user = ctx.message.author
@@ -47,7 +48,7 @@ class Triggered(commands.Cog):
             await ctx.send(file=discord.File(data, filename=AVATAR_FILE_NAME.format(user)))
 
     @commands.command(name="reallytriggered")
-    async def hypertriggered(self, ctx, user: discord.Member = None):
+    async def hypertriggered(self, ctx: Context, user: discord.Member = None):
         """Are you in an elevated state of triggered? Say no more."""
         if not user:
             user = ctx.message.author
@@ -60,7 +61,7 @@ class Triggered(commands.Cog):
             await ctx.send(file=discord.File(data, filename=AVATAR_FILE_NAME.format(user)))
 
     @commands.command(name="hypertriggered")
-    async def deepfry(self, ctx, user: discord.Member = None):
+    async def deepfry(self, ctx: Context, user: discord.Member = None):
         """Are you incredibly triggered? Say no more."""
         if not user:
             user = ctx.message.author


### PR DESCRIPTION
## Cog
Triggered.

## Summary
This PR resolves #453. Instead of cleaning up files, images are now created, processed and finalized using in-memory `bytes` interfaces. **After this PR, during creation of triggered images, the cog should perform no storage of permanent image files on disk.**

### Switch from file IO to bytes IO
Instead of a file object:
- Image data received from GET request is now stored as `bytes`.
- Image operations are now performed on `bytes`.
- Resulting image now gets saved in an `io.BytesIO` object. It is file-like, in-memory, and can be consumed by `discord.File`.

### Imports, method signature, docstring, type hints
- Remove unused import `os`.
- Add new import `io`.
- Add type hint `Context` for command methods for consistency.
- Add type hint `discord.User` for `_createTrigger`.
- Correct docstring for `_createTrigger`.

### Adjust code logic in command methods
- Change variable name from `savePath` to `data` for meaning accuracy.
- Declare format-able constant `AVATAR_FILE_NAME` for filenames. The filename (without extension `.gif`) ends with `triggered` instead of `trig` to make it easier to see changes when this PR is merged, but other than that, nothing is affected.
- Add parameter `filename` to `discord.File` (fed with string value obtained from `AVATAR_FILE_NAME`) to let Discord recognize the file(s) as GIF file(s).

## Notes
**This PR should only change how avatar and image data gets processed under the hood. There should be no changes towards any other image-related logic, operations, or image results produced by calls to `_createTrigger`. No commands are added or 
deleted, and execution of any of them should produce image results (except under slightly different names) as if this PR had not been made.**