### PR TITLE
[Tags] Fix rename command

### DIFF
--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -882,6 +882,7 @@ class Tags(commands.Cog):
             return
 
         db[newName] = deepcopy(db[oldName])
+        db[newName].name = newName
         del db[oldName]
 
         await self.config.put(location, db)

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -848,7 +848,7 @@ class Tags(commands.Cog):
             The new tag name.
         """
         try:
-            aliasCog = self.checkAliasCog(newName)
+            aliasCog = await self.checkAliasCog(ctx, newName)
             self.checkValidCommandName(newName)
         except RuntimeError as error:
             return await ctx.send(error)


### PR DESCRIPTION
This PR fixes the `[p]tag rename` command by doing the following:
- Add a missing await, as we were expecting to manipulate an object rather than a coroutine.
- Change the name of the actual tag to the new tag, or else when we try to access the newly renamed tag, it won't work: it will default to the old tag name instead.

Tested locally and working as expected now.