### PR TITLE
[Welcome] Add user mention to no-DM welcome log

### DIFF
--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -124,10 +124,9 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
                 LOGGER.error(errorMsg)
                 if guildData[KEY_LOG_JOIN_ENABLED] and not test and channel:
                     await channel.send(
-                        ":bangbang: ``Server Welcome:`` User "
+                        f":bangbang: ``Server Welcome:`` User {newUser.mention} "
                         f"{newUser.name}#{newUser.discriminator} "
-                        f"({newUser.id}) has joined. Could not send "
-                        "DM!"
+                        f"({newUser.id}) has joined. Could not send DM!"
                     )
                     await channel.send(errorMsg)
             else:


### PR DESCRIPTION
## Summary
Add user mention to the `Server Welcome` message that is posted when DMs cannot be sent to the new user.

## Description of the changes
Add `{newUser.mention}` in welcome message in the `except` block.

## Related issues
This supplements #507.
