### PR TITLE
[Birthday] Output special message if bot's birthday is set

### DIFF
--- a/.github/workflows/cogUnitTests.yml
+++ b/.github/workflows/cogUnitTests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio
+          pip install pytest pytest-asyncio pytest-mock
       - name: Install Red-DiscordBot
         run: |
           python setup.py install

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -592,6 +592,23 @@ class Birthday(commands.Cog):
             await allowSelfBirthdayConfig.set(True)
             await ctx.send(msgAllow)
 
+    def getBirthdayMessage(self, member: discord.Member) -> str:
+        """Get the birthday message.
+
+        Parameters
+        ----------
+        member: discord.Member
+            The member that we want the birthday message for.
+
+        Returns
+        -------
+        str
+            The birthday message, already formatted.
+        """
+        if self.bot.user.id == member.id:
+            return "Wow! It's my own birthday! Happy birthday to myself!"
+        return choice(CANNED_MESSAGES).format(member.mention)
+
     async def checkBirthday(self):
         """Check birthday list once."""
         await self._dailySweep()
@@ -729,7 +746,8 @@ class Birthday(commands.Cog):
                                 continue
                             try:
                                 msg = choice(CANNED_MESSAGES)
-                                await channel.send(msg.format(member.mention))
+                                msg = self.getBirthdayMessage(member)
+                                await channel.send(msg)
                             except discord.Forbidden:
                                 self.logger.error(
                                     "Could not send message!",

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -48,8 +48,8 @@ class Birthday(commands.Cog):
     def __init__(self, bot: Red):
         self.bot = bot
         self.bgTask: asyncio.Task = None
-        self.config = None
-        self.lastChecked = None
+        self.config: Config = None
+        self.lastChecked: datetime = None
         self.logger: logging.Logger = None
 
         self.initializeConfigAndLogger()
@@ -606,7 +606,7 @@ class Birthday(commands.Cog):
             The birthday message, already formatted.
         """
         if self.bot.user.id == member.id:
-            return BOT_BIRTHDAY
+            return BOT_BIRTHDAY_MSG
         return choice(CANNED_MESSAGES).format(member.mention)
 
     async def checkBirthday(self):
@@ -745,7 +745,6 @@ class Birthday(commands.Cog):
                             if not channel:
                                 continue
                             try:
-                                msg = choice(CANNED_MESSAGES)
                                 msg = self.getBirthdayMessage(member)
                                 await channel.send(msg)
                             except discord.Forbidden:

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -606,7 +606,7 @@ class Birthday(commands.Cog):
             The birthday message, already formatted.
         """
         if self.bot.user.id == member.id:
-            return "Wow! It's my own birthday! Happy birthday to myself!"
+            return BOT_BIRTHDAY
         return choice(CANNED_MESSAGES).format(member.mention)
 
     async def checkBirthday(self):

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -22,9 +22,7 @@ class Birthday(commands.Cog):
     """Adds a role to someone on their birthday, and automatically remove them
     from this role after the day is over."""
 
-    # Class constructor
-    def __init__(self, bot: Red):
-        self.bot = bot
+    def initializeConfigAndLogger(self):
         self.config = Config.get_conf(self, identifier=5842647, force_registration=True)
         # Register default (empty) settings.
         self.config.register_guild(**BASE_GUILD)
@@ -41,9 +39,21 @@ class Birthday(commands.Cog):
             )
             self.logger.addHandler(handler)
 
+    def initializeBgTask(self):
         # On cog load, we want the loop to run once.
         self.lastChecked = datetime.now() - timedelta(days=1)
         self.bgTask = self.bot.loop.create_task(self.birthdayLoop())
+
+    # Class constructor
+    def __init__(self, bot: Red):
+        self.bot = bot
+        self.bgTask: asyncio.Task = None
+        self.config = None
+        self.lastChecked = None
+        self.logger: logging.Logger = None
+
+        self.initializeConfigAndLogger()
+        self.initializeBgTask()
 
     # Cancel the background task on cog unload.
     def __unload(self):  # pylint: disable=invalid-name

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -589,6 +589,9 @@ class Birthday(commands.Cog):
 
     async def birthdayLoop(self):
         """The main event loop that will call the add and sweep methods."""
+        self.logger.info("Waiting for bot to be ready")
+        await self.bot.wait_until_red_ready()
+        self.logger.info("Bot is ready")
         while self == self.bot.get_cog("Birthday"):
             if self.lastChecked.day != datetime.now().day:
                 self.lastChecked = datetime.now()

--- a/cogs/birthday/constants.py
+++ b/cogs/birthday/constants.py
@@ -20,6 +20,7 @@ BASE_GUILD = {
     KEY_ALLOW_SELF_BDAY: False,
 }
 
+BOT_BIRTHDAY = "Wow! It's my own birthday! Happy birthday to myself!"
 CANNED_MESSAGES = [
     "Wow look, it's {}'s birthday today! Happy birthday, hope you have a good one!",
     "お誕生日おめでとう、{}! (TL note: Happy birthday!)",

--- a/cogs/birthday/constants.py
+++ b/cogs/birthday/constants.py
@@ -20,7 +20,7 @@ BASE_GUILD = {
     KEY_ALLOW_SELF_BDAY: False,
 }
 
-BOT_BIRTHDAY = "Wow! It's my own birthday! Happy birthday to myself!"
+BOT_BIRTHDAY_MSG = "Wow! It's my own birthday! Happy birthday to myself!"
 CANNED_MESSAGES = [
     "Wow look, it's {}'s birthday today! Happy birthday, hope you have a good one!",
     "お誕生日おめでとう、{}! (TL note: Happy birthday!)",

--- a/cogs/birthday/testBirthday.py
+++ b/cogs/birthday/testBirthday.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import discord
+import pytest
+
+
+from .birthday import Birthday
+from .constants import CANNED_MESSAGES
+
+BOT_BIRTHDAY = "Wow! It's my own birthday! Happy birthday to myself!"
+
+
+class MockUser:
+    def __init__(self, _id: int, mention: str):
+        self.id = _id
+        self.mention = mention
+
+
+class MockBot:
+    user = MockUser(1234, "Ren")
+
+
+# XXX Move this out later once we refactor birthday cog layout
+class TestBirthdayHelpers:
+    bot = MockBot()
+
+    @pytest.mark.parametrize(
+        ["uid", "mention"],
+        [
+            (1111, "Onii-chan"),
+            (2222, "Ara-ara Onee-chan"),
+            (3333, "SENPAI"),
+            (4444, "Sensei"),
+        ],
+    )
+    def testGetBirthdayMessageWhenUserIsNotBot(self, mocker, uid, mention):
+        # Do not initialize config, logger, and background task
+        mocker.patch("birthday.Birthday.initializeConfigAndLogger")
+        mocker.patch("birthday.Birthday.initializeBgTask")
+
+        birthday = Birthday(self.bot)
+        mockUser = MockUser(uid, mention)
+        expectedMessages = [msg.format(mockUser.mention) for msg in CANNED_MESSAGES]
+
+        msg = birthday.getBirthdayMessage(mockUser)
+        assert msg in expectedMessages
+
+    def testGetBirthdayMessageWhenUserIsBot(self, mocker):
+        # Do not initialize config, logger, and background task
+        mocker.patch("birthday.Birthday.initializeConfigAndLogger")
+        mocker.patch("birthday.Birthday.initializeBgTask")
+
+        birthday = Birthday(self.bot)
+        mockUser = MockUser(1234, "Ren")
+
+        msg = birthday.getBirthdayMessage(mockUser)
+        assert msg == BOT_BIRTHDAY

--- a/cogs/birthday/testBirthday.py
+++ b/cogs/birthday/testBirthday.py
@@ -4,9 +4,7 @@ import pytest
 
 
 from .birthday import Birthday
-from .constants import CANNED_MESSAGES
-
-BOT_BIRTHDAY = "Wow! It's my own birthday! Happy birthday to myself!"
+from .constants import BOT_BIRTHDAY_MSG, CANNED_MESSAGES
 
 
 class MockUser:
@@ -53,4 +51,4 @@ class TestBirthdayHelpers:
         mockUser = MockUser(1234, "Ren")
 
         msg = birthday.getBirthdayMessage(mockUser)
-        assert msg == BOT_BIRTHDAY
+        assert msg == BOT_BIRTHDAY_MSG


### PR DESCRIPTION
### Description of the changes
This PR will do a few things:
1. Add an interlock to wait for the bot to be ready before starting the loop, or else `bot.user` is `None` when the bot is starting up.
2. Add a helper `getBirthdayMessage` that gets a random message from `CANNED_MESSAGES` if it's not the bot's birthday, else returns `BOT_BIRTHDAY`. This helper replaces the background loop's version of fetching the message in order to output a special message if the bot's birthday has been configured.
4. Move config, logger, and background init to helpers in order to avoid running into initialization issues while unit testing helper functions.
5. Add a unit test for the `getBirthdayMessage` helper.


![Screenshot from 2022-10-03 23-59-59](https://user-images.githubusercontent.com/6710854/193758080-53ce35e9-9bb2-4a88-89a9-01dd19244add.png)

