### PR TITLE
[Highlight] Use ID-based guild-wide denylist

### DIFF
--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -644,7 +644,7 @@ class Highlight(commands.Cog):
 
         guildConfig = self.config.guild(msg.channel.guild)
         # Prevent messages in a denylist channel from triggering highlight words
-        if msg.channel.name in await guildConfig.get_attr(KEY_CHANNEL_DENYLIST)():
+        if msg.channel.id in await guildConfig.get_attr(KEY_CHANNEL_DENYLIST)():
             self.logger.debug("Message is from a denylist channel, returning")
             return
 

--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -26,7 +26,7 @@ KEY_TIMEOUT = "timeout"
 KEY_WORDS = "words"
 KEY_WORDS_IGNORE = "ignoreWords"
 KEY_CHANNEL_IGNORE = "userIgnoreChannelID"
-KEY_CHANNEL_DENYLIST = "denylistChannels"
+KEY_CHANNEL_DENYLIST = "denylistChannelID"
 
 BASE_GUILD_MEMBER = {
     KEY_BLACKLIST: [],


### PR DESCRIPTION
### Description of the changes
This PR resolves #384 by doing the following:
- Change the config key to `denylistChannelID`. This is a breaking change in that all previous denylist channels will be removed.
- Change the `add`, `remove`, and `list` commands to use IDs.
- Change the listener to check for IDs.

Note that this is a **__breaking change__**:
- Since the Config mapping has changed, any channels in the denylist will need to be re-added!
- The AfterHours cog may also need to be adjusted to pass in the `discord.TextChannel` object. This will be checked and addressed in a subsequent PR if need be.