### PR TITLE
[Invoice] Modify for Red-DiscordBot dpy2 support

### DIFF
--- a/cogs/invoice/__init__.py
+++ b/cogs/invoice/__init__.py
@@ -1,5 +1,5 @@
 from .invoice import InVoice
 
 
-def setup(bot):
-    bot.add_cog(InVoice())
+async def setup(bot):
+    await bot.add_cog(InVoice())

--- a/cogs/invoice/invoice.py
+++ b/cogs/invoice/invoice.py
@@ -5,7 +5,7 @@ import typing
 
 from copy import copy
 from redbot.core import checks, commands, Config
-from redbot.core.utils.chat_formatting import box, bordered
+from redbot.core.utils.chat_formatting import box
 
 listener = getattr(commands.Cog, "listener", lambda name=None: (lambda f: f))
 


### PR DESCRIPTION
### Description of the changes
This PR fixes the Invoice cog from being loaded after upgrading to `Red-DiscordBot` v3.5.x/`discord.py` 2.x by doing the following:
- `add_cog` is now a coroutine, so make setup async.
- Remove bordered import, as it no longer exists in redbot and is not being used.



### Have the changes in this PR been tested?

Yes, tested in prod. Verified that `Voice-Text` role is applied on voice channel join and removed when leaving.