### PR TITLE
[AfterHours] Handle missing permissions gracefully

### DIFF
--- a/cogs/afterhours/afterhours.py
+++ b/cogs/afterhours/afterhours.py
@@ -102,8 +102,19 @@ class AfterHours(commands.Cog):
                     creationTime = datetime.fromtimestamp(data["time"])
                     self.logger.debug("Time difference = %s", datetime.now() - creationTime)
                     if datetime.now() - creationTime > timedelta(seconds=DELETE_TIME):
-                        self.logger.info("Deleting channel %s (%s)", channel.name, channel.id)
-                        await channel.delete(reason="AfterHours purge")
+                        try:
+                            await channel.delete(reason="AfterHours purge")
+                        except discord.Forbidden:
+                            self.logger.error(
+                                "Could not delete channel %s (%s) because "
+                                "the bot doesn't have enough permissions!",
+                                channel.name,
+                                channel.id,
+                                exc_info=True,
+                            )
+                        else:
+                            self.logger.info("Deleted channel %s (%s)", channel.name, channel.id)
+
                         # Don't delete the ID here, this will be taken care of in
                         # the delete listener
                 for channelId in staleIds:


### PR DESCRIPTION
- If we don't have enough permissions to delete the channel, then emit
  an error message in the console for now and try again later instead of
  raising an exception and causing the background loop to stop working.

Tested manually by reloading the cog, logs look like the following:
```
[15:49:07] INFO     [red.luicogs.AfterHours] Unloading cog
           INFO     [red.luicogs.AfterHours] Unloading cog
           ERROR    [red.luicogs.AfterHours] Could not delete channel tc-2022-05-22_15-47-19 (978066173818200094) because the bot doesn't have enough permissions!
╭──────────────────────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────────────────────╮
│ /home/injabie3/github/Rin/Rin/cogs/afterhours/afterhours.py:106 in checkGarbageCollect                                                                            │
│ ❱ 106                             await channel.delete(reason="AfterHours purge")                                                                                 │
│ /home/injabie3/github/Rin/lib/python3.8/site-packages/discord.py-1.7.3-py3.8.egg/discord/abc.py:574 in delete                                                     │
│ ❱  574         await self._state.http.delete_channel(self.id, reason=reason)                                                                                      │
│ /home/injabie3/github/Rin/lib/python3.8/site-packages/discord.py-1.7.3-py3.8.egg/discord/http.py:248 in request                                                   │
│ ❱  248                             raise Forbidden(r, data)                                                                                                       │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Forbidden: 403 Forbidden (error code: 50001): Missing Access

```