### PR TITLE
[Tags] Save data in the config directory

### DIFF
--- a/cogs/tags/config.py
+++ b/cogs/tags/config.py
@@ -1,7 +1,8 @@
+import asyncio
 import json
 import os
+import pathlib
 import uuid
-import asyncio
 
 """
 NOTE: I wrote none of this (well, updated some things),
@@ -14,7 +15,7 @@ class Config:
 
     def __init__(self, directory, name, **options):
         self.name = name
-        self.directory = "{}/".format(directory)
+        self.directory = pathlib.Path(directory)
         self.object_hook = options.pop("object_hook", None)
         self.encoder = options.pop("encoder", None)
         self.loop = options.pop("loop", asyncio.get_event_loop())
@@ -36,7 +37,7 @@ class Config:
             await self.loop.run_in_executor(None, self.load_from_file)
 
     def _dump(self):
-        temp = "%s-%s.tmp" % (uuid.uuid4(), self.name)
+        temp = self.directory / f"{uuid.uuid4()}-{self.name}.tmp"
         with open(temp, "w", encoding="utf-8") as tmp:
             json.dump(
                 self._db.copy(), tmp, ensure_ascii=True, cls=self.encoder, separators=(",", ":")


### PR DESCRIPTION
## Summary ##

This PR fixes #638 by making `Tags` write to the directory specified in `Config` class (which is specified by the cog to be the cog data path set up as a part of bot instance setup) which is writable.

## Details ##

Currently the cog writes to a file whose path is specified as a purely relative path, which, at absolute path resolution time, will become a path under wherever the bot is running (most likely not the writable cog data path) and the cog will fail when it does not have write permission to the said resolved path.

This commit specifies a path relative to the cog data path which is writable by cogs, which avoids the aforementioned issue.

## Testing ##

<details><summary>Without the fix</summary>

![image](https://user-images.githubusercontent.com/6735818/230711249-48df2ff6-ab9e-4127-aee5-8d2c5cfac3ff.png)

<details><summary>Log lines</summary>

```
ren  | [2023-04-08 01:01:05] [ERROR] discord.client: Ignoring exception in on_message
ren  | Traceback (most recent call last):
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/ext/commands/core.py", line 229, in wrapped
ren  |     ret = await coro(*args, **kwargs)
ren  |   File "/data/cogs/CogManager/cogs/tags/tags.py", line 449, in create
ren  |     await self.config.put(location, db)
ren  |   File "/data/cogs/CogManager/cogs/tags/config.py", line 59, in put
ren  |     await self.save()
ren  |   File "/data/cogs/CogManager/cogs/tags/config.py", line 50, in save
ren  |     await self.loop.run_in_executor(None, self._dump)
ren  |   File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run
ren  |     result = self.fn(*self.args, **self.kwargs)
ren  |   File "/data/cogs/CogManager/cogs/tags/config.py", line 40, in _dump
ren  |     with open(temp, "w", encoding="utf-8") as tmp:
ren  | PermissionError: [Errno 13] Permission denied: '84f4e12f-9800-4e24-a760-f2b487f19409-tags.json.tmp'
ren  |
ren  | The above exception was the direct cause of the following exception:
ren  |
ren  | Traceback (most recent call last):
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/client.py", line 409, in _run_event
ren  |     await coro(*args, **kwargs)
ren  |   File "/data/venv/lib/python3.9/site-packages/redbot/core/events.py", line 374, in on_message
ren  |     await bot.process_commands(message)
ren  |   File "/data/venv/lib/python3.9/site-packages/redbot/core/bot.py", line 1599, in process_commands
ren  |     await self.invoke(ctx)
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/ext/commands/bot.py", line 1353, in invoke
ren  |     await ctx.command.dispatch_error(ctx, exc)
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/ext/commands/core.py", line 633, in dispatch_error
ren  |     await injected(cog, ctx, error)
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/ext/commands/core.py", line 211, in wrapped
ren  |     ret = await coro(*args, **kwargs)
ren  |   File "/data/cogs/CogManager/cogs/tags/tags.py", line 469, in create_error
ren  |     raise error
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/ext/commands/bot.py", line 1349, in invoke
ren  |     await ctx.command.invoke(ctx)
ren  |   File "/data/venv/lib/python3.9/site-packages/redbot/core/commands/commands.py", line 782, in invoke
ren  |     await super().invoke(ctx)
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/ext/commands/core.py", line 1642, in invoke
ren  |     await ctx.invoked_subcommand.invoke(ctx)
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/ext/commands/core.py", line 1023, in invoke
ren  |     await injected(*ctx.args, **ctx.kwargs)  # type: ignore
ren  |   File "/data/venv/lib/python3.9/site-packages/discord/ext/commands/core.py", line 238, in wrapped
ren  |     raise CommandInvokeError(exc) from exc
ren  | discord.ext.commands.errors.CommandInvokeError: Command raised an exception: PermissionError: [Errno 13] Permission denied: '84f4e12f-9800-4e24-a760-f2b487f19409-tags.json.tmp'
``` 

</details>

</details>

<details><summary>With the fix</summary>

![image](https://user-images.githubusercontent.com/6735818/230711784-ab952835-ca42-4d05-b42b-f7c8e4d2b1b1.png)

</details>