### PR TITLE
README: replace #feedback with suggestion form, also some formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 [![discord.py](https://img.shields.io/badge/discord-py-blue.svg)](https://github.com/Rapptz/discord.py)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
-**Ren** is one of SFU Anime Club's mascots, and is also our main Discord bot. It is a
-forked version of [Red-DiscordBot v3](https://github.com/Cog-Creators/Red-DiscordBot/).
+**Ren** is one of SFU Anime Club's mascots, and is also our main Discord bot. It is a forked version of [Red-DiscordBot v3](https://github.com/Cog-Creators/Red-DiscordBot/).    
 We have made changes to suit our needs.
 
 # Contribute
-We welcome changes that benefit the server as a whole! Please feel free to discuss in
-`#feedback` on the Discord server about your ideas.
+We welcome changes that benefit the server as a whole! Please feel free to submit any suggestions via [SFU Anime Club feedback form](https://u.sfuani.me/feedback) about your ideas.
 
 # Installation
 Please consult the original forked README [here](README_upstream.md) for more details.


### PR DESCRIPTION
### Description of the changes

This PR:
- replaces `#feedback` with the form link as, well, that's what is used in this day and age.
- adds some minor formatting compatible with markdown so sentences aren't disconnected (is that like a relic of Red or something?)

Feel free to request changes or directly commit.