### PR TITLE
[Welcome] Also remember members when they leave

### DIFF
--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -69,6 +69,8 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
     async def on_member_remove(self, leaveMember: discord.Member):
         await self.logServerLeave(leaveMember)
         await self.sendLogUserDescription(leaveMember)
+        # for those who were not encountered by the cog on joining the guild
+        await self.addToJoinedUserIds(leaveMember)
 
     # This async function is to look for if the welcome channel was removed
     @commands.Cog.listener()


### PR DESCRIPTION
## Summary

This PR makes the cog remember also members when they leave a guild, because the cog may be loaded while there are already members in the guild. This is just so that the checks for greeting pools still work well (i.e.,  `returning` pool without needing a member rejoining twice).
