### PR TITLE
[Birthday] Always initialize local variable `birthday`

### DIFF
--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -153,14 +153,10 @@ class Birthday(commands.Cog):
             )
             return
 
-        # Check if both the inputs are empty, for this case set the birthday as current day
-        # If one of the parameters are missing, then send error message
         if not birthday:
-            day = int(time.strftime("%d"))
-            month = int(time.strftime("%m"))
-        else:
-            day = birthday.day
-            month = birthday.month
+            birthday = datetime.today()
+        day = birthday.day
+        month = birthday.month
 
         def check(msg: discord.Message):
             return msg.author == ctx.author and msg.channel == ctx.channel


### PR DESCRIPTION
This tiny PR fixes a small issue where if we use `[p]birthday set` with a user with no birthday, then it errors out because it expects the local variable `birthday` to be a `datetime.datetime` object but it is in fact `None`.

Here, if we pass in `None` (i.e. birthday is not supplied), then initialize it to `datetime.datetime.today()`.