### PR TITLE
[WordFilter] Fix `_isAllFiltered` regex and add tests

### DIFF
--- a/cogs/wordfilter/testWordFilter.py
+++ b/cogs/wordfilter/testWordFilter.py
@@ -14,7 +14,7 @@ class TestHelperFunctions:
             ("I am cool", "am", "I `**` cool"),
             (
                 "https://discord.gg/testing123",
-                r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-z,A-Z,0-9]*",
+                r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-zA-Z0-9]*",
                 "https://`*********************`",
             ),
             (

--- a/cogs/wordfilter/testWordFilter.py
+++ b/cogs/wordfilter/testWordFilter.py
@@ -21,7 +21,7 @@ class TestHelperFunctions:
             ),
             (
                 "https://discord.gg/YcW3AtX",
-                r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-z,A-Z,0-9]*",
+                r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[A-Za-z0-9,]*",
                 "https://discord.gg/YcW3AtX",
             ),
         ],

--- a/cogs/wordfilter/testWordFilter.py
+++ b/cogs/wordfilter/testWordFilter.py
@@ -1,6 +1,6 @@
 import pytest
 from .wordfilter import (
-    _censorMatch,
+    _filterWord,
     _isAllFiltered,
     _isOneWord,
 )
@@ -24,9 +24,14 @@ class TestHelperFunctions:
             ),
         ],
     )
-    def testCensorMatch(self, inputPhrase, toFilter, result):
-        filteredPhrase = re.sub(toFilter, _censorMatch, inputPhrase, flags=re.IGNORECASE)
+    def testFilterWordSingle(self, inputPhrase, toFilter, result):
+        filteredPhrase = _filterWord([toFilter], inputPhrase)
         assert result == filteredPhrase
+
+    @pytest.mark.parametrize("inputPhrase", ["https://discord.gg/testing123"])
+    def testFilterWordNoRegexFilter(self, inputPhrase):
+        filteredPhrase = _filterWord([], inputPhrase)
+        assert filteredPhrase == inputPhrase
 
     @pytest.mark.parametrize(
         ["inputStr", "result"],

--- a/cogs/wordfilter/testWordFilter.py
+++ b/cogs/wordfilter/testWordFilter.py
@@ -6,23 +6,26 @@ from .wordfilter import (
 )
 import re
 
+
 class TestHelperFunctions:
     @pytest.mark.parametrize(
         ["inputPhrase", "toFilter", "result"],
         [
-            ("I am cool",
-             "am",
-             "I `**` cool"),
-            ("https://discord.gg/testing123",
-             r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-z,A-Z,0-9]*",
-             "https://`*********************`"),
-            ("https://discord.gg/YcW3AtX",
-             r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-z,A-Z,0-9]*",
-             "https://discord.gg/YcW3AtX"),
-        ])
+            ("I am cool", "am", "I `**` cool"),
+            (
+                "https://discord.gg/testing123",
+                r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-z,A-Z,0-9]*",
+                "https://`*********************`",
+            ),
+            (
+                "https://discord.gg/YcW3AtX",
+                r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-z,A-Z,0-9]*",
+                "https://discord.gg/YcW3AtX",
+            ),
+        ],
+    )
     def testCensorMatch(self, inputPhrase, toFilter, result):
-        filteredPhrase = re.sub(
-            toFilter, _censorMatch, inputPhrase, flags=re.IGNORECASE)
+        filteredPhrase = re.sub(toFilter, _censorMatch, inputPhrase, flags=re.IGNORECASE)
         assert result == filteredPhrase
 
     @pytest.mark.parametrize(
@@ -30,7 +33,8 @@ class TestHelperFunctions:
         [
             ("test", True),
             ("another phrase", False),
-        ])
+        ],
+    )
     def testIsOneWord(self, inputStr, result):
         assert _isOneWord(inputStr) == result
 
@@ -44,6 +48,7 @@ class TestHelperFunctions:
             ("* ** ***", True),
             (" *** **** ", True),
             ("**** ** ****", True),
-        ])
+        ],
+    )
     def testIsAllFiltered(self, inputStr, result):
         assert _isAllFiltered(inputStr) == result

--- a/cogs/wordfilter/testWordFilter.py
+++ b/cogs/wordfilter/testWordFilter.py
@@ -1,0 +1,49 @@
+import pytest
+from .wordfilter import (
+    _censorMatch,
+    _isAllFiltered,
+    _isOneWord,
+)
+import re
+
+class TestHelperFunctions:
+    @pytest.mark.parametrize(
+        ["inputPhrase", "toFilter", "result"],
+        [
+            ("I am cool",
+             "am",
+             "I `**` cool"),
+            ("https://discord.gg/testing123",
+             r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-z,A-Z,0-9]*",
+             "https://`*********************`"),
+            ("https://discord.gg/YcW3AtX",
+             r"(discord.gg\/)(?!YcW3AtX)(?!MmpqtqD)[a-z,A-Z,0-9]*",
+             "https://discord.gg/YcW3AtX"),
+        ])
+    def testCensorMatch(self, inputPhrase, toFilter, result):
+        filteredPhrase = re.sub(
+            toFilter, _censorMatch, inputPhrase, flags=re.IGNORECASE)
+        assert result == filteredPhrase
+
+    @pytest.mark.parametrize(
+        ["inputStr", "result"],
+        [
+            ("test", True),
+            ("another phrase", False),
+        ])
+    def testIsOneWord(self, inputStr, result):
+        assert _isOneWord(inputStr) == result
+
+    @pytest.mark.parametrize(
+        ["inputStr", "result"],
+        [
+            ("test", False),
+            ("***** phrase", False),
+            ("**** **another** **phrase**", False),
+            ("F*CKING B*LLSH*T", False),
+            ("* ** ***", True),
+            (" *** **** ", True),
+            ("**** ** ****", True),
+        ])
+    def testIsAllFiltered(self, inputStr, result):
+        assert _isAllFiltered(inputStr) == result

--- a/cogs/wordfilter/testWordFilter.py
+++ b/cogs/wordfilter/testWordFilter.py
@@ -1,10 +1,12 @@
+import re
+
 import pytest
+
 from .wordfilter import (
     _filterWord,
     _isAllFiltered,
     _isOneWord,
 )
-import re
 
 
 class TestHelperFunctions:

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -623,7 +623,7 @@ class WordFilter(commands.Cog):  # pylint: disable=too-many-instance-attributes
 
 def _censorMatch(matchobj: re.Match):
     matchLength = len(matchobj.group(0))
-    return "`" + ("*" * matchLength) + "`"
+    return f"`{'*' * matchLength}`"
 
 
 def _filterWord(words: List, string: str):

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -621,12 +621,11 @@ class WordFilter(commands.Cog):  # pylint: disable=too-many-instance-attributes
             await ctx.send("Sorry you have no filtered words in **{}**".format(ctx.guild.name))
 
 
-def _censorMatch(matchobj: re.Match):
-    matchLength = len(matchobj.group(0))
-    return f"`{'*' * matchLength}`"
-
-
 def _filterWord(words: List, string: str):
+    def _censorMatch(matchobj: re.Match):
+        matchLength = len(matchobj.group(0))
+        return f"`{'*' * matchLength}`"
+
     numWords = len(words)
     if not words:
         # if no filters added yet, do nothing

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -621,7 +621,7 @@ class WordFilter(commands.Cog):  # pylint: disable=too-many-instance-attributes
             await ctx.send("Sorry you have no filtered words in **{}**".format(ctx.guild.name))
 
 
-def _filterWord(words: List, string: str):
+def _filterWord(words: List[str], string: str):
     def _censorMatch(matchobj: re.Match):
         matchLength = len(matchobj.group(0))
         return f"`{'*' * matchLength}`"

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -647,6 +647,6 @@ def _isAllFiltered(string):
     words = string.split()
     cnt = 0
     for word in words:
-        if bool(re.search("[*]+", word)):
+        if bool(re.search(r"^\*+$", word, flags=re.MULTILINE)):
             cnt += 1
     return cnt == len(words)

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -647,6 +647,6 @@ def _isAllFiltered(string: str):
     words = string.split()
     cnt = 0
     for word in words:
-        if bool(re.search(r"^\*+$", word, flags=re.MULTILINE)):
+        if all(map(lambda c: c == "*", word)):
             cnt += 1
     return cnt == len(words)

--- a/cogs/wordfilter/wordfilter.py
+++ b/cogs/wordfilter/wordfilter.py
@@ -4,6 +4,7 @@ deleting a message.
 """
 import re
 from threading import Lock
+from typing import List
 import logging
 import os
 import asyncio
@@ -620,12 +621,12 @@ class WordFilter(commands.Cog):  # pylint: disable=too-many-instance-attributes
             await ctx.send("Sorry you have no filtered words in **{}**".format(ctx.guild.name))
 
 
-def _censorMatch(matchobj):
+def _censorMatch(matchobj: re.Match):
     matchLength = len(matchobj.group(0))
     return "`" + ("*" * matchLength) + "`"
 
 
-def _filterWord(words, string):
+def _filterWord(words: List, string: str):
     numWords = len(words)
     if not words:
         # if no filters added yet, do nothing
@@ -639,11 +640,11 @@ def _filterWord(words, string):
         return re.sub(regex, _censorMatch, string, flags=re.IGNORECASE)
 
 
-def _isOneWord(string):
+def _isOneWord(string: str):
     return len(string.split()) == 1
 
 
-def _isAllFiltered(string):
+def _isAllFiltered(string: str):
     words = string.split()
     cnt = 0
     for word in words:


### PR DESCRIPTION
### Description of the changes
This PR will do a few things:
- Fix #584.
- Add test cases that would have caught #584.
- Add additional tests for other helper functions.
    - Move `_censorMatch` into `_filterWord` as that is the only place that it is used.
    - Use f-string in `_censorMatch`. This is functionally equivalent so I decided to include this change within this PR.

This PR does not look at testing inside the WordFilter class itself yet, this is a task left for a subsequent PR instead.

## Screenshot
- Fix for #584 (notice how the non-filtered part of the message still exists): 
![image](https://user-images.githubusercontent.com/6710854/190885802-b9a86466-3ff0-49ca-8e6f-9f94ff765e91.png)

Note: I plan to merge this in via rebase.