### PR TITLE
[Triggered] Convert images with the mode "P" to "RBGA" so hypertriggered works

### DIFF
--- a/cogs/triggered/core.py
+++ b/cogs/triggered/core.py
@@ -63,6 +63,10 @@ class Core:
                 avatar = Image.composite(avatar, red_overlay, mask)
 
             elif mode == Modes.HYPER_TRIGGERED:
+                if avatar.mode == "P":
+                    # for Discord default avatars
+                    avatar = avatar.convert(mode="RGBA")
+                    
                 avatar = ImageEnhance.Color(avatar).enhance(5)
                 avatar = ImageEnhance.Sharpness(avatar).enhance(24)
                 avatar = ImageEnhance.Contrast(avatar).enhance(4)

--- a/cogs/triggered/core.py
+++ b/cogs/triggered/core.py
@@ -66,7 +66,6 @@ class Core:
                 if avatar.mode == "P":
                     # for Discord default avatars
                     avatar = avatar.convert(mode="RGBA")
-                    
                 avatar = ImageEnhance.Color(avatar).enhance(5)
                 avatar = ImageEnhance.Sharpness(avatar).enhance(24)
                 avatar = ImageEnhance.Contrast(avatar).enhance(4)


### PR DESCRIPTION
### Description of the changes
Resolves https://github.com/SFUAnime/Ren/issues/614 based on the proposed fix. It converts images with the mode "P" to "RGBA" before applying the hypertriggered effect. For example, the mode of the default Discord avatar image is "P".


### Have the changes in this PR been tested?

<!--
Choose one (remove the line that doesn't apply):
-->
Yes
<!--
If the question doesn't apply (for example, it's not a code change), choose Yes.

Please respond to this question truthfully. We do not delay nor reject PRs
based on the answer to this question but it allows to better review this PR.
-->

![image](https://user-images.githubusercontent.com/20215696/224235927-ba0f441f-9309-45dd-9c3f-267a977128d2.png)
![image](https://user-images.githubusercontent.com/20215696/224236001-ac01c605-ca2d-42c7-9cdc-12c4fa7e4d61.png)

