### PR TITLE
[Birthday] Fix permission checks

### DIFF
--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -53,7 +53,6 @@ class Birthday(commands.Cog):
 
     @commands.group(name="birthday")
     @commands.guild_only()
-    @checks.mod_or_permissions(administrator=True)
     async def _birthday(self, ctx: Context):
         """Birthday role assignment settings."""
 
@@ -117,6 +116,7 @@ class Birthday(commands.Cog):
 
     @_birthday.command(name="test")
     @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
     async def test(self, ctx: Context):
         """Test at-mentions."""
         for msg in CANNED_MESSAGES:


### PR DESCRIPTION
## Summary

Fix permission check for `[p]birthday` that was missed out in #571. This PR makes the `[p]birthday` command accessible to everyone (just so `[p]birthday self` commands can work), but still keeps existing checks for mod/admin-required individual commands. The `test()` method was initially not with any checks, is now limited to mods/admins.

## Related issues

#571 