### PR TITLE
[AfterHours] Log last message times when doing auto-purge

### DIFF
--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -6,7 +6,7 @@ import os
 import re
 import logging
 import asyncio
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from datetime import datetime, timedelta
 import discord
 from discord.ext import commands
@@ -134,7 +134,7 @@ class AfterHours(commands.Cog):
                     continue
 
             # a list of members to be purged
-            inactiveMembers: List[discord.Member] = []
+            inactiveMembers: List[Tuple[discord.Member, datetime]] = []
 
             # check for inactive members based on a set inactive duration
             inactiveDuration: int = await autoPurgeInactiveDurationConfig()
@@ -160,10 +160,10 @@ class AfterHours(commands.Cog):
                         if memberId in lastMsgTimestamps:
                             lastMsgTime = datetime.fromtimestamp(lastMsgTimestamps[memberId])
                             if datetime.utcnow() - lastMsgTime > inactiveDurationTimeDelta:
-                                inactiveMembers.append(member)
+                                inactiveMembers.append((member, lastMsgTime))
                         else:
                             self.logger.debug(
-                                "User %s has no AfterHours message timestamp recorded, "
+                                "Member %s has no AfterHours message timestamp recorded, "
                                 "therefore assuming the last message timestamp is right now",
                                 memberId,
                             )
@@ -172,7 +172,7 @@ class AfterHours(commands.Cog):
             # purge inactive members
             try:
                 async with guildConfig.get_attr(KEY_LAST_MSG_TIMESTAMPS)() as lastMsgTimestamps:
-                    for inactiveMember in inactiveMembers:
+                    for inactiveMember, lastMsgTime in inactiveMembers:
                         # obtain information
                         memberName = inactiveMember.name
                         memberDiscriminator = inactiveMember.discriminator
@@ -180,11 +180,13 @@ class AfterHours(commands.Cog):
                         # purge this inactive member
                         await inactiveMember.remove_roles(ahRole, reason="AfterHours auto-purge")
                         self.logger.info(
-                            "Removed role %s from %s#%s (%s) due to inactivity",
+                            "Removed role %s from %s#%s (%s) due to inactivity. Last message time: %s (%s)",
                             ahRole.name,
                             memberName,
                             memberDiscriminator,
                             memberId,
+                            lastMsgTime.timestamp(),
+                            lastMsgTime.strftime("%d/%m/%Y %H:%M:%S"),
                         )
                         # clean up dict entry for this member
                         del lastMsgTimestamps[memberId]


### PR DESCRIPTION
## Details.
As detailed in #492.

## Implementation notes
We save `datetime` objects because timestamps values may be updated while we are moving from one `async with` block to the next.

## Issues
This resolves #492.
Also, though related, this should not cause conflicts with #494, and vice versa.