### PR TITLE
[Mutes] Allow mods to mute, regardless of hierarchy

### DIFF
--- a/redbot/cogs/mutes/mutes.py
+++ b/redbot/cogs/mutes/mutes.py
@@ -190,6 +190,7 @@ class Mutes(VoiceMutes, commands.Cog, metaclass=CompositeMetaClass):
         self, guild: discord.Guild, mod: discord.Member, user: discord.Member
     ):
         is_special = mod == guild.owner or await self.bot.is_owner(mod)
+        is_special |= await self.bot.is_mod(mod)
         return mod.top_role > user.top_role or is_special
 
     async def _handle_automatic_unmute(self):


### PR DESCRIPTION
We want moderators to be able to mute people, regardless of the role hierarchy. This is because we have coloured roles.

I opted to not tack it on the end of the last line so it's easier to resolve merge conflicts should they arise in the future.