### PR TITLE
[Birthday] Handle DMs disabled for `self` commands

### DIFF
--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -461,8 +461,8 @@ class Birthday(commands.Cog):
                             await ctx.send("Alright then")
                             return
 
-                        can_delete = ctx.channel.permissions_for(ctx.me).manage_messages
-                        if can_delete:
+                        canDelete = ctx.channel.permissions_for(ctx.me).manage_messages
+                        if canDelete:
                             await ctx.send(
                                 f"{headerGood}: Your birthday is "
                                 f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -519,46 +519,110 @@ class Birthday(commands.Cog):
                 f"Type {bold('`yes`', escape_formatting=False)} to confirm."
             )
 
-            await ctx.author.send(f"{headerWarn}: {confirmationStr}")
-
-            def check(msg: discord.Message):
-                return msg.author == ctx.author and msg.channel == ctx.author.dm_channel
-
             try:
-                response = await self.bot.wait_for("message", timeout=30.0, check=check)
-            except asyncio.TimeoutError:
-                # hide the birthday portion within the previous message
+                def check(msg: discord.Message):
+                    return msg.author == ctx.author and msg.channel == ctx.author.dm_channel
+                await ctx.author.send(f"{headerWarn}: {confirmationStr}")
+    
+                try:
+                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
+                except asyncio.TimeoutError:
+                    # hide the birthday portion within the previous message
+                    await ctx.author.send(
+                        f"{headerBad}: You took too long. Not setting your birthday."
+                    )
+                    return
+    
+                if response.content.lower() != "yes":
+                    await ctx.author.send(f"{headerBad}: Declined. Not setting your birthday.")
+                    return
+    
+                await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
+                await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
+                await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
+    
                 await ctx.author.send(
-                    f"{headerBad}: You took too long. Not setting your birthday."
+                    f"{headerGood}: Successfully set your birthday to "
+                    f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
                 )
+    
+                self.logger.info(
+                    "%s#%s (%s) added their birthday as %s",
+                    ctx.author.name,
+                    ctx.author.discriminator,
+                    ctx.author.id,
+                    birthdayStr,
+                )
+    
+                # explicitly check to see if user should be added to role, if the month
+                # and day just so happen to be the same as it is now.
+                await self.checkBirthday()
                 return
+            except discord.Forbidden:
+                def check(msg: discord.Message):
+                    return msg.author == ctx.author and msg.channel == ctx.channel
+                try:
+                    await ctx.send(
+                        "You have disabled DMs from this server. Would you "
+                        "still like to continue here?"
+                        f"Type {bold('`yes`', escape_formatting=False)} to confirm."
+                        )
+                    response = await self.bot.wait_for("message", timeout = 30.0, check=check) 
+                except asyncio.TimeoutError:
+                    await ctx.send(f"{headerBad}: You took too long. Not setting your birthday.")
+                    return
 
-            if response.content.lower() != "yes":
-                await ctx.author.send(f"{headerBad}: Declined. Not setting your birthday.")
-                return
+                if response.content.lower() != "yes":
+                    await ctx.send(f"{headerBad}: Declined. Not setting your birthday.")
+                    return
+                can_delete = ctx.channel.permissions_for(ctx.me).manage_messages
 
-            await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
-            await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
-            await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
+                if can_delete:
+                    msg: discord.Message = await ctx.send(f"{headerWarn}: {confirmationStr}")
+                    try:
+                        response = await self.bot.wait_for("message", timeout = 10.0, check=check)
+                    except asyncio.TimeoutError:
+                        try:
+                            await ctx.send(
+                                    f"{headerBad}: No response. Aborting",
+                                    delete_after=10
+                                    )
+                            await msg.delete()
+                            return
+                        except (discord.NotFound, discord.HTTPException):
+                            return
 
-            await ctx.author.send(
-                f"{headerGood}: Successfully set your birthday to "
-                f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
-            )
+                    if response.content.lower() != "yes":
+                        await ctx.send(
+                                f"{headerBad}: Declined. Not setting your birthday.",
+                                delete_after=5
+                                )
+                        try:
+                            await msg.delete()
+                        except (discord.NotFound, discord.HTTPException):
+                            return
+                        return
 
-            self.logger.info(
-                "%s#%s (%s) added their birthday as %s",
-                ctx.author.name,
-                ctx.author.discriminator,
-                ctx.author.id,
-                birthdayStr,
-            )
-
-            # explicitly check to see if user should be added to role, if the month
-            # and day just so happen to be the same as it is now.
-            await self.checkBirthday()
-            return
-
+                    await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
+                    await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
+                    await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
+                    await ctx.send(
+                        f"{headerGood}: Successfully set your birthday to "
+                        f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
+                        delete_after=5
+                    )      
+                    self.logger.info(
+                        "%s#%s (%s) added their birthday as %s",
+                        ctx.author.name,
+                        ctx.author.discriminator,
+                        ctx.author.id,
+                        birthdayStr,
+                    )
+                    try:
+                        await msg.delete()
+                        return
+                    except (discord.NotFound, discord.HTTPException):
+                        return
         raise Exception("Error while accessing member's birthday config. This should not happen!")
 
     @_birthday.command(name="selfbirthday")

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -7,7 +7,7 @@ import time  # To auto remove birthday role on the next day.
 import asyncio
 from datetime import date, datetime, timedelta
 import discord
-import typing
+from typing import Union
 from redbot.core import Config, checks, commands, data_manager
 from redbot.core.commands.context import Context
 from redbot.core.utils import AsyncIter
@@ -35,7 +35,9 @@ class Birthday(commands.Cog):
             logPath = os.path.join(saveFolder, "info.log")
             handler = logging.FileHandler(filename=logPath, encoding="utf-8", mode="a")
             handler.setFormatter(
-                logging.Formatter("%(asctime)s %(message)s", datefmt="[%d/%m/%Y %H:%M:%S]")
+                logging.Formatter(
+                    "%(asctime)s %(message)s", datefmt="[%d/%m/%Y %H:%M:%S]"
+                )
             )
             self.logger.addHandler(handler)
 
@@ -80,7 +82,9 @@ class Birthday(commands.Cog):
         """
 
         if channel:
-            await self.config.guild(ctx.guild).get_attr(KEY_BDAY_CHANNEL).set(channel.id)
+            await self.config.guild(ctx.guild).get_attr(KEY_BDAY_CHANNEL).set(
+                channel.id
+            )
             self.logger.info(
                 "%s#%s (%s) set the birthday channel to %s",
                 ctx.author.name,
@@ -186,7 +190,9 @@ class Birthday(commands.Cog):
                     )
                 )
                 try:
-                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
+                    response = await self.bot.wait_for(
+                        "message", timeout=30.0, check=check
+                    )
                 except asyncio.TimeoutError:
                     await ctx.send(f"You took too long, not re-adding them.")
                     return
@@ -201,7 +207,9 @@ class Birthday(commands.Cog):
         confMsg = await ctx.send(
             ":white_check_mark: **Birthday - Add**: Successfully {0} **{1}**'s birthday "
             "as **{2:%B} {2:%d}**. The role will be assigned automatically on this "
-            "day.".format("updated" if birthdayExists else "added", member.name, birthday)
+            "day.".format(
+                "updated" if birthdayExists else "added", member.name, birthday
+            )
         )
 
         # Explicitly check to see if user should be added to role, if the month
@@ -236,7 +244,9 @@ class Birthday(commands.Cog):
         """Lists the birthdays of users in the server."""
 
         sortedList = []  # List to sort by month, day.
-        display = []  # List of text for paginator to use.  Will be constructed from sortedList.
+        display = (
+            []
+        )  # List of text for paginator to use.  Will be constructed from sortedList.
 
         # Add only the users we care about (e.g. the ones that have birthdays set).
         membersData = await self.config.all_members(ctx.guild)
@@ -281,7 +291,9 @@ class Birthday(commands.Cog):
         pages = list(pagify(msg, page_length=300))
         totalPages = len(pages)
         async for pageNumber, page in AsyncIter(pages).enumerate(start=1):
-            embed = discord.Embed(title=f"Birthdays in **{ctx.guild.name}**", description=page)
+            embed = discord.Embed(
+                title=f"Birthdays in **{ctx.guild.name}**", description=page
+            )
             embed.set_footer(text=f"Page {pageNumber}/{totalPages}")
             embed.colour = discord.Colour.red()
             pageList.append(embed)
@@ -447,7 +459,7 @@ class Birthday(commands.Cog):
                         return
                     except discord.Forbidden:
                         await ctx.send(
-                            f"{headerWarn}: I would like to DM you your birthday but it seeems that"
+                            f"{headerWarn}: I would like to DM you your birthday but it seeems that "
                             "you have disabled DMs from this server. Would you still like to continue here? "
                             "Your birthday will be sent here and deleted after a short delay. "
                             f"Type {bold('`yes`', escape_formatting=False)} to confirm. "
@@ -455,14 +467,18 @@ class Birthday(commands.Cog):
                         )
 
                         def check(msg: discord.Message):
-                            return msg.author == ctx.author and msg.channel == ctx.channel
+                            return (
+                                msg.author == ctx.author and msg.channel == ctx.channel
+                            )
 
                         try:
                             response = await self.bot.wait_for(
                                 "message", timeout=30.0, check=check
                             )
                         except asyncio.TimeoutError:
-                            await ctx.send(f"{headerBad}: No response detected. Aborting.")
+                            await ctx.send(
+                                f"{headerBad}: No response detected. Aborting."
+                            )
                             return
 
                         if response.content.lower() != "yes":
@@ -541,55 +557,56 @@ class Birthday(commands.Cog):
             return
 
         birthdayStr = "{0:%B} {0:%d}".format(birthday)
-
         if birthdayConfig:
-            confirmationStr = "\n".join(
-                (
-                    f"Are you sure you want to set your birthday to "
-                    f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}? "
-                    "Only administrators and moderators can reset your birthday afterwards.",
-                    f"Type {bold('`yes`', escape_formatting=False)} to confirm.",
-                )
-            )
 
-            async def mainFlow(destination, carefree: bool = False):
+            async def mainFlow(channel: discord.TextChannel, carefree: bool = False):
+                confirmationStr = "\n".join(
+                    (
+                        f"Are you sure you want to set your birthday to "
+                        f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}? "
+                        "Only administrators and moderators can reset your birthday afterwards.",
+                        f"Type {bold('`yes`', escape_formatting=False)} to confirm.",
+                    )
+                )
                 # define the time for the message to live for
-                SENSITIVE_MSG_TTL = None if carefree else 10.0
+                SENSITIVE_MSG_TTL = None if carefree else 5.0
                 try:
-                    await destination.send(
+                    await channel.send(
                         f"{headerWarn}: {confirmationStr}",
                         delete_after=SENSITIVE_MSG_TTL,
                     )
                 except discord.Forbidden:
-                    # catch failed DM
+                    # this means messages cannot be sent to the the destination channel
+                    # so we abort the flow now by re-raising the exception
+                    # and the caller shall handle it gracefullyu
                     raise
-                # wait for answer
-                responseChannel = None
-                if carefree:
-                    responseChannel = destination.dm_channel
-                else:
-                    responseChannel = destination.channel
 
+                # wait for answer
                 def check(msg: discord.Message):
-                    return msg.author == ctx.author and msg.channel == responseChannel
+                    return msg.author == ctx.author and msg.channel == channel
 
                 try:
-                    response = await self.bot.wait_for("message", timeout=10.0, check=check)
+                    response = await self.bot.wait_for(
+                        "message", timeout=10.0, check=check
+                    )
                 except asyncio.TimeoutError:
-                    await destination.send(
+                    await channel.send(
                         f"{headerBad}: You took too long. Not setting your birthday."
                     )
                     return
 
                 if response.content.lower() != "yes":
-                    await destination.send(f"{headerBad}: Declined. Not setting your birthday.")
+                    await channel.send(
+                        f"{headerBad}: Declined. Not setting your birthday."
+                    )
                     return
+
                 # Set birthday and notify user that their birthday has been set
                 await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
                 await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
                 await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
 
-                await destination.send(
+                await channel.send(
                     f"{headerGood}: Successfully set your birthday to "
                     f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
                     delete_after=SENSITIVE_MSG_TTL,
@@ -608,37 +625,42 @@ class Birthday(commands.Cog):
                 await self.checkBirthday()
                 return
 
+            noDmStr = "\n".join(
+                (
+                    "You have disabled DMs from this server. Would you "
+                    "still like to continue here? All messages containing your "
+                    "birthday will be deleted after a short delay.",
+                    f"Type {bold('`yes`', escape_formatting=False)} to confirm.",
+                )
+            )
             try:
-                await mainFlow(ctx.author, carefree=True)
+                await mainFlow(ctx.author.dm_channel, carefree=True)
                 return
             except discord.Forbidden:
-                await ctx.send(
-                    "\n".join(
-                        (
-                            "You have disabled DMs from this server. Would you "
-                            "still like to continue here? All messages containing your "
-                            "birthday will be deleted after a short delay.",
-                            f"Type {bold('`yes`', escape_formatting=False)} to confirm.",
-                        )
-                    )
-                )
+                await ctx.send(noDmStr)
 
                 def check(msg: discord.Message):
                     return msg.author == ctx.author and msg.channel == ctx.channel
 
                 try:
-                    response = await self.bot.wait_for("message", timeout=10.0, check=check)
+                    response = await self.bot.wait_for(
+                        "message", timeout=10.0, check=check
+                    )
                 except asyncio.TimeoutError:
-                    await ctx.send(f"{headerBad}: You took too long. Not setting your birthday.")
+                    await ctx.send(
+                        f"{headerBad}: You took too long. Not setting your birthday."
+                    )
                     return
 
                 if response.content.lower() != "yes":
                     await ctx.send(f"{headerBad}: Declined. Not setting your birthday.")
                     return
-                await mainFlow(ctx, carefree=False)
+                await mainFlow(ctx.channel, carefree=False)
                 return
 
-        raise Exception("Error while accessing member's birthday config. This should not happen!")
+        raise Exception(
+            "Error while accessing member's birthday config. This should not happen!"
+        )
 
     @_birthday.command(name="selfbirthday")
     @commands.guild_only()
@@ -659,9 +681,7 @@ class Birthday(commands.Cog):
             f"{bold('Enabled')}. Members can set their birthdays themselves "
             f"{bold('ONCE')} and {bold('ONLY IF')} their birthdays were not already set."
         )
-        msgNotAllow = (
-            f"{headerGood}: {bold('Disabled')}. Members cannot set their birthdays themselves."
-        )
+        msgNotAllow = f"{headerGood}: {bold('Disabled')}. Members cannot set their birthdays themselves."
         guildConfig = self.config.guild(ctx.guild)
         allowSelfBirthdayConfig = guildConfig.get_attr(KEY_ALLOW_SELF_BDAY)
         if await allowSelfBirthdayConfig():
@@ -726,9 +746,9 @@ class Birthday(commands.Cog):
                 memberData = await self.config.all_members(guild)  # dict
                 for memberId, memberDetails in memberData.items():
                     # If assigned and the date is different than the date assigned, remove role.
-                    if memberDetails[KEY_IS_ASSIGNED] and memberDetails[KEY_BDAY_DAY] != int(
-                        time.strftime("%d")
-                    ):
+                    if memberDetails[KEY_IS_ASSIGNED] and memberDetails[
+                        KEY_BDAY_DAY
+                    ] != int(time.strftime("%d")):
 
                         role = discord.utils.get(guild.roles, id=bdayRoleId)
                         member = discord.utils.get(guild.members, id=memberId)
@@ -757,7 +777,9 @@ class Birthday(commands.Cog):
                             continue
 
                         # Update the list.
-                        await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(False)
+                        await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(
+                            False
+                        )
 
     async def _dailyAdd(self):  # pylint: disable=too-many-branches
         """Add guild members to the birthday role."""
@@ -774,7 +796,9 @@ class Birthday(commands.Cog):
                 # Make sure the guild is configured with birthday role.
                 # If it's not, skip over it.
                 bdayRoleId = await self.config.guild(guild).get_attr(KEY_BDAY_ROLE)()
-                bdayChannelId = await self.config.guild(guild).get_attr(KEY_BDAY_CHANNEL)()
+                bdayChannelId = await self.config.guild(guild).get_attr(
+                    KEY_BDAY_CHANNEL
+                )()
                 if not bdayRoleId:
                     continue
 
@@ -809,9 +833,9 @@ class Birthday(commands.Cog):
                                     member.id,
                                 )
                                 # Update the list.
-                                await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(
-                                    True
-                                )
+                                await self.config.member(member).get_attr(
+                                    KEY_IS_ASSIGNED
+                                ).set(True)
 
                             except discord.Forbidden:
                                 self.logger.error(

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -35,9 +35,7 @@ class Birthday(commands.Cog):
             logPath = os.path.join(saveFolder, "info.log")
             handler = logging.FileHandler(filename=logPath, encoding="utf-8", mode="a")
             handler.setFormatter(
-                logging.Formatter(
-                    "%(asctime)s %(message)s", datefmt="[%d/%m/%Y %H:%M:%S]"
-                )
+                logging.Formatter("%(asctime)s %(message)s", datefmt="[%d/%m/%Y %H:%M:%S]")
             )
             self.logger.addHandler(handler)
 
@@ -82,9 +80,7 @@ class Birthday(commands.Cog):
         """
 
         if channel:
-            await self.config.guild(ctx.guild).get_attr(KEY_BDAY_CHANNEL).set(
-                channel.id
-            )
+            await self.config.guild(ctx.guild).get_attr(KEY_BDAY_CHANNEL).set(channel.id)
             self.logger.info(
                 "%s#%s (%s) set the birthday channel to %s",
                 ctx.author.name,
@@ -190,9 +186,7 @@ class Birthday(commands.Cog):
                     )
                 )
                 try:
-                    response = await self.bot.wait_for(
-                        "message", timeout=30.0, check=check
-                    )
+                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
                     await ctx.send(f"You took too long, not re-adding them.")
                     return
@@ -207,9 +201,7 @@ class Birthday(commands.Cog):
         confMsg = await ctx.send(
             ":white_check_mark: **Birthday - Add**: Successfully {0} **{1}**'s birthday "
             "as **{2:%B} {2:%d}**. The role will be assigned automatically on this "
-            "day.".format(
-                "updated" if birthdayExists else "added", member.name, birthday
-            )
+            "day.".format("updated" if birthdayExists else "added", member.name, birthday)
         )
 
         # Explicitly check to see if user should be added to role, if the month
@@ -244,9 +236,7 @@ class Birthday(commands.Cog):
         """Lists the birthdays of users in the server."""
 
         sortedList = []  # List to sort by month, day.
-        display = (
-            []
-        )  # List of text for paginator to use.  Will be constructed from sortedList.
+        display = []  # List of text for paginator to use.  Will be constructed from sortedList.
 
         # Add only the users we care about (e.g. the ones that have birthdays set).
         membersData = await self.config.all_members(ctx.guild)
@@ -291,9 +281,7 @@ class Birthday(commands.Cog):
         pages = list(pagify(msg, page_length=300))
         totalPages = len(pages)
         async for pageNumber, page in AsyncIter(pages).enumerate(start=1):
-            embed = discord.Embed(
-                title=f"Birthdays in **{ctx.guild.name}**", description=page
-            )
+            embed = discord.Embed(title=f"Birthdays in **{ctx.guild.name}**", description=page)
             embed.set_footer(text=f"Page {pageNumber}/{totalPages}")
             embed.colour = discord.Colour.red()
             pageList.append(embed)
@@ -467,18 +455,14 @@ class Birthday(commands.Cog):
                         )
 
                         def check(msg: discord.Message):
-                            return (
-                                msg.author == ctx.author and msg.channel == ctx.channel
-                            )
+                            return msg.author == ctx.author and msg.channel == ctx.channel
 
                         try:
                             response = await self.bot.wait_for(
                                 "message", timeout=30.0, check=check
                             )
                         except asyncio.TimeoutError:
-                            await ctx.send(
-                                f"{headerBad}: No response detected. Aborting."
-                            )
+                            await ctx.send(f"{headerBad}: No response detected. Aborting.")
                             return
 
                         if response.content.lower() != "yes":
@@ -568,7 +552,7 @@ class Birthday(commands.Cog):
                         f"Type {bold('`yes`', escape_formatting=False)} to confirm.",
                     )
                 )
-                # define the time for the message to live for
+                # define the time for sensitive messages to live for
                 SENSITIVE_MSG_TTL = None if carefree else 5.0
                 try:
                     await channel.send(
@@ -578,7 +562,7 @@ class Birthday(commands.Cog):
                 except discord.Forbidden:
                     # this means messages cannot be sent to the the destination channel
                     # so we abort the flow now by re-raising the exception
-                    # and the caller shall handle it gracefullyu
+                    # and the caller shall handle it gracefully
                     raise
 
                 # wait for answer
@@ -586,9 +570,7 @@ class Birthday(commands.Cog):
                     return msg.author == ctx.author and msg.channel == channel
 
                 try:
-                    response = await self.bot.wait_for(
-                        "message", timeout=6.0, check=check
-                    )
+                    response = await self.bot.wait_for("message", timeout=6.0, check=check)
                 except asyncio.TimeoutError:
                     await channel.send(
                         f"{headerBad}: You took too long. Not setting your birthday."
@@ -596,9 +578,7 @@ class Birthday(commands.Cog):
                     return
 
                 if response.content.lower() != "yes":
-                    await channel.send(
-                        f"{headerBad}: Declined. Not setting your birthday."
-                    )
+                    await channel.send(f"{headerBad}: Declined. Not setting your birthday.")
                     return
 
                 # Set birthday and notify user that their birthday has been set
@@ -643,13 +623,9 @@ class Birthday(commands.Cog):
                     return msg.author == ctx.author and msg.channel == ctx.channel
 
                 try:
-                    response = await self.bot.wait_for(
-                        "message", timeout=10.0, check=check
-                    )
+                    response = await self.bot.wait_for("message", timeout=10.0, check=check)
                 except asyncio.TimeoutError:
-                    await ctx.send(
-                        f"{headerBad}: You took too long. Not setting your birthday."
-                    )
+                    await ctx.send(f"{headerBad}: You took too long. Not setting your birthday.")
                     return
 
                 if response.content.lower() != "yes":
@@ -657,10 +633,6 @@ class Birthday(commands.Cog):
                     return
                 await mainFlow(ctx.channel, carefree=False)
                 return
-
-        raise Exception(
-            "Error while accessing member's birthday config. This should not happen!"
-        )
 
     @_birthday.command(name="selfbirthday")
     @commands.guild_only()
@@ -681,7 +653,9 @@ class Birthday(commands.Cog):
             f"{bold('Enabled')}. Members can set their birthdays themselves "
             f"{bold('ONCE')} and {bold('ONLY IF')} their birthdays were not already set."
         )
-        msgNotAllow = f"{headerGood}: {bold('Disabled')}. Members cannot set their birthdays themselves."
+        msgNotAllow = (
+            f"{headerGood}: {bold('Disabled')}. Members cannot set their birthdays themselves."
+        )
         guildConfig = self.config.guild(ctx.guild)
         allowSelfBirthdayConfig = guildConfig.get_attr(KEY_ALLOW_SELF_BDAY)
         if await allowSelfBirthdayConfig():
@@ -746,9 +720,9 @@ class Birthday(commands.Cog):
                 memberData = await self.config.all_members(guild)  # dict
                 for memberId, memberDetails in memberData.items():
                     # If assigned and the date is different than the date assigned, remove role.
-                    if memberDetails[KEY_IS_ASSIGNED] and memberDetails[
-                        KEY_BDAY_DAY
-                    ] != int(time.strftime("%d")):
+                    if memberDetails[KEY_IS_ASSIGNED] and memberDetails[KEY_BDAY_DAY] != int(
+                        time.strftime("%d")
+                    ):
 
                         role = discord.utils.get(guild.roles, id=bdayRoleId)
                         member = discord.utils.get(guild.members, id=memberId)
@@ -777,9 +751,7 @@ class Birthday(commands.Cog):
                             continue
 
                         # Update the list.
-                        await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(
-                            False
-                        )
+                        await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(False)
 
     async def _dailyAdd(self):  # pylint: disable=too-many-branches
         """Add guild members to the birthday role."""
@@ -796,9 +768,7 @@ class Birthday(commands.Cog):
                 # Make sure the guild is configured with birthday role.
                 # If it's not, skip over it.
                 bdayRoleId = await self.config.guild(guild).get_attr(KEY_BDAY_ROLE)()
-                bdayChannelId = await self.config.guild(guild).get_attr(
-                    KEY_BDAY_CHANNEL
-                )()
+                bdayChannelId = await self.config.guild(guild).get_attr(KEY_BDAY_CHANNEL)()
                 if not bdayRoleId:
                     continue
 
@@ -833,9 +803,9 @@ class Birthday(commands.Cog):
                                     member.id,
                                 )
                                 # Update the list.
-                                await self.config.member(member).get_attr(
-                                    KEY_IS_ASSIGNED
-                                ).set(True)
+                                await self.config.member(member).get_attr(KEY_IS_ASSIGNED).set(
+                                    True
+                                )
 
                             except discord.Forbidden:
                                 self.logger.error(

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -137,7 +137,11 @@ class Birthday(commands.Cog):
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def addMemberBirthday(
-        self, ctx: Context, member: discord.Member, *, birthday: MonthDayConverter = None
+        self,
+        ctx: Context,
+        member: discord.Member,
+        *,
+        birthday: MonthDayConverter = None,
     ):
         """Add a user's birthday to the list.
 
@@ -434,24 +438,25 @@ class Birthday(commands.Cog):
                 if month and day:
                     birthday = date(2020, month, day)
                     birthdayStr = "{0:%B} {0:%d}".format(birthday)
+                    birthdayInfoMsg = (
+                        f"{headerGood}: Your birthday is "
+                        f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
+                    )
                     try:
-                        await ctx.author.send(
-                            f"{headerGood}: Your birthday is "
-                            f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
-                        )
+                        await ctx.author.send(birthdayInfoMsg)
                         return
                     except discord.Forbidden:
+                        await ctx.send(
+                            f"{headerWarn}: I would like to DM you your birthday but it seeems that"
+                            "you have disabled DMs from this server. Would you still like to continue here? "
+                            "Your birthday will be sent here and deleted after a short delay. "
+                            f"Type {bold('`yes`', escape_formatting=False)} to confirm. "
+                            "Anything else will be treated as no."
+                        )
 
                         def check(msg: discord.Message):
                             return msg.author == ctx.author and msg.channel == ctx.channel
 
-                        await ctx.send(
-                            f"{headerWarn}: I would like to DM you your birthday but it seeems that "
-                            "you have disabled DMs from this server. Would you still like to continue here? "
-                            "Your birthday will be sent here and deleted after a short delay. "
-                            f"\nType {bold('`yes`', escape_formatting=False)} to confirm. "
-                            "\nAnything else will be treated as no."
-                        )
                         try:
                             response = await self.bot.wait_for(
                                 "message", timeout=30.0, check=check
@@ -463,12 +468,7 @@ class Birthday(commands.Cog):
                         if response.content.lower() != "yes":
                             await ctx.send(f"{headerBad}: Aborting.")
                             return
-
-                        await ctx.send(
-                            f"{headerGood}: Your birthday is "
-                            f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
-                            delete_after=5,
-                        )
+                        await ctx.send(birthdayInfoMsg, delete_after=5)
                         return
         setSelfBirthdayCmd: commands.Command = self.setSelfBirthday
         helpSetSelfBirthdayCmdStr = (
@@ -543,39 +543,56 @@ class Birthday(commands.Cog):
         birthdayStr = "{0:%B} {0:%d}".format(birthday)
 
         if birthdayConfig:
-            confirmationStr = (
-                f"Are you sure you want to set your birthday to "
-                f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}? "
-                "Only administrators and moderators can reset your birthday afterwards. "
-                f"Type {bold('`yes`', escape_formatting=False)} to confirm."
+            confirmationStr = "\n".join(
+                (
+                    f"Are you sure you want to set your birthday to "
+                    f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}? "
+                    "Only administrators and moderators can reset your birthday afterwards.",
+                    f"Type {bold('`yes`', escape_formatting=False)} to confirm.",
+                )
             )
 
-            try:
+            async def mainFlow(destination, carefree: bool = False):
+                # define the time for the message to live for
+                SENSITIVE_MSG_TTL = None if carefree else 10.0
+                try:
+                    await destination.send(
+                        f"{headerWarn}: {confirmationStr}",
+                        delete_after=SENSITIVE_MSG_TTL,
+                    )
+                except discord.Forbidden:
+                    # catch failed DM
+                    raise
+                # wait for answer
+                responseChannel = None
+                if carefree:
+                    responseChannel = destination.dm_channel
+                else:
+                    responseChannel = destination.channel
 
                 def check(msg: discord.Message):
-                    return msg.author == ctx.author and msg.channel == ctx.author.dm_channel
-
-                await ctx.author.send(f"{headerWarn}: {confirmationStr}")
+                    return msg.author == ctx.author and msg.channel == responseChannel
 
                 try:
-                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
+                    response = await self.bot.wait_for("message", timeout=10.0, check=check)
                 except asyncio.TimeoutError:
-                    await ctx.author.send(
+                    await destination.send(
                         f"{headerBad}: You took too long. Not setting your birthday."
                     )
                     return
 
                 if response.content.lower() != "yes":
-                    await ctx.author.send(f"{headerBad}: Declined. Not setting your birthday.")
+                    await destination.send(f"{headerBad}: Declined. Not setting your birthday.")
                     return
-
+                # Set birthday and notify user that their birthday has been set
                 await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
                 await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
                 await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
 
-                await ctx.author.send(
+                await destination.send(
                     f"{headerGood}: Successfully set your birthday to "
-                    f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
+                    f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
+                    delete_after=SENSITIVE_MSG_TTL,
                 )
 
                 self.logger.info(
@@ -586,22 +603,31 @@ class Birthday(commands.Cog):
                     birthdayStr,
                 )
 
-                # explicitly check to see if user should be added to role, if the month
-                # and day just so happen to be the same as it is now.
+                # explicitly check to see if the role should be applied to the user
+                # if the month and day just so happen to be the same as it is now.
                 await self.checkBirthday()
                 return
+
+            try:
+                await mainFlow(ctx.author, carefree=True)
+                return
             except discord.Forbidden:
+                await ctx.send(
+                    "\n".join(
+                        (
+                            "You have disabled DMs from this server. Would you "
+                            "still like to continue here? All messages containing your "
+                            "birthday will be deleted after a short delay.",
+                            f"Type {bold('`yes`', escape_formatting=False)} to confirm.",
+                        )
+                    )
+                )
 
                 def check(msg: discord.Message):
                     return msg.author == ctx.author and msg.channel == ctx.channel
 
-                await ctx.send(
-                    "You have disabled DMs from this server. Would you "
-                    "still like to continue here?"
-                    f"Type {bold('`yes`', escape_formatting=False)} to confirm."
-                )
                 try:
-                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
+                    response = await self.bot.wait_for("message", timeout=10.0, check=check)
                 except asyncio.TimeoutError:
                     await ctx.send(f"{headerBad}: You took too long. Not setting your birthday.")
                     return
@@ -609,52 +635,9 @@ class Birthday(commands.Cog):
                 if response.content.lower() != "yes":
                     await ctx.send(f"{headerBad}: Declined. Not setting your birthday.")
                     return
-
-            msg: discord.Message = await ctx.send(f"{headerWarn}: {confirmationStr}")
-            try:
-                response = await self.bot.wait_for("message", timeout=10.0, check=check)
-            except asyncio.TimeoutError:
-                try:
-                    await ctx.send(f"{headerBad}: No response. Aborting.")
-                    await msg.delete()
-                    return
-                except (discord.NotFound, discord.HTTPException, discord.Forbidden) as e:
-                    self.logger.debug(e)
-                    return
-
-            if response.content.lower() != "yes":
-                await ctx.send(
-                    f"{headerBad}: Declined. Not setting your birthday.",
-                )
-                try:
-                    await msg.delete()
-                    return
-                except (discord.NotFound, discord.HTTPException, discord.Forbidden) as e:
-                    self.logger.debug(e)
-                    return
-
-            await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
-            await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
-            await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
-            await ctx.send(
-                f"{headerGood}: Successfully set your birthday to "
-                f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
-                delete_after=5,
-            )
-            self.logger.info(
-                "%s#%s (%s) added their birthday as %s",
-                ctx.author.name,
-                ctx.author.discriminator,
-                ctx.author.id,
-                birthdayStr,
-            )
-            await self.checkBirthday()
-            try:
-                await msg.delete()
+                await mainFlow(ctx, carefree=False)
                 return
-            except (discord.NotFound, discord.HTTPException, discord.Forbidden) as e:
-                self.logger.debug(e)
-                return
+
         raise Exception("Error while accessing member's birthday config. This should not happen!")
 
     @_birthday.command(name="selfbirthday")

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -573,9 +573,9 @@ class Birthday(commands.Cog):
                     return msg.author == ctx.author and msg.channel == channel
 
                 # define response wait time
-                timeout = SENSITIVE_MSG_TTL + 1 if SENSITIVE_MSG_TTL else 30
+                responseTimeout = SENSITIVE_MSG_TTL + 1 if SENSITIVE_MSG_TTL else 30
                 try:
-                    response = await self.bot.wait_for("message", timeout=6.0, check=check)
+                    response = await self.bot.wait_for("message", timeout=responseTimeout, check=check)
                 except asyncio.TimeoutError:
                     await channel.send(
                         f"{headerBad}: You took too long. Not setting your birthday."

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -433,12 +433,49 @@ class Birthday(commands.Cog):
                 if month and day:
                     birthday = date(2020, month, day)
                     birthdayStr = "{0:%B} {0:%d}".format(birthday)
-                    await ctx.author.send(
-                        f"{headerGood}: Your birthday is "
-                        f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
-                    )
-                    return
+                    try:
+                        await ctx.author.send(
+                            f"{headerGood}: Your birthday is "
+                            f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
+                        )
+                        return
+                    except discord.Forbidden:
 
+                        def check(msg: discord.Message):
+                            return msg.author == ctx.author and msg.channel == ctx.channel
+
+                        try:
+                            await ctx.send(
+                                "You have disabled DMs from this server. Would you still like to continue here? "
+                                "The your birthday will be sent here and deleted after a short delay. "
+                                f"Type {bold('`yes`', escape_formatting=False)} to confirm."
+                            )
+                            response = await self.bot.wait_for(
+                                "message", timeout=30.0, check=check
+                            )
+                        except asyncio.TimeoutError:
+                            await ctx.send(f"{headerBad}: No response detected. Aborting.")
+                            return
+
+                        if response.content.lower() != "yes":
+                            await ctx.send("Alright then")
+                            return
+
+                        can_delete = ctx.channel.permissions_for(ctx.me).manage_messages
+                        if can_delete:
+                            await ctx.send(
+                                f"{headerGood}: Your birthday is "
+                                f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
+                                delete_after=5,
+                            )
+                            return
+                        else:
+                            await ctx.send(
+                                f"{headerBad}: Unable to delete messages. Please "
+                                "notify the server administrators to give me the "
+                                '"Manage Messages" permission'
+                            )
+                            return
         setSelfBirthdayCmd: commands.Command = self.setSelfBirthday
         helpSetSelfBirthdayCmdStr = (
             # pylint: disable=no-member
@@ -520,10 +557,12 @@ class Birthday(commands.Cog):
             )
 
             try:
+
                 def check(msg: discord.Message):
                     return msg.author == ctx.author and msg.channel == ctx.author.dm_channel
+
                 await ctx.author.send(f"{headerWarn}: {confirmationStr}")
-    
+
                 try:
                     response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
@@ -532,20 +571,20 @@ class Birthday(commands.Cog):
                         f"{headerBad}: You took too long. Not setting your birthday."
                     )
                     return
-    
+
                 if response.content.lower() != "yes":
                     await ctx.author.send(f"{headerBad}: Declined. Not setting your birthday.")
                     return
-    
+
                 await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
                 await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
                 await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
-    
+
                 await ctx.author.send(
                     f"{headerGood}: Successfully set your birthday to "
                     f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}."
                 )
-    
+
                 self.logger.info(
                     "%s#%s (%s) added their birthday as %s",
                     ctx.author.name,
@@ -553,21 +592,23 @@ class Birthday(commands.Cog):
                     ctx.author.id,
                     birthdayStr,
                 )
-    
+
                 # explicitly check to see if user should be added to role, if the month
                 # and day just so happen to be the same as it is now.
                 await self.checkBirthday()
                 return
             except discord.Forbidden:
+
                 def check(msg: discord.Message):
                     return msg.author == ctx.author and msg.channel == ctx.channel
+
                 try:
                     await ctx.send(
                         "You have disabled DMs from this server. Would you "
                         "still like to continue here?"
                         f"Type {bold('`yes`', escape_formatting=False)} to confirm."
-                        )
-                    response = await self.bot.wait_for("message", timeout = 30.0, check=check) 
+                    )
+                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
                     await ctx.send(f"{headerBad}: You took too long. Not setting your birthday.")
                     return
@@ -580,13 +621,10 @@ class Birthday(commands.Cog):
                 if can_delete:
                     msg: discord.Message = await ctx.send(f"{headerWarn}: {confirmationStr}")
                     try:
-                        response = await self.bot.wait_for("message", timeout = 10.0, check=check)
+                        response = await self.bot.wait_for("message", timeout=10.0, check=check)
                     except asyncio.TimeoutError:
                         try:
-                            await ctx.send(
-                                    f"{headerBad}: No response. Aborting",
-                                    delete_after=10
-                                    )
+                            await ctx.send(f"{headerBad}: No response. Aborting", delete_after=10)
                             await msg.delete()
                             return
                         except (discord.NotFound, discord.HTTPException):
@@ -594,9 +632,8 @@ class Birthday(commands.Cog):
 
                     if response.content.lower() != "yes":
                         await ctx.send(
-                                f"{headerBad}: Declined. Not setting your birthday.",
-                                delete_after=5
-                                )
+                            f"{headerBad}: Declined. Not setting your birthday.", delete_after=5
+                        )
                         try:
                             await msg.delete()
                         except (discord.NotFound, discord.HTTPException):
@@ -609,8 +646,8 @@ class Birthday(commands.Cog):
                     await ctx.send(
                         f"{headerGood}: Successfully set your birthday to "
                         f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
-                        delete_after=5
-                    )      
+                        delete_after=5,
+                    )
                     self.logger.info(
                         "%s#%s (%s) added their birthday as %s",
                         ctx.author.name,
@@ -623,6 +660,14 @@ class Birthday(commands.Cog):
                         await msg.delete()
                         return
                     except (discord.NotFound, discord.HTTPException):
+                        return
+
+                    else:
+                        await ctx.send(
+                            f"{headerBad}: Unable to delete messages. Please "
+                            "notify the server administrators to give me the "
+                            '"Manage Messages" permission'
+                        )
                         return
         raise Exception("Error while accessing member's birthday config. This should not happen!")
 

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -587,7 +587,7 @@ class Birthday(commands.Cog):
 
                 try:
                     response = await self.bot.wait_for(
-                        "message", timeout=10.0, check=check
+                        "message", timeout=6.0, check=check
                     )
                 except asyncio.TimeoutError:
                     await channel.send(

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -423,6 +423,7 @@ class Birthday(commands.Cog):
         fnTitle = "Birthday - Get Self's Birthday"
         headerBad = f":negative_squared_cross_mark: {bold(fnTitle)}"
         headerGood = f":white_check_mark: {bold(fnTitle)}"
+        headerWarn = warning(bold(fnTitle))
 
         birthdayConfig = self.config.member(ctx.author)
         if birthdayConfig:
@@ -444,12 +445,14 @@ class Birthday(commands.Cog):
                         def check(msg: discord.Message):
                             return msg.author == ctx.author and msg.channel == ctx.channel
 
+                        await ctx.send(
+                            f"{headerWarn}: I would like to DM you your birthday but it seeems that "
+                            "you have disabled DMs from this server. Would you still like to continue here? "
+                            "Your birthday will be sent here and deleted after a short delay. "
+                            f"\nType {bold('`yes`', escape_formatting=False)} to confirm. "
+                            "\nAnything else will be treated as no."
+                        )
                         try:
-                            await ctx.send(
-                                "You have disabled DMs from this server. Would you still like to continue here? "
-                                "The your birthday will be sent here and deleted after a short delay. "
-                                f"Type {bold('`yes`', escape_formatting=False)} to confirm."
-                            )
                             response = await self.bot.wait_for(
                                 "message", timeout=30.0, check=check
                             )
@@ -458,24 +461,17 @@ class Birthday(commands.Cog):
                             return
 
                         if response.content.lower() != "yes":
-                            await ctx.send("Alright then")
+                            await ctx.send(
+                                    f"{headerBad}: Aborting."
+                                    )
                             return
 
-                        canDelete = ctx.channel.permissions_for(ctx.me).manage_messages
-                        if canDelete:
-                            await ctx.send(
-                                f"{headerGood}: Your birthday is "
-                                f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
-                                delete_after=5,
-                            )
-                            return
-                        else:
-                            await ctx.send(
-                                f"{headerBad}: Unable to delete messages. Please "
-                                "notify the server administrators to give me the "
-                                '"Manage Messages" permission'
-                            )
-                            return
+                        await ctx.send(
+                            f"{headerGood}: Your birthday is "
+                            f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
+                            delete_after=5,
+                        )
+                        return
         setSelfBirthdayCmd: commands.Command = self.setSelfBirthday
         helpSetSelfBirthdayCmdStr = (
             # pylint: disable=no-member
@@ -566,7 +562,6 @@ class Birthday(commands.Cog):
                 try:
                     response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
-                    # hide the birthday portion within the previous message
                     await ctx.author.send(
                         f"{headerBad}: You took too long. Not setting your birthday."
                     )
@@ -602,12 +597,12 @@ class Birthday(commands.Cog):
                 def check(msg: discord.Message):
                     return msg.author == ctx.author and msg.channel == ctx.channel
 
+                await ctx.send(
+                    "You have disabled DMs from this server. Would you "
+                    "still like to continue here?"
+                    f"Type {bold('`yes`', escape_formatting=False)} to confirm."
+                )
                 try:
-                    await ctx.send(
-                        "You have disabled DMs from this server. Would you "
-                        "still like to continue here?"
-                        f"Type {bold('`yes`', escape_formatting=False)} to confirm."
-                    )
                     response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
                     await ctx.send(f"{headerBad}: You took too long. Not setting your birthday.")
@@ -616,59 +611,52 @@ class Birthday(commands.Cog):
                 if response.content.lower() != "yes":
                     await ctx.send(f"{headerBad}: Declined. Not setting your birthday.")
                     return
-                can_delete = ctx.channel.permissions_for(ctx.me).manage_messages
 
-                if can_delete:
-                    msg: discord.Message = await ctx.send(f"{headerWarn}: {confirmationStr}")
-                    try:
-                        response = await self.bot.wait_for("message", timeout=10.0, check=check)
-                    except asyncio.TimeoutError:
-                        try:
-                            await ctx.send(f"{headerBad}: No response. Aborting", delete_after=10)
-                            await msg.delete()
-                            return
-                        except (discord.NotFound, discord.HTTPException):
-                            return
+            msg: discord.Message = await ctx.send(f"{headerWarn}: {confirmationStr}")
+            try:
+                response = await self.bot.wait_for("message", timeout=10.0, check=check)
+            except asyncio.TimeoutError:
+                try:
+                    await ctx.send(f"{headerBad}: No response. Aborting.")
+                    await msg.delete()
+                    return
+                except (discord.NotFound, discord.HTTPException, discord.Forbidden) as e:
+                    self.logger.debug(e)
+                    return
 
-                    if response.content.lower() != "yes":
-                        await ctx.send(
-                            f"{headerBad}: Declined. Not setting your birthday.", delete_after=5
-                        )
-                        try:
-                            await msg.delete()
-                        except (discord.NotFound, discord.HTTPException):
-                            return
-                        return
+            if response.content.lower() != "yes":
+                await ctx.send(
+                    f"{headerBad}: Declined. Not setting your birthday.",
+                )
+                try:
+                    await msg.delete()
+                    return
+                except (discord.NotFound, discord.HTTPException) as e:
+                    self.logger.debug(e)
+                    return
 
-                    await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
-                    await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
-                    await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
-                    await ctx.send(
-                        f"{headerGood}: Successfully set your birthday to "
-                        f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
-                        delete_after=5,
-                    )
-                    self.logger.info(
-                        "%s#%s (%s) added their birthday as %s",
-                        ctx.author.name,
-                        ctx.author.discriminator,
-                        ctx.author.id,
-                        birthdayStr,
-                    )
-                    await self.checkBirthday()
-                    try:
-                        await msg.delete()
-                        return
-                    except (discord.NotFound, discord.HTTPException):
-                        return
-
-                    else:
-                        await ctx.send(
-                            f"{headerBad}: Unable to delete messages. Please "
-                            "notify the server administrators to give me the "
-                            '"Manage Messages" permission'
-                        )
-                        return
+            await birthdayConfig.get_attr(KEY_BDAY_MONTH).set(birthday.month)
+            await birthdayConfig.get_attr(KEY_BDAY_DAY).set(birthday.day)
+            await birthdayConfig.get_attr(KEY_ADDED_BEFORE).set(True)
+            await ctx.send(
+                f"{headerGood}: Successfully set your birthday to "
+                f"{spoiler(bold(birthdayStr, escape_formatting=False), escape_formatting=False)}.",
+                delete_after=5,
+            )
+            self.logger.info(
+                "%s#%s (%s) added their birthday as %s",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                birthdayStr,
+            )
+            await self.checkBirthday()
+            try:
+                await msg.delete()
+                return
+            except (discord.NotFound, discord.HTTPException, discord.Forbidden) as e:
+                self.logger.debug(e)
+                return
         raise Exception("Error while accessing member's birthday config. This should not happen!")
 
     @_birthday.command(name="selfbirthday")

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -618,6 +618,7 @@ class Birthday(commands.Cog):
                         ctx.author.id,
                         birthdayStr,
                     )
+                    await self.checkBirthday()
                     try:
                         await msg.delete()
                         return

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -428,6 +428,15 @@ class Birthday(commands.Cog):
         headerBad = f":negative_squared_cross_mark: {bold(fnTitle)}"
         headerGood = f":white_check_mark: {bold(fnTitle)}"
         headerWarn = warning(bold(fnTitle))
+        noDmStr = "\n".join(
+            (
+                f"{headerWarn}: I would like to DM you your birthday but it seeems that "
+                "you have disabled DMs from this server. Would you still like to continue here? "
+                "Your birthday will be sent here and deleted after a short delay. ",
+                f"Type {bold('`yes`', escape_formatting=False)} to confirm. ",
+                "Anything else will be treated as no.",
+            )
+        )
 
         birthdayConfig = self.config.member(ctx.author)
         if birthdayConfig:
@@ -446,13 +455,7 @@ class Birthday(commands.Cog):
                         await ctx.author.send(birthdayInfoMsg)
                         return
                     except discord.Forbidden:
-                        await ctx.send(
-                            f"{headerWarn}: I would like to DM you your birthday but it seeems that "
-                            "you have disabled DMs from this server. Would you still like to continue here? "
-                            "Your birthday will be sent here and deleted after a short delay. "
-                            f"Type {bold('`yes`', escape_formatting=False)} to confirm. "
-                            "Anything else will be treated as no."
-                        )
+                        await ctx.send(noDmStr)
 
                         def check(msg: discord.Message):
                             return msg.author == ctx.author and msg.channel == ctx.channel
@@ -569,6 +572,8 @@ class Birthday(commands.Cog):
                 def check(msg: discord.Message):
                     return msg.author == ctx.author and msg.channel == channel
 
+                # define response wait time
+                timeout = SENSITIVE_MSG_TTL + 1 if SENSITIVE_MSG_TTL else 30
                 try:
                     response = await self.bot.wait_for("message", timeout=6.0, check=check)
                 except asyncio.TimeoutError:
@@ -632,7 +637,6 @@ class Birthday(commands.Cog):
                     await ctx.send(f"{headerBad}: Declined. Not setting your birthday.")
                     return
                 await mainFlow(ctx.channel, carefree=False)
-                return
 
     @_birthday.command(name="selfbirthday")
     @commands.guild_only()

--- a/cogs/birthday/birthday.py
+++ b/cogs/birthday/birthday.py
@@ -461,9 +461,7 @@ class Birthday(commands.Cog):
                             return
 
                         if response.content.lower() != "yes":
-                            await ctx.send(
-                                    f"{headerBad}: Aborting."
-                                    )
+                            await ctx.send(f"{headerBad}: Aborting.")
                             return
 
                         await ctx.send(
@@ -631,7 +629,7 @@ class Birthday(commands.Cog):
                 try:
                     await msg.delete()
                     return
-                except (discord.NotFound, discord.HTTPException) as e:
+                except (discord.NotFound, discord.HTTPException, discord.Forbidden) as e:
                     self.logger.debug(e)
                     return
 


### PR DESCRIPTION
## Summary

Adds a try catch statement when sending DMs and offers/prompts the user to finish the process of setting their own birthday in the channel rather than DMs.

Both the get and set command self delete any message that mentions the user's birthday in any capacity. 

Fixes #583
