### PR TITLE
[Respects] Wrap `filter` with `list` when obtaining the list of all respect-paid non-`None` members

### DIFF
--- a/cogs/respects/respects.py
+++ b/cogs/respects/respects.py
@@ -300,8 +300,10 @@ class Respects(commands.Cog):
 
             confUserIds = chData[KEY_USERS]
             currentGuild: discord.Guild = ctx.guild
-            members = filter(
-                lambda member: member, (currentGuild.get_member(uid) for uid in confUserIds)
+            members = list(
+                filter(
+                    lambda member: member, (currentGuild.get_member(uid) for uid in confUserIds)
+                )
             )
 
             message = "{memberNames} {haveHas} paid their respects {heartEmote}".format(


### PR DESCRIPTION
## Cog
`Respects`.

## Changes
Wrap `filter` with `list` when obtaining the list of all respect-paid non-`None` members. This is to avoid applying `len()` on a `filter` object because it is an iterator, not a `list`.

The following stack trace was reported before this PR:
```
Exception in command 'f'
Traceback (most recent call last):
  File "/home/ubuntu/github/renchan/lib/python3.8/site-packages/discord.py-1.7.3-py3.8.egg/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/github/renchan/Ren/cogs/respects/respects.py", line 70, in plusF
    await self.payRespects(ctx)
  File "/home/ubuntu/github/renchan/Ren/cogs/respects/respects.py", line 309, in payRespects
    haveHas=("has" if len(members) == 1 else "have"),
TypeError: object of type 'filter' has no len()

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/github/renchan/lib/python3.8/site-packages/discord.py-1.7.3-py3.8.egg/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/home/ubuntu/github/renchan/lib/python3.8/site-packages/discord.py-1.7.3-py3.8.egg/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/ubuntu/github/renchan/lib/python3.8/site-packages/discord.py-1.7.3-py3.8.egg/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: object of type 'filter' has no len()
```
This PR addresses the exception reported in the log section above.