### PR TITLE
[QRChecker] Skip empty messages and use `box`

### DIFF
--- a/cogs/qrchecker/qrchecker.py
+++ b/cogs/qrchecker/qrchecker.py
@@ -13,7 +13,7 @@ from pyzbar.pyzbar import Decoded, decode, ZBarSymbol
 from PIL import Image
 from redbot.core import commands, Config
 from redbot.core.bot import Red
-from redbot.core.utils.chat_formatting import pagify
+from redbot.core.utils.chat_formatting import box, pagify
 
 KEY_ENABLED = "enabled"
 
@@ -90,7 +90,7 @@ class QRChecker(commands.Cog):
                     contents = data
                 msg = (
                     f"Found a QR code from {message.author.mention}, "
-                    f"the contents are: ```{contents}```"
+                    f"the contents are: {box(contents)}"
                 )
                 await message.reply(
                     msg, mention_author=False, allowed_mentions=discord.AllowedMentions.none()
@@ -107,9 +107,9 @@ class QRChecker(commands.Cog):
                         self.logger.debug("No data in QR code.")
                         continue
                     if len(data) > 1990:
-                        contents = f"```{data[:1990]}...```"
+                        contents = f"{box(data[:1990])}..."
                     else:
-                        contents = f"```{data}```"
+                        contents = f"{box(data)}"
                     pages.append(contents)
                     has_data |= True
 

--- a/cogs/qrchecker/qrchecker.py
+++ b/cogs/qrchecker/qrchecker.py
@@ -96,7 +96,7 @@ class QRChecker(commands.Cog):
                     msg, mention_author=False, allowed_mentions=discord.AllowedMentions.none()
                 )
             else:
-                has_data = False
+                hasData = False
                 pages: List[str] = []
                 pages.append(
                     f"Found several QR codes from {message.author.mention}, their contents are:"
@@ -111,14 +111,14 @@ class QRChecker(commands.Cog):
                     else:
                         contents = f"{box(data)}"
                     pages.append(contents)
-                    has_data |= True
+                    hasData |= True
+
+                if not hasData:
+                    self.logger.debug("No data in %s QR codes.", numQrCodes)
+                    return
 
                 firstMessage = True
                 sentMessages = 0
-
-                if not has_data:
-                    self.logger.debug("No data in %s QR codes.", numQrCodes)
-                    return
 
                 ctx = await self.bot.get_context(message)
                 for textToSend in pagify("\n".join(pages), escape_mass_mentions=True):

--- a/cogs/qrchecker/qrchecker.py
+++ b/cogs/qrchecker/qrchecker.py
@@ -81,6 +81,9 @@ class QRChecker(commands.Cog):
             if numQrCodes == 1:
                 code = codes[0]
                 data = code.data.decode()
+                if len(data) == 0:
+                    self.logger.debug("No data in QR code.")
+                    return
                 if len(data) > 1900:
                     contents = f"{data[:1900]}..."
                 else:
@@ -93,20 +96,29 @@ class QRChecker(commands.Cog):
                     msg, mention_author=False, allowed_mentions=discord.AllowedMentions.none()
                 )
             else:
+                has_data = False
                 pages: List[str] = []
                 pages.append(
                     f"Found several QR codes from {message.author.mention}, their contents are:"
                 )
                 for code in codes:
                     data = code.data.decode()
+                    if len(data) == 0:
+                        self.logger.debug("No data in QR code.")
+                        continue
                     if len(data) > 1990:
                         contents = f"```{data[:1990]}...```"
                     else:
                         contents = f"```{data}```"
                     pages.append(contents)
+                    has_data |= True
 
                 firstMessage = True
                 sentMessages = 0
+
+                if not has_data:
+                    self.logger.debug("No data in %s QR codes.", numQrCodes)
+                    return
 
                 ctx = await self.bot.get_context(message)
                 for textToSend in pagify("\n".join(pages), escape_mass_mentions=True):


### PR DESCRIPTION
## Summary
- Skip empty messages (plus some debug logging when this happens).
- Remove hardcoded backticks and use `redbot.core.utils.chat_formatting.box()`.

## Linked issues
This resolves #517.