### PR TITLE
[Highlight] Escape time and username in DMs

### DIFF
--- a/cogs/highlight/highlight.py
+++ b/cogs/highlight/highlight.py
@@ -756,9 +756,7 @@ class Highlight(commands.Cog):
             # with <<spoilers>>
             if len(escapedMsg.split("\\|\\|")) > 2:
                 escapedMsg = "<<spoilers>>"
-            embedMsg += "[{0}] {1.author.name}#{1.author.discriminator}: {2}" "\n".format(
-                time, msg, escapedMsg
-            )
+            embedMsg += "`[{0}] {1}`: {2}\n".format(time, msg.author.name, escapedMsg)
             if self._isWordMatch(word, msg.content):
                 msgStillThere = True
         if not msgStillThere:


### PR DESCRIPTION
This tiny PR resolves #651 by escaping the username with backticks. In addition, it also escapes the time portion so that times line up nicely across the message playback preview.

# Screenshots
![image](https://github.com/SFUAnime/Ren/assets/6710854/5c46f5c1-e2da-4740-af50-7324e1014077)

