### PR TITLE
[YOURLS] Add `bot_has_permissions` to `[p]yourls settings sig`

### DIFF
--- a/cogs/yourlsClient/commandHandlers.py
+++ b/cogs/yourlsClient/commandHandlers.py
@@ -106,6 +106,7 @@ class CommandHandlers(CommandsCore):
         await self.cmdApi(ctx=ctx, apiEndpoint=apiEndpoint)
 
     @_grpSettingsBase.command(name="signature", aliases=["sig"])
+    @checks.bot_has_permissions(manage_messages=True)
     async def _cmdSig(self, ctx: Context, signature: str):
         """Configure the API signature for YOURLS.
 


### PR DESCRIPTION
### Description of the changes
The `[p]yourls settings sig` command will try to delete the invoking message, ensure that the bot has enough permissions to delete the message.

This PR fixes #640 

### Have the changes in this PR been tested?
Yes

### Testing
Took off the Manage Message permissions from the bot and ran the following:
![image](https://user-images.githubusercontent.com/6710854/232260612-51de0c17-93c4-4486-a575-2bdd8bcd5686.png)
