### PR TITLE
[VxTwit] Add per-guild toggle

### DIFF
--- a/cogs/vxtwitconverter/commandHandlers.py
+++ b/cogs/vxtwitconverter/commandHandlers.py
@@ -1,0 +1,20 @@
+from redbot.core import checks, commands
+from redbot.core.commands.context import Context
+
+from .commandsCore import CommandsCore
+
+
+class CommandHandlers(CommandsCore):
+    @commands.group(name="vxtwitter", aliases=["vxtwit"])
+    @checks.is_owner()
+    async def _grpVxTwit(self, ctx: Context):
+        """VxTwitter settings"""
+
+    @_grpVxTwit.command(name="toggle")
+    async def _cmdToggle(self, ctx: Context):
+        """Toggle VxTwitter replacements on the server
+
+        This will toggle the auto-reply of any Twitter links with embeds, and
+        replace them with VxTwitter.
+        """
+        await self.cmdToggle(ctx)

--- a/cogs/vxtwitconverter/commandsCore.py
+++ b/cogs/vxtwitconverter/commandsCore.py
@@ -1,0 +1,13 @@
+from redbot.core.commands.context import Context
+
+from .core import Core
+from .constants import KEY_ENABLED
+
+
+class CommandsCore(Core):
+    async def cmdToggle(self, ctx: Context):
+        enabled = not await self.config.guild(ctx.guild).get_attr(KEY_ENABLED)()
+        await self.config.guild(ctx.guild).get_attr(KEY_ENABLED).set(enabled)
+
+        status = "enabled" if enabled else "disabled"
+        await ctx.send(f"VxTwitter replacements are now {status}.")

--- a/cogs/vxtwitconverter/commandsCore.py
+++ b/cogs/vxtwitconverter/commandsCore.py
@@ -6,8 +6,9 @@ from .constants import KEY_ENABLED
 
 class CommandsCore(Core):
     async def cmdToggle(self, ctx: Context):
-        enabled = not await self.config.guild(ctx.guild).get_attr(KEY_ENABLED)()
-        await self.config.guild(ctx.guild).get_attr(KEY_ENABLED).set(enabled)
+        enabledCfg = self.config.guild(ctx.guild).get_attr(KEY_ENABLED)
+        enabled = not await enabledCfg()
+        await enabledCfg.set(enabled)
 
         status = "enabled" if enabled else "disabled"
         await ctx.send(f"VxTwitter replacements are now {status}.")

--- a/cogs/vxtwitconverter/constants.py
+++ b/cogs/vxtwitconverter/constants.py
@@ -1,0 +1,3 @@
+KEY_ENABLED = "enabled"
+
+DEFAULT_GUILD = {KEY_ENABLED: False}

--- a/cogs/vxtwitconverter/core.py
+++ b/cogs/vxtwitconverter/core.py
@@ -1,14 +1,19 @@
 import logging
 import os
 
-from redbot.core import data_manager
+from redbot.core import Config, data_manager
 from redbot.core.bot import Red
+
+from .constants import DEFAULT_GUILD
 
 
 class Core:
     def __init__(self, bot: Red):
         super().__init__()
         self.bot = bot
+
+        self.config = Config.get_conf(self, identifier=5842647, force_registration=True)
+        self.config.register_guild(**DEFAULT_GUILD)
 
         # Initialize logger, and save to cog folder.
         save_folder = data_manager.cog_data_path(cog_instance=self)

--- a/cogs/vxtwitconverter/eventsCore.py
+++ b/cogs/vxtwitconverter/eventsCore.py
@@ -1,6 +1,7 @@
 from discord import Message, channel
 from urlextract import URLExtract
 
+from .constants import KEY_ENABLED
 from .core import Core
 
 
@@ -12,6 +13,12 @@ class EventsCore(Core):
 
         # skips if message is in dm
         if isinstance(message.channel, channel.DMChannel):
+            return
+
+        if not await self.config.guild(message.guild).get_attr(KEY_ENABLED)():
+            self.logger.debug(
+                "VxTwit disabled for guild %s (%s), skipping", message.guild.name, message.guild.id
+            )
             return
 
         # skips if the message has no embeds

--- a/cogs/vxtwitconverter/vxtwitconverter.py
+++ b/cogs/vxtwitconverter/vxtwitconverter.py
@@ -1,9 +1,10 @@
 from redbot.core import commands
 
+from .commandHandlers import CommandHandlers
 from .eventHandlers import EventHandlers
 
 
-class VxTwitConverter(commands.Cog, EventHandlers):
+class VxTwitConverter(commands.Cog, CommandHandlers, EventHandlers):
     """Converts Twitter link to VxTwitter for better video embeds"""
 
     pass


### PR DESCRIPTION
This PR adds the ability to toggle the VxTwitter replacements on a per-guild basis. It requires the use of Config to store the enabled state, which is then used within the event handler.    

By default, it is disabled. It can be toggled by the guild admin using the `[p]vxtwit toggle` command.

# Screenshots
![Screenshot from 2023-06-17 00-17-10](https://github.com/SFUAnime/Ren/assets/6710854/5f101d1c-1feb-4f68-a189-d53eb10604a2)
