### PR TITLE
[Starboard] Separate blocked/allowed roles and channels

### DIFF
--- a/cogs/starboard/events.py
+++ b/cogs/starboard/events.py
@@ -172,6 +172,9 @@ class StarboardEvents:
             return
         allowed = starboard.check_roles(member)
         allowed |= starboard.check_channel(self.bot, channel)
+        # temp-fix https://github.com/TrustyJAID/Trusty-cogs/issues/269
+        allowed = starboard.check_roles(member) and starboard.check_channel(self.bot, channel)
+        # temp-fix end
         if not allowed:
             log.debug("User or channel not in allowlist")
             return

--- a/cogs/starboard/menus.py
+++ b/cogs/starboard/menus.py
@@ -46,6 +46,8 @@ class StarboardPages(menus.ListPageSource):
             stars_added=starboard.stars_added,
             selfstar=starboard.selfstar,
         )
+        # temp-fix https://github.com/TrustyJAID/Trusty-cogs/issues/269
+        """
         if starboard.blacklist:
             channels = [guild.get_channel(c) for c in starboard.blacklist]
             roles = [guild.get_role(r) for r in starboard.blacklist]
@@ -64,6 +66,28 @@ class StarboardPages(menus.ListPageSource):
                 msg += _("Allowed Channels: {chans}\n").format(chans=chans)
             if roles_str:
                 msg += _("Allowed roles: {roles}\n").format(roles=roles_str)
+        """
+        if starboard.blacklist_role_ids:
+            roles = [guild.get_role(r) for r in starboard.blacklist_role_ids]
+            if roles:
+                roles_str = humanize_list([r.mention for r in roles if r is not None])
+                msg += _("Blocked roles: {roles}\n").format(roles=roles_str)
+        if starboard.blacklist_channel_ids:
+            channels = [guild.get_channel(c) for c in starboard.blacklist_channel_ids]
+            if channels:
+                channels_str = humanize_list([c.mention for c in channels if c is not None])
+                msg += _("Blocked channels: {channels}\n").format(channels=channels_str)
+        if starboard.whitelist_role_ids:
+            roles = [guild.get_role(r) for r in starboard.whitelist_role_ids]
+            if roles:
+                roles_str = humanize_list([r.mention for r in roles if r is not None])
+                msg += _("Allowed roles: {roles}\n").format(roles=roles_str)
+        if starboard.whitelist_channel_ids:
+            channels = [guild.get_channel(c) for c in starboard.whitelist_channel_ids]
+            if channels:
+                channels_str = humanize_list([c.mention for c in channels if c is not None])
+                msg += _("Allowed channels: {channels}\n").format(channels=channels_str)
+        # temp-fix end
         count = 0
         embed.description = ""
         for page in pagify(msg, page_length=1024):


### PR DESCRIPTION
## Summary
This PR separates roles and channels in blacklist and whitelist by creating additional blacklists and whitelists for roles and channels, and lets the cog check if **both** the star-giver role **and** the channel are good before posting a starboard post. This should fix TrustyJAID/Trusty-cogs#261 and fix TrustyJAID/Trusty-cogs#269.

## Details

### Before this PR

When a post is starred, before posting to an appropriate starboard, the cog checks if either:
- The person who starred the post has a permitted role, or 
- The channel containing the starred post is a permitted channel.

A permitted role is a Discord role, and, satisfies at least one of these conditions (in that order*):
- Must be present in the whitelist if the whitelist contains any roles or channels. If the whitelist is empty,
- Must be absent from the blacklist if the blacklist contains any roles or channels.

The same logic applies for checking whether a Discord (text/category) channel is a permitted channel.

### After this PR

When a post is starred, before posting to an appropriate starboard, the cog checks if the person who starred the post has **both** a permitted role **and** the channel containing the starred post is a permitted channel.

A permitted role is a Discord role, and, satisfies all of these conditions (in that order*):
- Must be absent from the role blacklist if the blacklist contains any roles.
- Must be present in the role whitelist if the whitelist contains any roles.

The similar logic applies for checking whether a Discord (text/category) channel is a permitted channel. The only difference is that the channel blacklist/whitelist in which case contains only (zero or more) channels.

_\* The latter checks get evaluted only after the former checks have been evaluated._

## Notes

This PR only adds additional blacklists and whitelists for roles and channels, and still lets the cog add/remove channels/roles to/from its existing whitelist and blacklist. Also, a large portion of the existing code is kept undeleted. We can clean things up when there is a fix for TrustyJAID/Trusty-cogs#261 and TrustyJAID/Trusty-cogs#269 from upstream ([TrustyJAID/Trusty-cogs](https://github.com/TrustyJAID/Trusty-cogs)).