### PR TITLE
[Welcome] Log user's tagged description on server leave

### DIFF
--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -46,6 +46,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
     @commands.Cog.listener()
     async def on_member_remove(self, leaveMember: discord.Member):
         await self.logServerLeave(leaveMember)
+        await self.sendLogUserDescription(leaveMember)
 
     # This async function is to look for if the welcome channel was removed
     @commands.Cog.listener()


### PR DESCRIPTION
Log user's tagged description when they leave the server.

### Description of the changes
#479 let the cog log users' tagged descriptions when they (re)join servers. This PR adds 1 function call to let the cog also log users' tagged descriptions when they leave their servers.