### PR TITLE
[QRChecker] Add guild-wide toggle command

### DIFF
--- a/cogs/qrchecker/qrchecker.py
+++ b/cogs/qrchecker/qrchecker.py
@@ -17,9 +17,8 @@ from redbot.core.utils.chat_formatting import pagify
 
 KEY_ENABLED = "enabled"
 
-BASE_GUILD = {
-    KEY_ENABLED: False
-}
+BASE_GUILD = {KEY_ENABLED: False}
+
 
 class QRChecker(commands.Cog):
     """A QR code checker for attachments"""

--- a/cogs/qrchecker/qrchecker.py
+++ b/cogs/qrchecker/qrchecker.py
@@ -36,6 +36,11 @@ class QRChecker(commands.Cog):
             return
         # check if enabled
         if not await self.config.guild(message.guild).get_attr(KEY_ENABLED)():
+            self.logger.debug(
+                "QR Checker disabled for %s (%s); return early",
+                message.guild.name,
+                message.guild.id,
+            )
             return
         if not message.attachments:
             self.logger.debug("No attachments, return early")
@@ -123,6 +128,7 @@ class QRChecker(commands.Cog):
     @commands.guild_only()
     @commands.admin_or_permissions(manage_guild=True)
     async def qrchecker(self, ctx: commands.Context):
+        """Configure QR code checker"""
         pass
 
     # toggle command
@@ -140,4 +146,4 @@ class QRChecker(commands.Cog):
             await ctx.send("QR code checking is now **disabled** for this guild.")
         else:
             await guildConfig.get_attr(KEY_ENABLED).set(True)
-            await ctx.send("QR code checking is now **enabled ** for this guild.")
+            await ctx.send("QR code checking is now **enabled** for this guild.")

--- a/cogs/qrchecker/qrchecker.py
+++ b/cogs/qrchecker/qrchecker.py
@@ -11,10 +11,15 @@ import logging
 import discord
 from pyzbar.pyzbar import Decoded, decode
 from PIL import Image
-from redbot.core import commands
+from redbot.core import commands, Config
 from redbot.core.bot import Red
 from redbot.core.utils.chat_formatting import pagify
 
+KEY_ENABLED = "enabled"
+
+BASE_GUILD = {
+    KEY_ENABLED: False
+}
 
 class QRChecker(commands.Cog):
     """A QR code checker for attachments"""
@@ -22,10 +27,17 @@ class QRChecker(commands.Cog):
     def __init__(self, bot: Red):
         self.bot = bot
         self.logger = logging.getLogger("red.luicogs.QRChecker")
+        self.config = Config.get_conf(self, identifier=5842647, force_registration=True)
+        self.config.register_guild(**BASE_GUILD)
 
     @commands.Cog.listener("on_message")
     async def listener(self, message: discord.Message):
         """Find QR code in message attachments"""
+        if not message.guild:
+            return
+        # check if enabled
+        if not await self.config.guild(message.guild).get_attr(KEY_ENABLED)():
+            return
         if not message.attachments:
             self.logger.debug("No attachments, return early")
             return
@@ -107,3 +119,26 @@ class QRChecker(commands.Cog):
                     else:
                         await ctx.send(textToSend, allowed_mentions=discord.AllowedMentions.none())
                     sentMessages += 1
+
+    @commands.group(name="qrchecker", aliases=["qr"])
+    @commands.guild_only()
+    @commands.admin_or_permissions(manage_guild=True)
+    async def qrchecker(self, ctx: commands.Context):
+        pass
+
+    # toggle command
+    @qrchecker.command(name="toggle")
+    async def qrcheckerToggle(self, ctx: commands.Context):
+        """Toggle QR code checking"""
+        guild = ctx.guild
+        if not guild:
+            return
+        guildConfig = self.config.guild(guild)
+
+        enabled = await guildConfig.get_attr(KEY_ENABLED)()
+        if enabled:
+            await guildConfig.get_attr(KEY_ENABLED).set(False)
+            await ctx.send("QR code checking is now **disabled** for this guild.")
+        else:
+            await guildConfig.get_attr(KEY_ENABLED).set(True)
+            await ctx.send("QR code checking is now **enabled ** for this guild.")


### PR DESCRIPTION
## Summary
Add a command to toggle whether QR codes should be checked in a guild/server.

## Description of the changes
Add:
- `[p]qrchecker`: a command group.
  - Alias: `[p]qr`.
  - Permission: Admin or has `MANAGE_GUILD`.
- `[p]qrchecker toggle`: toggle the QR checker on and off for a guild.

By default QR checking is not enabled.

## Related issues
This resolves #505.