### PR TITLE
[Birthday] Allow members to set their birthdays

### DIFF
--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -440,14 +440,7 @@ class Birthday(commands.Cog):
                 if month and day:
                     birthday = date(2020, month, day)
                     birthdayStr = "{0:%B} {0:%d}".format(birthday)
-                    replyMsg = (
-                        f"{headerGood}: "
-                        f"Your birthday is {birthdayStr}.\n"
-                        f"{italics('(For your privacy, this message will disappear shortly.)')}"
-                    )
-                    sentReplyMsg: discord.Message = await ctx.send(replyMsg)
-                    await asyncio.sleep(5)
-                    await sentReplyMsg.delete()
+                    ctx.author.send(f"{headerGood}: Your birthday is {birthdayStr}.")
                     return
 
         setSelfBirthdayCmd: commands.Command = self.setSelfBirthday
@@ -568,10 +561,12 @@ class Birthday(commands.Cog):
             await ctx.send(f"{headerBad}: Please enter a valid birthday!")
             return
 
-        sentReplyMsg: discord.Message = await ctx.send(
-            f"{headerGood}: "
-            f"Successfully set your birthday to {bold(birthdayStr)}.: "
-            f"{italics('(For your privacy, your birthday shown will be hidden shortly.)')}"
+        await ctx.author.send(
+            f"{headerGood}: Successfully set your birthday to {bold(birthdayStr)}."
+        )
+
+        await ctx.send(
+            f"{headerGood}: Successfully set your birthday."
         )
 
         self.logger.info(
@@ -581,9 +576,6 @@ class Birthday(commands.Cog):
             ctx.author.id,
             birthdayStr,
         )
-
-        await asyncio.sleep(5)
-        await sentReplyMsg.edit(content=(f"{headerGood}: Successfully set your birthday."))
 
         # Explicitly check to see if user should be added to role, if the month
         # and day just so happen to be the same as it is now.

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -600,7 +600,7 @@ class Birthday(commands.Cog):
             f"{bold('ONCE')} and {bold('ONLY IF')} their birthdays were not already set."
         )
         msgNotAllow = (
-            f"{headerGood}: " f"{bold('Disabled')}. Members cannot set their birthdays themselves."
+            f"{headerGood}: {bold('Disabled')}. Members cannot set their birthdays themselves."
         )
         guildConfig = self.config.guild(ctx.guild)
         allowSelfBirthdayConfig = guildConfig.get_attr(KEY_ALLOW_SELF_BDAY)

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -467,6 +467,7 @@ class Birthday(commands.Cog):
         await ctx.send(replyMsg)
 
     @me.command("set", aliases=["add"])
+    @commands.guild_only()
     async def setSelfBirthday(self, ctx: Context, month: int, day: int):
         """Set your birthday.
 
@@ -526,8 +527,7 @@ class Birthday(commands.Cog):
                 await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
             else:
                 raise Exception(
-                    "Error while accessing member's birthday config."
-                    "This should not happen!"
+                    "Error while accessing member's birthday config. This should not happen!"
                 )
         except ValueError:
             await ctx.send(f"{headerBad}\n" "Please enter a valid birthday!")

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -440,7 +440,7 @@ class Birthday(commands.Cog):
                 if month and day:
                     birthday = date(2020, month, day)
                     birthdayStr = "{0:%B} {0:%d}".format(birthday)
-                    ctx.author.send(f"{headerGood}: Your birthday is {birthdayStr}.")
+                    await ctx.author.send(f"{headerGood}: Your birthday is {birthdayStr}.")
                     return
 
         setSelfBirthdayCmd: commands.Command = self.setSelfBirthday

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -470,7 +470,7 @@ class Birthday(commands.Cog):
         administrator or a moderator in case you want to have your birthday erased and/or set.
 
         Specify your birth month and birth day in numbers.
-        
+
         For your privacy, you can delete the command message right away after sending it.
 
         Parameters
@@ -523,56 +523,57 @@ class Birthday(commands.Cog):
         try:
             birthday = date(2020, month, day)
             birthdayStr = "{0:%B} {0:%d}".format(birthday)
-
-            if birthdayConfig:
-                confirmationStr = (
-                    f"Are you sure you want to set your birthday to {spoiler(bold(birthdayStr))}? "
-                    "Only administrators and moderators can reset your birthday afterwards. "
-                    f"Type {bold('`yes`')} to confirm."
-                )
-
-                await ctx.author.send(f"{headerWarn}: {confirmationStr}")
-
-                def check(msg: discord.Message):
-                    return msg.author == ctx.author and msg.channel == ctx.author.dm_channel
-
-                try:
-                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
-                except asyncio.TimeoutError:
-                    # hide the birthday portion within the previous message
-                    await ctx.author.send(f"{headerBad}: You took too long. Not setting your birthday.")
-                    return
-
-                if response.content.lower() != "yes":
-                    await ctx.author.send(f"{headerBad}: Declined. Not setting your birthday.")
-                    return
-
-                await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(month)
-                await birthdayConfig.get_attr(KEY_BDAY_DAY).set(day)
-                await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
-            else:
-                raise Exception(
-                    "Error while accessing member's birthday config. This should not happen!"
-                )
         except ValueError:
             await ctx.send(f"{headerBad}: Please enter a valid birthday!")
             return
 
-        await ctx.author.send(
-            f"{headerGood}: Successfully set your birthday to {spoiler(bold(birthdayStr))}."
-        )
+        if birthdayConfig:
+            confirmationStr = (
+                f"Are you sure you want to set your birthday to {spoiler(bold(birthdayStr))}? "
+                "Only administrators and moderators can reset your birthday afterwards. "
+                f"Type {bold('`yes`')} to confirm."
+            )
 
-        self.logger.info(
-            "%s#%s (%s) added their birthday as %s",
-            ctx.author.name,
-            ctx.author.discriminator,
-            ctx.author.id,
-            birthdayStr,
-        )
+            await ctx.author.send(f"{headerWarn}: {confirmationStr}")
 
-        # Explicitly check to see if user should be added to role, if the month
-        # and day just so happen to be the same as it is now.
-        await self.checkBirthday()
+            def check(msg: discord.Message):
+                return msg.author == ctx.author and msg.channel == ctx.author.dm_channel
+
+            try:
+                response = await self.bot.wait_for("message", timeout=30.0, check=check)
+            except asyncio.TimeoutError:
+                # hide the birthday portion within the previous message
+                await ctx.author.send(
+                    f"{headerBad}: You took too long. Not setting your birthday."
+                )
+                return
+
+            if response.content.lower() != "yes":
+                await ctx.author.send(f"{headerBad}: Declined. Not setting your birthday.")
+                return
+
+            await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(month)
+            await birthdayConfig.get_attr(KEY_BDAY_DAY).set(day)
+            await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
+
+            await ctx.author.send(
+                f"{headerGood}: Successfully set your birthday to {spoiler(bold(birthdayStr))}."
+            )
+
+            self.logger.info(
+                "%s#%s (%s) added their birthday as %s",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                birthdayStr,
+            )
+
+            # explicitly check to see if user should be added to role, if the month
+            # and day just so happen to be the same as it is now.
+            await self.checkBirthday()
+            return
+
+        raise Exception("Error while accessing member's birthday config. This should not happen!")
 
     @_birthday.command(name="selfbirthday")
     @commands.guild_only()

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -454,6 +454,7 @@ class Birthday(commands.Cog):
         setSelfBirthdayCmdStr = (
             # pylint: disable=no-member
             f"`{ctx.clean_prefix}help {setSelfBirthdayCmd.qualified_name}`"
+            # pylint: enable=no-member
         )
 
         replyMsg = (

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -12,7 +12,7 @@ from redbot.core import Config, checks, commands, data_manager
 from redbot.core.commands.context import Context
 from redbot.core.utils import AsyncIter
 from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
-from redbot.core.utils.chat_formatting import bold, italics, pagify, spoiler, warning
+from redbot.core.utils.chat_formatting import bold, pagify, spoiler, warning
 from redbot.core.bot import Red
 from .constants import *
 
@@ -440,7 +440,10 @@ class Birthday(commands.Cog):
                 if month and day:
                     birthday = date(2020, month, day)
                     birthdayStr = "{0:%B} {0:%d}".format(birthday)
-                    await ctx.author.send(f"{headerGood}: Your birthday is {birthdayStr}.")
+                    await ctx.author.send(
+                        f"{headerGood}: Your birthday is "
+                        f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
+                    )
                     return
 
         setSelfBirthdayCmd: commands.Command = self.setSelfBirthday
@@ -529,9 +532,10 @@ class Birthday(commands.Cog):
 
         if birthdayConfig:
             confirmationStr = (
-                f"Are you sure you want to set your birthday to {spoiler(bold(birthdayStr))}? "
+                f"Are you sure you want to set your birthday to "
+                f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}? "
                 "Only administrators and moderators can reset your birthday afterwards. "
-                f"Type {bold('`yes`')} to confirm."
+                f"Type {bold('`yes`', escape_formatting=False)} to confirm."
             )
 
             await ctx.author.send(f"{headerWarn}: {confirmationStr}")
@@ -557,7 +561,8 @@ class Birthday(commands.Cog):
             await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
 
             await ctx.author.send(
-                f"{headerGood}: Successfully set your birthday to {spoiler(bold(birthdayStr))}."
+                f"{headerGood}: Successfully set your birthday to "
+                f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
             )
 
             self.logger.info(

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -441,7 +441,7 @@ class Birthday(commands.Cog):
                     birthday = date(2020, month, day)
                     birthdayStr = "{0:%B} {0:%d}".format(birthday)
                     replyMsg = (
-                        f"{headerGood}\n"
+                        f"{headerGood}: "
                         f"Your birthday is {birthdayStr}.\n"
                         f"{italics('(For your privacy, this message will disappear shortly.)')}"
                     )
@@ -458,7 +458,7 @@ class Birthday(commands.Cog):
         )
 
         replyMsg = (
-            f"{headerBad}\n"
+            f"{headerBad}: "
             "Your birthday in this server has not been set. "
             "Please contact an administrator/moderator, or, "
             "if it is allowed by the server's admins and/or "
@@ -487,7 +487,7 @@ class Birthday(commands.Cog):
 
         if not await self.config.guild(ctx.guild).get_attr(KEY_ALLOW_SELF_BDAY)():
             await ctx.send(
-                f"{headerBad}\n"
+                f"{headerBad}: "
                 "This function is not enabled. You cannot set your birthday. "
                 "Please let an administrator or a moderator know if you "
                 "believe this function should be enabled."
@@ -500,7 +500,7 @@ class Birthday(commands.Cog):
             birthDay = birthdayConfig.get_attr(KEY_BDAY_DAY)
             if birthMonth and birthDay and await birthMonth() and await birthDay():
                 await ctx.send(
-                    f"{headerBad}\n"
+                    f"{headerBad}: "
                     "Your birthday is already set. If you believe it is "
                     "incorrect, please contact an admin or a moderator."
                 )
@@ -510,7 +510,7 @@ class Birthday(commands.Cog):
 
         if not birthdayRoleId:
             await ctx.send(
-                f"{headerBad}\n"
+                f"{headerBad}: "
                 "This server is not configured, please let a server "
                 "administrator or moderator know."
             )
@@ -531,14 +531,14 @@ class Birthday(commands.Cog):
                     "Error while accessing member's birthday config. This should not happen!"
                 )
         except ValueError:
-            await ctx.send(f"{headerBad}\n" "Please enter a valid birthday!")
+            await ctx.send(f"{headerBad}: Please enter a valid birthday!")
             return
 
         birthdayStr = "{0:%B} {0:%d}".format(birthday)
 
         sentReplyMsg: discord.Message = await ctx.send(
-            f"{headerGood}\n"
-            f"Successfully set your birthday to {bold(birthdayStr)}.\n"
+            f"{headerGood}: "
+            f"Successfully set your birthday to {bold(birthdayStr)}.: "
             f"{italics('(For your privacy, your birthday shown will be hidden shortly.)')}"
         )
 
@@ -551,7 +551,7 @@ class Birthday(commands.Cog):
         )
 
         await asyncio.sleep(5)
-        await sentReplyMsg.edit(content=(f"{headerGood}\n" "Successfully set your birthday."))
+        await sentReplyMsg.edit(content=(f"{headerGood}: Successfully set your birthday."))
 
         # Explicitly check to see if user should be added to role, if the month
         # and day just so happen to be the same as it is now.
@@ -572,14 +572,12 @@ class Birthday(commands.Cog):
         headerGood = f":white_check_mark: {bold(fnTitle)}"
 
         msgAllow = (
-            f"{headerGood}\n"
-            f":white_check_mark: Enabled. Members can set their birthdays themselves "
+            f"{headerGood}: "
+            f"{bold('Enabled')}. Members can set their birthdays themselves "
             f"{bold('ONCE')} and {bold('ONLY IF')} their birthdays were not already set."
         )
         msgNotAllow = (
-            f"{headerGood}\n"
-            ":negative_squared_cross_mark: Disabled. Members cannot set their birthdays "
-            "themselves."
+            f"{headerGood}: " f"{bold('Disabled')}. Members cannot set their birthdays themselves."
         )
         guildConfig = self.config.guild(ctx.guild)
         allowSelfBirthdayConfig = guildConfig.get_attr(KEY_ALLOW_SELF_BDAY)

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -470,6 +470,8 @@ class Birthday(commands.Cog):
         administrator or a moderator in case you want to have your birthday erased and/or set.
 
         Specify your birth month and birth day in numbers.
+        
+        For your privacy, you can delete the command message right away after sending it.
 
         Parameters
         ----------
@@ -524,30 +526,25 @@ class Birthday(commands.Cog):
 
             if birthdayConfig:
                 confirmationStr = (
-                    f"Are you sure you want to set your birthday to {spoiler(birthdayStr)}? "
-                    "Only administrators and moderators can reset your birthday afterwards."
-                )
-                confirmationStrNoBirthday = (
-                    "Are you sure you want to set your birthday to the specified month and day? "
-                    "Only administrators and moderators can reset your birthday afterwards."
+                    f"Are you sure you want to set your birthday to {spoiler(bold(birthdayStr))}? "
+                    "Only administrators and moderators can reset your birthday afterwards. "
+                    f"Type {bold('`yes`')} to confirm."
                 )
 
-                sentReplyMsg = await ctx.send(f"{headerWarn}: {confirmationStr}")
+                await ctx.author.send(f"{headerWarn}: {confirmationStr}")
 
                 def check(msg: discord.Message):
-                    return msg.author == ctx.author and msg.channel == ctx.channel
+                    return msg.author == ctx.author and msg.channel == ctx.author.dm_channel
 
                 try:
                     response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
                     # hide the birthday portion within the previous message
-                    await sentReplyMsg.edit(content=f"{headerWarn}: {confirmationStrNoBirthday}")
-                    await ctx.send(f"{headerBad}: You took too long. Not setting your birthday.")
+                    await ctx.author.send(f"{headerBad}: You took too long. Not setting your birthday.")
                     return
 
                 if response.content.lower() != "yes":
-                    await sentReplyMsg.edit(content=f"{headerWarn}: {confirmationStrNoBirthday}")
-                    await ctx.send(f"{headerBad}: Declined. Not setting your birthday.")
+                    await ctx.author.send(f"{headerBad}: Declined. Not setting your birthday.")
                     return
 
                 await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(month)
@@ -562,11 +559,7 @@ class Birthday(commands.Cog):
             return
 
         await ctx.author.send(
-            f"{headerGood}: Successfully set your birthday to {bold(birthdayStr)}."
-        )
-
-        await ctx.send(
-            f"{headerGood}: Successfully set your birthday."
+            f"{headerGood}: Successfully set your birthday to {spoiler(bold(birthdayStr))}."
         )
 
         self.logger.info(

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -547,7 +547,7 @@ class Birthday(commands.Cog):
             ctx.author.name,
             ctx.author.discriminator,
             ctx.author.id,
-            birthday.strftime("%B %d"),
+            birthdayStr,
         )
 
         await asyncio.sleep(5)

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -451,7 +451,7 @@ class Birthday(commands.Cog):
                     return
 
         setSelfBirthdayCmd: commands.Command = self.setSelfBirthday
-        setSelfBirthdayCmdStr = (
+        helpSetSelfBirthdayCmdStr = (
             # pylint: disable=no-member
             f"`{ctx.clean_prefix}help {setSelfBirthdayCmd.qualified_name}`"
             # pylint: enable=no-member
@@ -463,7 +463,7 @@ class Birthday(commands.Cog):
             "Please contact an administrator/moderator, or, "
             "if it is allowed by the server's admins and/or "
             "moderators, try setting it yourself. Reference "
-            f"{setSelfBirthdayCmdStr} for the command syntax."
+            f"{helpSetSelfBirthdayCmdStr} for the command syntax."
         )
         await ctx.send(replyMsg)
 

--- a/cogs/birthday/constants.py
+++ b/cogs/birthday/constants.py
@@ -5,6 +5,7 @@ KEY_BDAY_USERS = "birthdayUsers"
 KEY_BDAY_MONTH = "birthdateMonth"
 KEY_BDAY_DAY = "birthdateDay"
 KEY_IS_ASSIGNED = "isAssigned"
+KEY_ALLOW_SELF_BDAY = "allowSelfBirthday"
 
 BASE_GUILD_MEMBER = {
     KEY_ADDED_BEFORE: False,
@@ -13,7 +14,11 @@ BASE_GUILD_MEMBER = {
     KEY_IS_ASSIGNED: False,
 }
 
-BASE_GUILD = {KEY_BDAY_CHANNEL: None, KEY_BDAY_ROLE: None}
+BASE_GUILD = {
+    KEY_BDAY_CHANNEL: None,
+    KEY_BDAY_ROLE: None,
+    KEY_ALLOW_SELF_BDAY: False,
+}
 
 CANNED_MESSAGES = [
     "Wow look, it's {}'s birthday today! Happy birthday, hope you have a good one!",


### PR DESCRIPTION
## Summary

This PR introduces a switch at admin/mod level that enables/disables the ability to set birthdays for members. If it is enabled, members can set their birthdays **once** and **only if** their birthdays were not set. Admins and mods still have access to existing commands that allow setting/removing birthdays at will.

This fixes #570.

## Details

### Command groups

This PR introduces a new command group `self` (i.e., `[p]birthday self`; aliases: `[p]birthday me`) allowing a server member to access his/her/their birthday info.

### Commands

This PR introduces 3 new commands:

#### `[p]birthday self get`

Aliases:
- `[p]birthday self show`
- `[p]birthday self display`

This command simply shows the birthday of the one who invoked the command, or a notice if no birthday was set.

For privacy, the message containing the birthday is sent via a DM. Only the error message for when there was no saved birthday for the user is shown in the server text channel where the command is invoked.

#### `[p]birthday self set <month> <day>`

Aliases:
- `[p]birthday self add <month> <day>`

This command lets whoever invoked the command to set his/her/their birthday, provided the birthday was not set before. If it were already set, only admins/mods can intervene (e.g., through `[p]birthday delete`).

For privacy, the message is sent via a DM. Confirmation/affirmation messages and timeout/yes/no checks are also done in DMs. Only invalid birthday error message is shown in the server text channel where the command is invoked.

#### `[p]birthday selfbirthday`

This command lets admins/mods allow/disallow members to set their birthdays themselves (i.e., via `[p]birthday self set`), and is `False` by default for every server. This command is a toggle command so there are no separate getter and setter.

## Testing done

Manual testing to check some functions involving DMs:
![image](https://user-images.githubusercontent.com/6735818/188334941-7b5b4f3e-f676-40a1-80a6-b17c8cbd6d08.png)

## Notes

- ~~Honestly I don't like seeing `mm/dd` but I tried to reason `yyyy/mm/dd` (less `yyyy`) just to cope with this.~~

## Linked issues

#570