### PR TITLE
[Welcome] Separate welcome logging from DMs

### DIFF
--- a/cogs/welcome/welcome.py
+++ b/cogs/welcome/welcome.py
@@ -288,10 +288,12 @@ class Welcome(commands.Cog):  # pylint: disable=too-many-instance-attributes
 
     async def logServerJoin(self, joinUser: discord.Member):
         """Logs the server join to a channel, if enabled."""
-        async with self.config.guild(joinUser.guild).all() as guildData:
-            if guildData[KEY_LOG_JOIN_ENABLED]:
-                channel = discord.utils.get(
-                    joinUser.guild.text_channels, id=guildData[KEY_LOG_JOIN_CHANNEL]
+        guildConfig: Group = self.config.guild(joinUser.guild)
+        if await guildConfig.get_attr(KEY_LOG_JOIN_ENABLED)():
+            logJoinChannelId: Optional[int] = await guildConfig.get_attr(KEY_LOG_JOIN_CHANNEL)()
+            if logJoinChannelId:
+                channel: Optional[TextChannel] = discord.utils.get(
+                    joinUser.guild.text_channels, id=logJoinChannelId
                 )
                 if channel:
                     await channel.send(


### PR DESCRIPTION
Welcome logging was tied to welcome DMs before.

This PR resolves #635 by decoupling the two.

# Screenshot
![image](https://user-images.githubusercontent.com/6710854/229698746-5b98257d-070f-49d0-856f-755fa63077f0.png)

# Logs
```
[22:05:08] INFO     [red.luicogs.Welcome] User Injabie4#2961 (302961479005765633) has joined server Ren's Playground (224254872302780416).
[22:05:32] INFO     [red.luicogs.Welcome] User Injabie4#2961 (302961479005765633) has left server Ren's Playground (224254872302780416).

```