### PR TITLE
[AfterHours] Ignore messages from DMs

### DIFF
--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -338,6 +338,10 @@ class AfterHours(commands.Cog):
     @commands.Cog.listener("on_message")
     async def handleMessage(self, message: discord.Message):
         """Listener to save every AfterHours member's latest message's timestamp for purging purposes"""
+        # Ignore on DMs.
+        if not isinstance(message.channel, discord.TextChannel):
+            return
+
         # ignore bot messages
         if message.author.bot:
             return
@@ -347,6 +351,10 @@ class AfterHours(commands.Cog):
     @commands.Cog.listener("on_message_edit")
     async def handleMessageEdit(self, before: discord.Message, after: discord.Message):
         """Listener to save every AfterHours member's latest message's timestamp for purging purposes"""
+        # Ignore on DMs.
+        if not isinstance(after.channel, discord.TextChannel):
+            return
+
         # ignore bot messages
         if after.author.bot:
             return


### PR DESCRIPTION
This PR will fix the following errors that come up when you DM the bot:
```
Ignoring exception in on_message
Traceback (most recent call last):
  File "/home/ubuntu/github/renchan/lib/python3.8/site-packages/discord.py-1.7.3-py3.8.egg/discord/client.py", line 343, in _run_event
    await coro(*args, **kwargs)
  File "/home/ubuntu/github/renchan/Ren/cogs/afterhours/afterhours.py", line 345, in handleMessage
    await self.saveMessageTimestamp(message, message.created_at.timestamp())
  File "/home/ubuntu/github/renchan/Ren/cogs/afterhours/afterhours.py", line 329, in saveMessageTimestamp
    guildConfig = self.config.guild(message.guild)
  File "/home/ubuntu/github/renchan/lib/python3.8/site-packages/Red_DiscordBot-3.5.0.dev1-py3.8.egg/redbot/core/config.py", line 976, in guild
    return self._get_base_group(self.GUILD, str(guild.id))
AttributeError: 'NoneType' object has no attribute 'id'
```