### PR TITLE
[CI] Bump versions of `cogUnitTests` Python and actions

### DIFF
--- a/.github/workflows/cogUnitTests.yml
+++ b/.github/workflows/cogUnitTests.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup python3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
### Description of the changes

For `cogUnitTests.yml` workflow:
- Bump `actions/checkout` and `actions/setup-python` from `v2` to `v3`.
- Bump Python version from 3.8 to 3.9.

### Have the changes in this PR been tested?

Yes. Successful runs:
- https://github.com/quachtridat/Ren/actions/runs/3925185169
- https://github.com/SFUAnime/Ren/actions/runs/3925213449

The `set-output` deprecation warning is from `actions/setup-python@v3`, so we'll wait for them to fix it.