### PR TITLE
[CI] Temporarily disable Python `tox` tests on cogs

### DIFF
--- a/.github/workflows/temp_tests.yml
+++ b/.github/workflows/temp_tests.yml
@@ -1,0 +1,47 @@
+# This is a temporary tests workflow as we are catching up with upstream.
+# Please switch back to tests.yml as soon as we finish.
+
+name: Tests
+on:
+  pull_request:
+  push:
+  repository_dispatch:
+    types:
+      - dispatched_test
+
+env:
+  ref: ${{ github.event.client_payload.ref || '' }}
+
+jobs:
+    tox:
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          python_version:
+            - "3.8"
+          tox_env:
+            - style
+            - docs
+          include:
+            - tox_env: style
+              friendly_name: Style
+            - tox_env: docs
+              friendly_name: Docs
+        fail-fast: false
+      name: Tox - ${{ matrix.friendly_name }}
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            ref: ${{ env.ref }}
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python_version }}
+        - name: Install tox
+          run: |
+            python -m pip install --upgrade pip
+            pip install tox
+        - name: Tox test
+          env:
+            TOXENV: ${{ matrix.tox_env }}
+          run: tox


### PR DESCRIPTION
## Summary

Since our commits are not in good sync with upstream Red, this is a workaround for the moment to avoid test run failures whenever we receive a pull request.

This PR introduces a new workflow file that only activates `tox` for style and docs tests.