### PR TITLE
[SFU] Modify Roads ctx typing call

### DIFF
--- a/cogs/sfu/roads.py
+++ b/cogs/sfu/roads.py
@@ -120,7 +120,7 @@ class SFURoads(SFUBase):
             udn:    University Drive North
             wmc:    West Mall Centre (WMC) Roof
         """
-        await ctx.trigger_typing()
+        await ctx.typing()
 
         camera = self.cameras.get(cam.lower(), "help")
         if camera == "help":


### PR DESCRIPTION
Roads used a function call `await ctx.trigger_typing()` which was deprecated due to dpy2 conversion, causing the cog to error out with the below error.
```
[2023-01-12 19:19:42] [ERROR] red: Exception in command 'sfu cam'
Traceback (most recent call last):
  File "/home/ubuntu/github/renchan/lib/python3.8/site-packages/discord/ext/commands/core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/github/renchan/Ren/cogs/sfu/roads.py", line 123, in cam
    await ctx.trigger_typing()
AttributeError: 'Context' object has no attribute 'trigger_typing'
```