### PR TITLE
[YOURLS] Bump `yourls-python` to 1.2.3

### DIFF
--- a/cogs/yourlsClient/info.json
+++ b/cogs/yourlsClient/info.json
@@ -4,7 +4,7 @@
     "short" : "Manage your YOURLS instance from Discord!",
     "description" : "This cog allows you to manage a YOURLS instance on a per-guild basis. It requires the `yourls-api-edit-url` and `yourls-api-delete` plugins to be install on your YOURLS instance.",
     "install_msg" : "Thanks for installing the YOURLS client. Before using this cog, be sure to install the `yourls-api-edit-url` and `yourls-api-delete` plugins on your YOURLS instance. Afterwards, please run [p]yourls to see all the relevant commands.",
-    "requirements" : ["git+https://github.com/Injabie3/yourls-python.git"],
+    "requirements" : ["git+https://github.com/Injabie3/yourls-python.git@1.2.3"],
     "tags" : ["url-shortener"],
     "permissions" : [],
     "end_user_data_statement": "This cog stores the API endpoint and signature in order to connect and authenticate to your YOURLS instance."


### PR DESCRIPTION
### Description of the changes
This PR fixes an issue where the `[p]yourls stats` command would error out. The root cause is in the call to YOURLS' `stats` method: when the `limit` value is more than the number of shorten URLs, it would raise a `KeyError`. This call is made by `cmdStats` in cog `yourlsClient` (which basically means `[p]yourls stats`) which always specifies a `limit` of 3.

This resolves #641 .

### Have the changes in this PR been tested?
Yes

### Testing
- Before
![image](https://user-images.githubusercontent.com/6710854/232260381-735abf99-f9e2-4001-bf96-c427b1ad17a4.png)
```
[17:20:28] ERROR    [red] Exception in command 'yourls stats'
╭─ Traceback (most recent call last)
<truncated>
│ /home/xxx/git/Ren/v3-data/cogs/Downloader/lib/yourls/core.py:162 in stats
│ ❱ 162                 links.append(_json_to_shortened_url(jsondata['links'][key]))
KeyError: 'link_2'
```
- After
![image](https://user-images.githubusercontent.com/6710854/232260391-0dca36b0-56ed-4e32-82e1-158a9b846c64.png)
