### PR TITLE
[Tags] Add a check for raw tag length

### DIFF
--- a/cogs/tags/constants.py
+++ b/cogs/tags/constants.py
@@ -9,3 +9,4 @@ DUMP_IN = "data/tags/tags.json"
 DUMP_OUT = "data/tags/export.csv"
 
 NO_LIMIT = float("inf")
+MAX_MSG_LEN = 2000

--- a/cogs/tags/helpers.py
+++ b/cogs/tags/helpers.py
@@ -1,10 +1,23 @@
 from typing import List
 
-from .constants import COLOUR_BLURPLE
+from .constants import COLOUR_BLURPLE, MAX_MSG_LEN
 from .data import TagAlias, TagInfo
 
 import discord
 from redbot.core.utils import AsyncIter, chat_formatting
+
+
+def checkLengthInRaw(content: str) -> bool:
+    """Checks if the length of the specified content with markdown escaped
+    exceeds Discord's max message length or not.
+
+    Returns
+    -------
+    bool
+        False if the content length exceeds Discord's max message length
+        when all markdown characters are escape, and True otherwise.
+    """
+    return len(discord.utils.escape_markdown(content)) <= MAX_MSG_LEN
 
 
 async def createSimplePages(

--- a/cogs/tags/tags.py
+++ b/cogs/tags/tags.py
@@ -7,7 +7,7 @@ from .config import Config
 from .constants import *
 from .data import TagAlias, TagEncoder, TagInfo
 from .exceptions import *
-from .helpers import createSimplePages, tagDecoder
+from .helpers import checkLengthInRaw, createSimplePages, tagDecoder
 from .rolecheck import roles_or_mod_or_permissions
 
 from collections import defaultdict
@@ -421,6 +421,11 @@ class Tags(commands.Cog):
             return
 
         content = self.clean_tag_content(content)
+
+        if not checkLengthInRaw(content):
+            await ctx.send("Your content is too long. Consider splitting it into two tags.")
+            return
+
         lookup = name.lower().strip()
         try:
             self.verify_lookup(lookup)
@@ -471,6 +476,11 @@ class Tags(commands.Cog):
         a generic tag and not a server-specific one.
         """
         content = self.clean_tag_content(content)
+
+        if not checkLengthInRaw(content):
+            await ctx.send("Your content is too long. Consider splitting it into two tags.")
+            return
+
         lookup = name.lower().strip()
         try:
             self.verify_lookup(lookup)
@@ -648,6 +658,9 @@ class Tags(commands.Cog):
             content = content.attachments[0].get("url", "*Could not get attachment data*")
         else:
             content = self.clean_tag_content(content.content)
+            if not checkLengthInRaw(content):
+                await ctx.send("Your content is too long. Consider splitting it into two tags.")
+                return
 
         db[lookup] = TagInfo(
             name.content,
@@ -726,6 +739,11 @@ class Tags(commands.Cog):
         """
 
         content = self.clean_tag_content(content)
+
+        if not checkLengthInRaw(content):
+            await ctx.send("Your content is too long. Consider splitting it into two tags.")
+            return
+
         lookup = name.lower()
         server = ctx.message.guild
         try:

--- a/cogs/tags/testHelpers.py
+++ b/cogs/tags/testHelpers.py
@@ -1,0 +1,129 @@
+import random
+
+import pytest
+
+from . import constants, helpers
+
+
+class Utils:
+    @classmethod
+    def randomNumberString(cls, len: int, digits: str = "0123456789"):
+        """Returns a string of specified length and of specified digits chosen randomly."""
+        return "".join(random.choice(digits) for _ in range(len))
+
+    @classmethod
+    def insertStringIntoString(cls, str1: str, str2: str, pos: int):
+        """Returns the result of inserting str1 into str2 at position pos."""
+        return "".join((str2[:pos], str1, str2[pos:]))
+
+
+class TestCheckLengthInRaw:
+    """Tests to ensure helper checkLengthInRaw() works as expected."""
+
+    # good cases
+    @pytest.mark.parametrize(
+        ["content"],
+        map(
+            lambda content: [content],
+            (
+                "",
+                "**test**",
+                "~~**__`test`__**~~",
+                "~~**__```test```__**~~",
+                Utils.randomNumberString(constants.MAX_MSG_LEN),
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 4) + "test",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 12) + "**test**",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 32) + "~~**__`test`__**~~",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 64) + "~~**__`test`__**~~",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 40) + "~~**__```test```__**~~",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 64) + "~~**__```test```__**~~",
+                # cases with non-effective block-quotes
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 42) + ">~~**__```test```__**~~<",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 46)
+                + ">>>~~**__```test```__**~~<<<",
+                # cases with effective block-quotes
+                "> ~~**__```test```__**~~ <"
+                + Utils.randomNumberString(constants.MAX_MSG_LEN - 45),
+                ">>> ~~**__```test```__**~~ <<<"
+                + Utils.randomNumberString(constants.MAX_MSG_LEN - 49),
+                # cases with non-ASCII characters
+                Utils.insertStringIntoString(
+                    "~*_`ネコミミ大好き`_*~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 23),
+                    random.randint(0, constants.MAX_MSG_LEN - 23),
+                ),
+                Utils.insertStringIntoString(
+                    "~*_`ねこみみだいすき`_*~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 24),
+                    random.randint(0, constants.MAX_MSG_LEN - 24),
+                ),
+                # cases with markdown-lookalike characters
+                Utils.insertStringIntoString(
+                    "~*_`バーバラ☆いっくよ！～`_*~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 27),
+                    random.randint(0, constants.MAX_MSG_LEN - 27),
+                ),
+                # cases with markdown effective block-quote lookalike characters
+                Utils.insertStringIntoString(
+                    "＞＞ ~*_`バーバラ☆いっくよ！～`_*~ ＜＜",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 33),
+                    random.randint(0, constants.MAX_MSG_LEN - 33),
+                ),
+            ),
+        ),
+    )
+    def testGoodCases(self, content: str):
+        assert helpers.checkLengthInRaw(content) == True
+
+    # bad cases
+    @pytest.mark.parametrize(
+        ["content"],
+        map(
+            lambda content: [content],
+            (
+                Utils.randomNumberString(constants.MAX_MSG_LEN * 2),
+                Utils.randomNumberString(constants.MAX_MSG_LEN + 1),
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 8) + "**test**",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 10) + "**test**",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 11) + "**test**",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 14) + "~~**__`test`__**~~",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 31) + "~~**__`test`__**~~",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 20) + "~~**__```test```__**~~",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 39) + "~~**__```test```__**~~",
+                # cases with non-effective block-quotes
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 41) + ">~~**__```test```__**~~<",
+                Utils.randomNumberString(constants.MAX_MSG_LEN - 45)
+                + ">>>~~**__```test```__**~~<<<",
+                # cases with effective block-quotes
+                "> ~~**__```test```__**~~ <"
+                + Utils.randomNumberString(constants.MAX_MSG_LEN - 44),
+                ">>> ~~**__```test```__**~~ <<<"
+                + Utils.randomNumberString(constants.MAX_MSG_LEN - 48),
+                # cases with non-ASCII characters
+                Utils.insertStringIntoString(
+                    "~*_`ネコミミ大好き`_*~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 22),
+                    random.randint(0, constants.MAX_MSG_LEN - 22),
+                ),
+                Utils.insertStringIntoString(
+                    "~*_`ねこみみだいすき`_*~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 23),
+                    random.randint(0, constants.MAX_MSG_LEN - 23),
+                ),
+                # cases with markdown-lookalike characters
+                Utils.insertStringIntoString(
+                    "~*_`バーバラ☆いっくよ！～`_*~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 26),
+                    random.randint(0, constants.MAX_MSG_LEN - 26),
+                ),
+                # cases with markdown effective block-quote lookalike characters
+                Utils.insertStringIntoString(
+                    "＞＞ ~*_`バーバラ☆いっくよ！～`_*~ ＜＜",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 32),
+                    random.randint(0, constants.MAX_MSG_LEN - 32),
+                ),
+            ),
+        ),
+    )
+    def testBadCases(self, content: str):
+        assert helpers.checkLengthInRaw(content) == False

--- a/cogs/tags/testHelpers.py
+++ b/cogs/tags/testHelpers.py
@@ -1,4 +1,5 @@
 import random
+import typing
 
 import pytest
 
@@ -12,8 +13,11 @@ class Utils:
         return "".join(random.choice(digits) for _ in range(len))
 
     @classmethod
-    def insertStringIntoString(cls, str1: str, str2: str, pos: int):
-        """Returns the result of inserting str1 into str2 at position pos."""
+    def insertStringIntoString(cls, str1: str, str2: str, pos: typing.Optional[int] = None):
+        """Returns the result of inserting str1 into str2 at position pos.
+        If pos is not specified, a random position in str2 will be chosen."""
+        if pos is None:
+            return Utils.insertStringIntoString(str1, str2, random.randint(0, len(str2)))
         return "".join((str2[:pos], str1, str2[pos:]))
 
 
@@ -31,43 +35,74 @@ class TestCheckLengthInRaw:
                 "~~**__`test`__**~~",
                 "~~**__```test```__**~~",
                 Utils.randomNumberString(constants.MAX_MSG_LEN),
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 4) + "test",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 12) + "**test**",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 32) + "~~**__`test`__**~~",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 64) + "~~**__`test`__**~~",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 40) + "~~**__```test```__**~~",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 64) + "~~**__```test```__**~~",
+                Utils.insertStringIntoString(
+                    "test",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 4),
+                ),
+                Utils.insertStringIntoString(
+                    "**test**",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 12),
+                ),
+                Utils.insertStringIntoString(
+                    "~~**__`test`__**~~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 32),
+                ),
+                Utils.insertStringIntoString(
+                    "~~**__`test`__**~~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 64),
+                ),
+                Utils.insertStringIntoString(
+                    "~~**__```test```__**~~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 40),
+                ),
+                Utils.insertStringIntoString(
+                    "~~**__```test```__**~~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 64),
+                ),
                 # cases with non-effective block-quotes
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 42) + ">~~**__```test```__**~~<",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 46)
-                + ">>>~~**__```test```__**~~<<<",
+                Utils.insertStringIntoString(
+                    ">~~**__```test```__**~~<",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 42),
+                ),
+                Utils.insertStringIntoString(
+                    ">>>~~**__```test```__**~~<<<",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 46),
+                ),
                 # cases with effective block-quotes
-                "> ~~**__```test```__**~~ <"
-                + Utils.randomNumberString(constants.MAX_MSG_LEN - 45),
-                ">>> ~~**__```test```__**~~ <<<"
-                + Utils.randomNumberString(constants.MAX_MSG_LEN - 49),
+                Utils.insertStringIntoString(
+                    "> ~~**__```test```__**~~ <",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 45),
+                    0,  # single-line block-quotes are only effective preceded by nothing and followed by something
+                ),
+                Utils.insertStringIntoString(
+                    ">>> ~~**__```test```__**~~ <<<",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 49),
+                    0,  # single-line block-quotes are only effective preceded by nothing and followed by something
+                ),
                 # cases with non-ASCII characters
                 Utils.insertStringIntoString(
                     "~*_`ネコミミ大好き`_*~",
                     Utils.randomNumberString(constants.MAX_MSG_LEN - 23),
-                    random.randint(0, constants.MAX_MSG_LEN - 23),
                 ),
                 Utils.insertStringIntoString(
                     "~*_`ねこみみだいすき`_*~",
                     Utils.randomNumberString(constants.MAX_MSG_LEN - 24),
-                    random.randint(0, constants.MAX_MSG_LEN - 24),
                 ),
                 # cases with markdown-lookalike characters
                 Utils.insertStringIntoString(
-                    "~*_`バーバラ☆いっくよ！～`_*~",
-                    Utils.randomNumberString(constants.MAX_MSG_LEN - 27),
-                    random.randint(0, constants.MAX_MSG_LEN - 27),
+                    "‘＊＿~*_`バーバラ＊いっくよ！～`_*~＿＊‘",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 33),
                 ),
                 # cases with markdown effective block-quote lookalike characters
                 Utils.insertStringIntoString(
-                    "＞＞ ~*_`バーバラ☆いっくよ！～`_*~ ＜＜",
-                    Utils.randomNumberString(constants.MAX_MSG_LEN - 33),
-                    random.randint(0, constants.MAX_MSG_LEN - 33),
+                    "＞ ~*_`バーバラ＊いっくよ！～`_*~ ＜",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 31),
+                    0,
+                ),
+                Utils.insertStringIntoString(
+                    "＞＞＞ ~*_`バーバラ＊いっくよ！～`_*~ ＜＜＜",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 35),
+                    0,
                 ),
             ),
         ),
@@ -83,44 +118,78 @@ class TestCheckLengthInRaw:
             (
                 Utils.randomNumberString(constants.MAX_MSG_LEN * 2),
                 Utils.randomNumberString(constants.MAX_MSG_LEN + 1),
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 8) + "**test**",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 10) + "**test**",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 11) + "**test**",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 14) + "~~**__`test`__**~~",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 31) + "~~**__`test`__**~~",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 20) + "~~**__```test```__**~~",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 39) + "~~**__```test```__**~~",
+                Utils.insertStringIntoString(
+                    "**test**",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 8),
+                ),
+                Utils.insertStringIntoString(
+                    "**test**",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 10),
+                ),
+                Utils.insertStringIntoString(
+                    "**test**",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 11),
+                ),
+                Utils.insertStringIntoString(
+                    "~~**__`test`__**~~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 14),
+                ),
+                Utils.insertStringIntoString(
+                    "~~**__`test`__**~~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 31),
+                ),
+                Utils.insertStringIntoString(
+                    "~~**__```test```__**~~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 20),
+                ),
+                Utils.insertStringIntoString(
+                    "~~**__```test```__**~~",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 39),
+                ),
                 # cases with non-effective block-quotes
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 41) + ">~~**__```test```__**~~<",
-                Utils.randomNumberString(constants.MAX_MSG_LEN - 45)
-                + ">>>~~**__```test```__**~~<<<",
+                Utils.insertStringIntoString(
+                    ">~~**__```test```__**~~<",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 41),
+                ),
+                Utils.insertStringIntoString(
+                    ">>>~~**__```test```__**~~<<<",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 45),
+                ),
                 # cases with effective block-quotes
-                "> ~~**__```test```__**~~ <"
-                + Utils.randomNumberString(constants.MAX_MSG_LEN - 44),
-                ">>> ~~**__```test```__**~~ <<<"
-                + Utils.randomNumberString(constants.MAX_MSG_LEN - 48),
+                Utils.insertStringIntoString(
+                    "> ~~**__```test```__**~~ <",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 44),
+                    0,
+                ),
+                Utils.insertStringIntoString(
+                    ">>> ~~**__```test```__**~~ <<<",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 48),
+                    0,
+                ),
                 # cases with non-ASCII characters
                 Utils.insertStringIntoString(
                     "~*_`ネコミミ大好き`_*~",
                     Utils.randomNumberString(constants.MAX_MSG_LEN - 22),
-                    random.randint(0, constants.MAX_MSG_LEN - 22),
                 ),
                 Utils.insertStringIntoString(
                     "~*_`ねこみみだいすき`_*~",
                     Utils.randomNumberString(constants.MAX_MSG_LEN - 23),
-                    random.randint(0, constants.MAX_MSG_LEN - 23),
                 ),
                 # cases with markdown-lookalike characters
                 Utils.insertStringIntoString(
-                    "~*_`バーバラ☆いっくよ！～`_*~",
-                    Utils.randomNumberString(constants.MAX_MSG_LEN - 26),
-                    random.randint(0, constants.MAX_MSG_LEN - 26),
+                    "‘＊＿~*_`バーバラ＊いっくよ！～`_*~＿＊‘",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 32),
                 ),
                 # cases with markdown effective block-quote lookalike characters
                 Utils.insertStringIntoString(
-                    "＞＞ ~*_`バーバラ☆いっくよ！～`_*~ ＜＜",
-                    Utils.randomNumberString(constants.MAX_MSG_LEN - 32),
-                    random.randint(0, constants.MAX_MSG_LEN - 32),
+                    "＞ ~*_`バーバラ＊いっくよ！～`_*~ ＜",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 30),
+                    0,
+                ),
+                Utils.insertStringIntoString(
+                    "＞＞＞ ~*_`バーバラ＊いっくよ！～`_*~ ＜＜＜",
+                    Utils.randomNumberString(constants.MAX_MSG_LEN - 34),
+                    0,
                 ),
             ),
         ),

--- a/cogs/tags/testHelpers.py
+++ b/cogs/tags/testHelpers.py
@@ -108,7 +108,7 @@ class TestCheckLengthInRaw:
         ),
     )
     def testGoodCases(self, content: str):
-        assert helpers.checkLengthInRaw(content) == True
+        assert helpers.checkLengthInRaw(content)
 
     # bad cases
     @pytest.mark.parametrize(
@@ -195,4 +195,4 @@ class TestCheckLengthInRaw:
         ),
     )
     def testBadCases(self, content: str):
-        assert helpers.checkLengthInRaw(content) == False
+        assert not helpers.checkLengthInRaw(content)


### PR DESCRIPTION
## Summary

Add a check to prevent users from adding tags where the raw contents (markdown-escaped) would exceed Discord's max message length.

This fixes SFUAnime/Ren#568.

## Details

Add a helper function `checkLengthInRaw(str)` and constant `MAX_MSG_LEN` being 2000 (Discord's message length limit at the moment).

Check content length using that function before adding the content in:
- `[p]tag add/create`
- `[p]tag edit`
- `[p]tag generic`
- `[p]tag make`

## Testing

### Unit testing

Unit tests for good/bad cases, with randomized strings of ASCII, non-ASCII and markdown-lookalike Japanese characters.

### Manual testing

Tested with a string of 1978 asterisks with `[p]tag edit`:
![image](https://user-images.githubusercontent.com/6735818/192453706-dd38dbab-b857-409e-8c4c-af54a0ffec28.png)
