### PR TITLE
[Welcome] Add a greeting pool for returning users

### DIFF
--- a/cogs/welcome/constants.py
+++ b/cogs/welcome/constants.py
@@ -1,4 +1,4 @@
-import enum
+from enum import IntEnum
 
 KEY_DM_ENABLED = "dmEnabled"
 KEY_LOG_JOIN_ENABLED = "logJoinEnabled"
@@ -36,6 +36,6 @@ DEFAULT_GUILD = {
 }
 
 
-class GreetingPools(enum.IntEnum):
+class GreetingPools(IntEnum):
     DEFAULT = 0
     RETURNING = 1

--- a/cogs/welcome/constants.py
+++ b/cogs/welcome/constants.py
@@ -1,3 +1,5 @@
+import enum
+
 KEY_DM_ENABLED = "dmEnabled"
 KEY_LOG_JOIN_ENABLED = "logJoinEnabled"
 KEY_LOG_JOIN_CHANNEL = "logJoinChannel"
@@ -7,9 +9,11 @@ KEY_TITLE = "title"
 KEY_MESSAGE = "message"
 KEY_IMAGE = "image"
 KEY_GREETINGS = "greetings"
+KEY_RETURNING_GREETINGS = "returningGreetings"
 KEY_WELCOME_CHANNEL = "welcomeChannel"
 KEY_WELCOME_CHANNEL_ENABLED = "welcomeChannelSet"
 KEY_DESCRIPTIONS = "descriptions"
+KEY_JOINED_USER_IDS = "joinedUserIds"
 
 MAX_MESSAGE_LENGTH = 2000
 MAX_DESCRIPTION_LENGTH = 500
@@ -24,7 +28,14 @@ DEFAULT_GUILD = {
     KEY_MESSAGE: "Welcome to the server! Hope you enjoy your stay!",
     KEY_IMAGE: None,
     KEY_GREETINGS: {},
+    KEY_RETURNING_GREETINGS: {},
     KEY_WELCOME_CHANNEL: None,
     KEY_WELCOME_CHANNEL_ENABLED: False,
     KEY_DESCRIPTIONS: {},
+    KEY_JOINED_USER_IDS: [],
 }
+
+
+class GreetingPools(enum.IntEnum):
+    DEFAULT = 0
+    RETURNING = 1

--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -36,6 +36,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         """Gets a random message from a greeting pool.
 
         If no pool is specified, the default pool is used.
+        If the specified pool is empty, the default pool is used.
 
         Parameters
         ----------
@@ -52,6 +53,9 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
             key = KEY_RETURNING_GREETINGS
 
         greetings = await self.config.guild(guild).get_attr(key)()
+
+        if not greetings:
+            greetings = await self.config.guild(guild).get_attr(KEY_GREETINGS)()
 
         if not greetings:
             return "Welcome to the server {USER}"

--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -30,9 +30,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         self.config = Config.get_conf(self, identifier=5842647, force_registration=True)
         self.config.register_guild(**DEFAULT_GUILD)
 
-    async def getRandomMessage(
-        self, guild: discord.Guild, pool: Optional[GreetingPools] = None
-    ):
+    async def getRandomMessage(self, guild: discord.Guild, pool: Optional[GreetingPools] = None):
         """Gets a random message from a greeting pool.
 
         If no pool is specified, the default pool is used.

--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -6,7 +6,6 @@ import asyncio
 import discord
 import logging
 import random
-import typing
 
 from redbot.core import Config, checks, commands
 from redbot.core.bot import Red
@@ -14,6 +13,7 @@ from redbot.core.commands.context import Context
 from redbot.core.utils.chat_formatting import box, info, pagify, warning
 from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils import AsyncIter
+from typing import Optional
 
 from .constants import *
 from .helpers import createTagListPages
@@ -31,7 +31,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         self.config.register_guild(**DEFAULT_GUILD)
 
     async def getRandomMessage(
-        self, guild: discord.Guild, pool: typing.Optional[GreetingPools] = None
+        self, guild: discord.Guild, pool: Optional[GreetingPools] = None
     ):
         """Gets a random message from a greeting pool.
 
@@ -42,7 +42,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         ----------
         guild: discord.Guild
             The guild to get a random greeting from.
-        pool: typing.Optional[GreetingPools]
+        pool: Optional[GreetingPools]
             The pool to get a random greeting from.
         """
         if pool is None:
@@ -302,7 +302,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
 
     @checks.mod_or_permissions()
     @greetings.command(name="add")
-    async def greetAdd(self, ctx: Context, name: str, pool: typing.Optional[str] = None):
+    async def greetAdd(self, ctx: Context, name: str, pool: Optional[str] = None):
         """Add a new greeting entry.
 
         If no pool is specified, the entry will be added to the default greeting pool.
@@ -369,7 +369,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
 
     @checks.mod_or_permissions()
     @greetings.command(name="remove", aliases=["delete", "del", "rm"])
-    async def greetRemove(self, ctx: Context, name: str, pool: typing.Optional[str] = None):
+    async def greetRemove(self, ctx: Context, name: str, pool: Optional[str] = None):
         """Remove a greeting entry.
 
         If no pool is specified, the entry will be removed from the default greeting pool.
@@ -420,7 +420,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
 
     @checks.mod_or_permissions()
     @greetings.command(name="list", aliases=["ls"])
-    async def greetList(self, ctx: Context, pool: typing.Optional[str] = None):
+    async def greetList(self, ctx: Context, pool: Optional[str] = None):
         """List all greetings on the server.
 
         If no pool is specified, those from the default pool will be listed.

--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -33,6 +33,17 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
     async def getRandomMessage(
         self, guild: discord.Guild, pool: typing.Optional[GreetingPools] = None
     ):
+        """Gets a random message from a greeting pool.
+
+        If no pool is specified, the default pool is used.
+
+        Parameters
+        ----------
+        guild: discord.Guild
+            The guild to get a random greeting from.
+        pool: typing.Optional[GreetingPools]
+            The pool to get a random greeting from.
+        """
         if pool is None:
             pool = GreetingPools.DEFAULT
 
@@ -75,6 +86,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         return
 
     async def addToJoinedUserIds(self, newUser: discord.Member):
+        """Adds the user's id to the list of joined users."""
         async with self.config.guild(newUser.guild).get_attr(
             KEY_JOINED_USER_IDS
         )() as joinedUserIds:
@@ -82,9 +94,11 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
                 joinedUserIds.append(newUser.id)
 
     async def isReturningUser(self, user: discord.Member):
+        """Checks if the user is a returning user."""
         return user.id in await self.config.guild(user.guild).get_attr(KEY_JOINED_USER_IDS)()
 
     async def sendWelcomeMessageChannel(self, newUser: discord.Member):
+        """Sends a welcome message to the welcome channel if it is set."""
         guild = newUser.guild
         channelID = await self.config.guild(guild).get_attr(KEY_WELCOME_CHANNEL)()
         isSet = await self.config.guild(guild).get_attr(KEY_WELCOME_CHANNEL_ENABLED)()
@@ -254,12 +268,12 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
     @checks.mod_or_permissions()
     @greetings.command(name="channel")
     async def welcomeChannelSet(self, ctx: Context, channel: discord.TextChannel = None):
-        """
-        Set the welcome channel
+        """Set the welcome channel
 
         Parameters:
         -----------
-        channel: The text channel to set welcome's to. If not passed anything, will remove the welcome channel
+        channel: discord.TextChannel
+            The text channel to set welcome's to. If not passed anything, will remove the welcome channel
         """
         if not channel:
             # channel == None
@@ -276,14 +290,21 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
     @checks.mod_or_permissions()
     @greetings.command(name="add")
     async def greetAdd(self, ctx: Context, name: str, pool: typing.Optional[str] = None):
-        """
-        Add a new greeting
+        """Add a new greeting entry.
 
-        Including {USER} in the message will have that replaced with a ping to the new user
+        If no pool is specified, the entry will be added to the default greeting pool.
+        I will ask for the greeting message after you run this command.
+
+        Including {USER} in the message will have that replaced with a ping to the new user.
 
         Parameters:
         -----------
-        name: name of the greeting
+        name: str
+            Name of the greeting
+        pool: str
+            A greeting pool to add to; leave blank for the default pool
+            - `default`: default pool, containing greetings that are sent to new users
+            - `returning`: pool of greetings that are sent to returning users
         """
 
         greetingPool = GreetingPools.DEFAULT
@@ -336,12 +357,18 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
     @checks.mod_or_permissions()
     @greetings.command(name="remove", aliases=["delete", "del", "rm"])
     async def greetRemove(self, ctx: Context, name: str, pool: typing.Optional[str] = None):
-        """
-        Remove a greeting
+        """Remove a greeting entry.
+
+        If no pool is specified, the entry will be removed from the default greeting pool.
 
         Parameters:
         -----------
-        name: name of the greeting to remove
+        name: str
+            Name of the greeting to remove
+        pool: str
+            A greeting pool to remove from; leave blank for the default pool
+            - `default`: default pool, containing greetings that are sent to new users
+            - `returning`: pool of greetings that are sent to returning users
         """
 
         greetingPool = GreetingPools.DEFAULT
@@ -381,8 +408,16 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
     @checks.mod_or_permissions()
     @greetings.command(name="list", aliases=["ls"])
     async def greetList(self, ctx: Context, pool: typing.Optional[str] = None):
-        """
-        List all greetings on the server
+        """List all greetings on the server.
+
+        If no pool is specified, those from the default pool will be listed.
+
+        Parameters:
+        -----------
+        pool: str
+            A greeting pool to list; leave blank for the default pool
+            - `default`: default pool, containing greetings that are sent to new users
+            - `returning`: pool of greetings that are sent to returning users
         """
 
         greetingPool = GreetingPools.DEFAULT

--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -267,7 +267,16 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
     @commands.guild_only()
     @checks.mod_or_permissions()
     async def greetings(self, ctx: Context):
-        """Server greetings message settings."""
+        """Server greetings message settings.
+
+        Greetings are seperated by pools.
+        A pool can be specified as an extra argument for subcommands under this command.
+        If not specified, the default pool will be used.
+
+        Currently available greeting pools are:
+        - `default`: default pool, containing greetings that are sent to new users
+        - `returning`: pool of greetings that are sent to returning users
+        """
 
     @checks.mod_or_permissions()
     @greetings.command(name="channel")

--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -43,9 +43,6 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
         pool: Optional[GreetingPools]
             The pool to get a random greeting from.
         """
-        if pool is None:
-            pool = GreetingPools.DEFAULT
-
         key = KEY_GREETINGS
         if pool == GreetingPools.RETURNING:
             key = KEY_RETURNING_GREETINGS


### PR DESCRIPTION
## Summary

This PR creates a separate pool containing the greeting entries for those who rejoin servers. When it happens, the returning member will get a random message pulled out from the said greeting pool.

Also this PR refactors some docstring. Multiple docstring changes are done in a separate commit, if that helps viewing Git diffs.

## Details

The cog basically records user IDs when they enter a server for the first time, and uses the list of recorded user IDs to decide which greeting pool to use to send greetings to joining members.

There are 2 pools for now:
- `DEFAULT`: for greetings sent to new members.
- `RETURNING`: for greetings sent to returning members. If this pool is empty, the `DEFAULT` pool will be used.

### Commands

Extend one extra argument to some commands to accomodate this change:
- `[p]welcomeset greetings add <name> [pool]`
- `[p]welcomeset greetings remove <name> [pool]`
  - The switch from `del dict[key]` to `dict.pop(key, default)` is because `del` may throw a `KeyError`.
- `[p]welcomeset greetings list [pool]`
  - The pool's name is shown in the embed footer.

## Linked issues
This resolves #478.