### PR TITLE
[Tags] Correct type-hints and docstring

### DIFF
--- a/cogs/tags/helpers.py
+++ b/cogs/tags/helpers.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .constants import COLOUR_BLURPLE
 from .data import TagAlias, TagInfo
 
@@ -6,7 +8,7 @@ from redbot.core.utils import AsyncIter, chat_formatting
 
 
 async def createSimplePages(
-    items: [str], embedTitle: str = "", embedAuthor: discord.Member = None
+    items: List[str], embedTitle: str = "", embedAuthor: discord.Member = None
 ):
     """Create embed pages for the redbot menu coroutine.
 
@@ -17,17 +19,17 @@ async def createSimplePages(
 
     Parameters
     ----------
-    items: [ str ]
+    items: List[ str ]
         A list of strings you wish to display to the user.
     embedTitle: Optional[ str ]
         The title for all the embed pages
-    embedAuthor : Optional[ discord.Member ]
+    embedAuthor: Optional[ discord.Member ]
         The author. If passed in, it will set the footer author's name and
         avatar
 
     Returns
     -------
-    [ discord.Embed ]
+    List[ discord.Embed ]
         A list of `discord.Embed`s, which can be passed directly into Red's
         menu coroutine.
     """


### PR DESCRIPTION
Correct some type-hints and docstring. Similar to what we did in #503. Not entirely sure if the order of imports is good.

## Description of the changes
- Use `typing.List` to address Pylance warning.
- Small changes in docstring to match the change above.
