### PR TITLE
Fix docstring in `yourlsCmd.py`

### DIFF
--- a/cogs/yourlsClient/yourlsCmd.py
+++ b/cogs/yourlsClient/yourlsCmd.py
@@ -412,7 +412,7 @@ class YOURLS(commands.Cog):
 
     @settingsBase.command(name="signature", aliases=["sig"])
     async def sig(self, ctx: Context, signature: str):
-        """Configure the API endpoint for YOURLS.
+        """Configure the API signature for YOURLS.
 
         Parameters
         ----------


### PR DESCRIPTION
Closes #522 by fixing a typo in [`yourlsCmd.py`](https://github.com/SFUAnime/Ren/blob/V3/testing/cogs/yourlsClient/yourlsCmd.py#L415)


