### PR TITLE
[Heartbeat] Use `pytest_asyncio.fixture()`

### DIFF
--- a/cogs/heartbeat/conftest.py
+++ b/cogs/heartbeat/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest.mock
 
 import pytest
+import pytest_asyncio
 
 from redbot.core.bot import Red
 from redbot.core.commands.context import Context
@@ -10,7 +11,7 @@ from .core import Core
 from .heartbeat import Heartbeat
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture()
 async def cogHeartbeat(
     monkeypatch: pytest.MonkeyPatch,
     red: Red,


### PR DESCRIPTION
## Summary ##

Let `conftest.py` in `cogs/heartbeat` use `pytest_asyncio.fixture()` to define async fixtures, instead of `pytest.fixture()`. This helps resolve Injabie3/lui-cogs-v3#10 because `pytest_asyncio.fixture()` is necessary for async fixtures to be picked up by `pytest-asyncio` strict mode.

## Testing ##

All tests ran and passed with `pytest-asyncio` strict test discovery mode.

```
PS> pytest .\cogs -o python_files=test*
================================================================== test session starts ================================================================== 
platform win32 -- Python 3.9.13, pytest-7.2.0, pluggy-1.0.0
rootdir: E:\Data\Coding\GitHub\quachtridat\Ren, configfile: pyproject.toml
plugins: aiohttp-json-rpc-0.13.3, asyncio-0.20.3, mock-3.10.0, Red-DiscordBot-3.5.1.dev1
asyncio: mode=strict
collected 75 items                                                                                                                                        

cogs\birthday\testBirthday.py .....                                                                                                                [  6%] 
cogs\birthday\testConverters.py ...........                                                                                                        [ 21%] 
cogs\heartbeat\testCommandsCore.py .......                                                                                                         [ 30%] 
cogs\heartbeat\testCore.py .                                                                                                                       [ 32%] 
cogs\tags\testHelpers.py ......................................                                                                                    [ 82%] 
cogs\wordfilter\testWordFilter.py .............                                                                                                    [100%]
```