### PR TITLE
[Welcome] Change the emote for new user joins

### DIFF
--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -244,7 +244,7 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
             else:
                 if guildData[KEY_LOG_JOIN_ENABLED] and not test and channel:
                     await channel.send(
-                        f":o: ``Server Welcome:`` User {newUser.mention} "
+                        f":white_check_mark: ``Server Welcome:`` User {newUser.mention} "
                         f"{newUser.name}#{newUser.discriminator} "
                         f"({newUser.id}) has joined. DM sent."
                     )


### PR DESCRIPTION
Based on feedback, decided to update the emote used for logging new users joins from ⭕ to ✅ (mainly for easier readability)