### PR TITLE
[QRChecker] Limit to QR codes only

### DIFF
--- a/cogs/qrchecker/info.json
+++ b/cogs/qrchecker/info.json
@@ -4,7 +4,7 @@
     "short" : "Scan image attachments for QR codes, and post its contents",
     "description" : "This cog scans for QR codes in image attachments, and posts their contents in a reply.",
     "hidden": false,
-    "install_msg" : "Thanks for installing the QRChecker cog. You may need to install the `zbar` shared library in your machine. Please see https://pypi.org/project/pyzbar/ for more details. There is nothing to configure, just load the cog and you're good to go!",
+    "install_msg" : "Thanks for installing the QRChecker cog. You may need to install the `zbar` shared library in your machine. Please see https://pypi.org/project/pyzbar/ for more details. By default, the cog disables QR code scanning on a per-guild basis until explicitly enabled. You may use `[p]qrchecker toggle` to enable the behaviour for a guild.",
     "requirements" : ["pyzbar", "Pillow"],
     "tags" : ["qrcode", "image"],
     "end_user_data_statement": "This cog does not store user-specific settings."

--- a/cogs/qrchecker/qrchecker.py
+++ b/cogs/qrchecker/qrchecker.py
@@ -9,7 +9,7 @@ from typing import List
 import logging
 
 import discord
-from pyzbar.pyzbar import Decoded, decode
+from pyzbar.pyzbar import Decoded, decode, ZBarSymbol
 from PIL import Image
 from redbot.core import commands, Config
 from redbot.core.bot import Red
@@ -58,7 +58,7 @@ class QRChecker(commands.Cog):
             try:
                 fp = io.BytesIO(await attachment.read())
                 image = Image.open(fp)
-                codes: List[Decoded] = decode(image)
+                codes: List[Decoded] = decode(image, symbols=[ZBarSymbol.QRCODE])
                 self.logger.debug("Found %s codes", len(codes))
             except Exception:
                 self.logger.error("Couldn't check file.", exc_info=True)


### PR DESCRIPTION
## Summary
This PR lets `QRChecker` give results for QR codes only.

## Description of the changes
Specify `ZBarSymbol.QRCODE` for cog `QRChecker`.

## Linked issues
This resolves #506.