### PR TITLE
[VxTwit] Add `ddinstagram.com` replacements

### DIFF
--- a/cogs/vxtwitconverter/constants.py
+++ b/cogs/vxtwitconverter/constants.py
@@ -1,3 +1,10 @@
+import enum
+
 KEY_ENABLED = "enabled"
 
 DEFAULT_GUILD = {KEY_ENABLED: False}
+
+
+class SocialMedia(enum.Enum):
+    INSTAGRAM = "Instagram"
+    TWITTER = "Twitter"

--- a/cogs/vxtwitconverter/constants.py
+++ b/cogs/vxtwitconverter/constants.py
@@ -1,8 +1,8 @@
 import enum
 
 KEY_ENABLED = "enabled"
-
 DEFAULT_GUILD = {KEY_ENABLED: False}
+INSTA_REGEX_MATCH = r"https://(?:www\.)?(instagram.com)"
 
 
 class SocialMedia(enum.Enum):

--- a/cogs/vxtwitconverter/constants.py
+++ b/cogs/vxtwitconverter/constants.py
@@ -1,8 +1,9 @@
 import enum
+import re
 
 KEY_ENABLED = "enabled"
 DEFAULT_GUILD = {KEY_ENABLED: False}
-INSTA_REGEX_MATCH = r"https://(?:www\.)?(instagram.com)"
+INSTA_REGEX_PATTERN = re.compile(r"https://(?:www\.)?(instagram.com)")
 
 
 class SocialMedia(enum.Enum):

--- a/cogs/vxtwitconverter/eventHandlers.py
+++ b/cogs/vxtwitconverter/eventHandlers.py
@@ -14,3 +14,4 @@ class EventHandlers(EventsCore):
     @commands.Cog.listener("on_message_edit")
     async def twit_edit_replacer(self, message_before: Message, message_after):
         await self._on_edit_twit_replacer(message_before, message_after)
+        await self._on_edit_insta_replacer(message_before, message_after)

--- a/cogs/vxtwitconverter/eventHandlers.py
+++ b/cogs/vxtwitconverter/eventHandlers.py
@@ -9,6 +9,7 @@ class EventHandlers(EventsCore):
     @commands.Cog.listener("on_message")
     async def twit_replacer(self, message: Message):
         await self._on_message_twit_replacer(message)
+        await self._on_message_insta_replacer(message)
 
     @commands.Cog.listener("on_message_edit")
     async def twit_edit_replacer(self, message_before: Message, message_after):

--- a/cogs/vxtwitconverter/eventsCore.py
+++ b/cogs/vxtwitconverter/eventsCore.py
@@ -1,6 +1,6 @@
 from discord import Message
 
-from .constants import KEY_ENABLED
+from .constants import KEY_ENABLED, SocialMedia
 from .core import Core
 from .helpers import convert_to_vx_twitter_url, convert_to_ddinsta_url, urls_to_string, valid
 
@@ -23,7 +23,7 @@ class EventsCore(Core):
             return
 
         # constructs the message and replies with a mention
-        ok = await message.reply(urls_to_string(ddinsta_urls, "Instagram"))
+        ok = await message.reply(urls_to_string(ddinsta_urls, SocialMedia.INSTAGRAM))
 
         # Remove embeds from user message if reply is successful
         if ok:
@@ -55,7 +55,7 @@ class EventsCore(Core):
             return
 
         # constructs the message and replies with a mention
-        ok = await message_after.reply(urls_to_string(ddinsta_urls, "Instagram"))
+        ok = await message_after.reply(urls_to_string(ddinsta_urls, SocialMedia.INSTAGRAM))
 
         # Remove embeds from user message if reply is successful
         if ok:
@@ -79,7 +79,7 @@ class EventsCore(Core):
             return
 
         # constructs the message and replies with a mention
-        ok = await message.reply(urls_to_string(vx_twtter_urls))
+        ok = await message.reply(urls_to_string(vx_twtter_urls, SocialMedia.TWITTER))
 
         # Remove embeds from user message if reply is successful
         if ok:
@@ -115,7 +115,7 @@ class EventsCore(Core):
             return
 
         # constructs the message and replies with a mention
-        ok = await message_after.reply(urls_to_string(vx_twtter_urls))
+        ok = await message_after.reply(urls_to_string(vx_twtter_urls, SocialMedia.TWITTER))
 
         # Remove embeds from user message if reply is successful
         if ok:

--- a/cogs/vxtwitconverter/eventsCore.py
+++ b/cogs/vxtwitconverter/eventsCore.py
@@ -17,7 +17,6 @@ class EventsCore(Core):
             return
 
         ddinsta_urls = convert_to_ddinsta_url(message.embeds)
-        self.logger.debug("what is this %s", ddinsta_urls)
 
         if not ddinsta_urls:
             return

--- a/cogs/vxtwitconverter/eventsCore.py
+++ b/cogs/vxtwitconverter/eventsCore.py
@@ -2,7 +2,7 @@ from discord import Message
 
 from .constants import KEY_ENABLED, SocialMedia
 from .core import Core
-from .helpers import convert_to_vx_twitter_url, convert_to_ddinsta_url, urls_to_string, valid
+from .helpers import convert_to_ddinsta_url, convert_to_vx_twitter_url, urls_to_string, valid
 
 
 class EventsCore(Core):

--- a/cogs/vxtwitconverter/helpers.py
+++ b/cogs/vxtwitconverter/helpers.py
@@ -2,7 +2,7 @@ import re
 
 from discord import Embed, Message, channel
 
-from .constants import INSTA_REGEX_MATCH, SocialMedia
+from .constants import INSTA_REGEX_PATTERN, SocialMedia
 
 
 def convert_to_ddinsta_url(embeds: list[Embed]):
@@ -20,9 +20,9 @@ def convert_to_ddinsta_url(embeds: list[Embed]):
     urls = [entry.url for entry in embeds]
 
     ddinsta_urls = [
-        re.sub(INSTA_REGEX_MATCH, r"https://dd\1", result)
+        re.sub(INSTA_REGEX_PATTERN, r"https://dd\1", result)
         for result in urls
-        if re.match(INSTA_REGEX_MATCH, result)
+        if re.match(INSTA_REGEX_PATTERN, result)
     ]
 
     return ddinsta_urls

--- a/cogs/vxtwitconverter/helpers.py
+++ b/cogs/vxtwitconverter/helpers.py
@@ -2,6 +2,8 @@ import re
 
 from discord import Embed, Message, channel
 
+from .constants import SocialMedia
+
 
 def convert_to_ddinsta_url(embeds: list[Embed]):
     """
@@ -50,25 +52,23 @@ def convert_to_vx_twitter_url(embeds: list[Embed]):
     return vxtwitter_urls
 
 
-def urls_to_string(links: list[str], urlType: str = "Twitter"):
+def urls_to_string(links: list[str], socialMedia: SocialMedia):
     """
     Parameters
     ----------
     links: List[str]
         A list of urls
-    urlType: str
-        The URL type. Either Instagram or Twitter.
+    socialMedia: SocialMedia
+        The social media to replace.
 
     Returns
     -------
         Formatted output
     """
-    assert urlType in ["Twitter", "Instagram"]
-
     return "".join(
         [
             "OwO what's this?\n",
-            f"*notices your terrible {urlType} embeds*\n",
+            f"*notices your terrible {socialMedia.value} embeds*\n",
             "Here's a better alternative:\n",
             "\n".join(links),
         ]

--- a/cogs/vxtwitconverter/helpers.py
+++ b/cogs/vxtwitconverter/helpers.py
@@ -55,7 +55,7 @@ def urls_to_string(links: list[str], socialMedia: SocialMedia):
     """
     Parameters
     ----------
-    links: List[str]
+    links: list[str]
         A list of urls
     socialMedia: SocialMedia
         The social media to replace.
@@ -64,12 +64,12 @@ def urls_to_string(links: list[str], socialMedia: SocialMedia):
     -------
         Formatted output
     """
-    return "".join(
+    return "\n".join(
         [
-            "OwO what's this?\n",
-            f"*notices your terrible {socialMedia.value} embeds*\n",
-            "Here's a better alternative:\n",
-            "\n".join(links),
+            "OwO what's this?",
+            f"*notices your terrible {socialMedia.value} embeds*",
+            "Here's a better alternative:",
+            *links,
         ]
     )
 

--- a/cogs/vxtwitconverter/helpers.py
+++ b/cogs/vxtwitconverter/helpers.py
@@ -1,4 +1,30 @@
+import re
+
 from discord import Embed, Message, channel
+
+
+def convert_to_ddinsta_url(embeds: list[Embed]):
+    """
+    Parameters
+    ----------
+    embeds: list of discord embeds
+
+    Returns
+    -------
+        filtered list of Instagram URLs that have been converted to ddinstagram
+    """
+
+    # pulls only video embeds from list of embeds
+    urls = [entry.url for entry in embeds]
+
+    INSTA_REGEX_MATCH = r"https://(?:www\.)?(instagram.com)"
+    ddinsta_urls = [
+        re.sub(INSTA_REGEX_MATCH, r"https://dd\1", result)
+        for result in urls
+        if re.match(INSTA_REGEX_MATCH, result)
+    ]
+
+    return ddinsta_urls
 
 
 def convert_to_vx_twitter_url(embeds: list[Embed]):
@@ -24,23 +50,27 @@ def convert_to_vx_twitter_url(embeds: list[Embed]):
     return vxtwitter_urls
 
 
-def urls_to_string(vx_twit_links: list[str]):
+def urls_to_string(links: list[str], urlType: str = "Twitter"):
     """
     Parameters
     ----------
-    vx_twit_links: list of urls
+    links: List[str]
+        A list of urls
+    urlType: str
+        The URL type. Either Instagram or Twitter.
 
     Returns
     -------
         Formatted output
     """
+    assert urlType in ["Twitter", "Instagram"]
 
     return "".join(
         [
             "OwO what's this?\n",
-            "*notices your terrible twitter embeds*\n",
+            f"*notices your terrible {urlType} embeds*\n",
             "Here's a better alternative:\n",
-            "\n".join(vx_twit_links),
+            "\n".join(links),
         ]
     )
 
@@ -53,7 +83,7 @@ def valid(message: Message):
 
     Returns
     -------
-        True if the message is from a human in a guild and contains video embeds
+        True if the message is from a human in a guild and contains embeds
         False otherwise
     """
 
@@ -66,7 +96,7 @@ def valid(message: Message):
         return False
 
     # skips if the message has no embeds
-    if not any(embed.video for embed in message.embeds):
+    if not message.embeds:
         return False
 
     return True

--- a/cogs/vxtwitconverter/helpers.py
+++ b/cogs/vxtwitconverter/helpers.py
@@ -2,7 +2,7 @@ import re
 
 from discord import Embed, Message, channel
 
-from .constants import SocialMedia
+from .constants import INSTA_REGEX_MATCH, SocialMedia
 
 
 def convert_to_ddinsta_url(embeds: list[Embed]):
@@ -19,7 +19,6 @@ def convert_to_ddinsta_url(embeds: list[Embed]):
     # pulls only video embeds from list of embeds
     urls = [entry.url for entry in embeds]
 
-    INSTA_REGEX_MATCH = r"https://(?:www\.)?(instagram.com)"
     ddinsta_urls = [
         re.sub(INSTA_REGEX_MATCH, r"https://dd\1", result)
         for result in urls

--- a/cogs/vxtwitconverter/helpers.py
+++ b/cogs/vxtwitconverter/helpers.py
@@ -9,7 +9,7 @@ def convert_to_ddinsta_url(embeds: list[Embed]):
     """
     Parameters
     ----------
-    embeds: list of discord embeds
+    embeds: list of Discord embeds
 
     Returns
     -------
@@ -32,7 +32,7 @@ def convert_to_vx_twitter_url(embeds: list[Embed]):
     """
     Parameters
     ----------
-    embeds: list of discord embeds
+    embeds: list of Discord embeds
 
     Returns
     -------


### PR DESCRIPTION
This PR fixes #655 by adding event listeners to replace instagram.com links with ddinstagram.com. It is using the same toggle as VxTwit.

Since instagram.com embeds don't have videos or photos, we will need to replace all embeds. As such, the `valid` method was modified to not check for videos in embeds: this is deferred to a later check for the VxTwitter case.

This commit doesn't change the cog name; this will be done in a follow up.

# Screenshot
![image](https://github.com/SFUAnime/Ren/assets/6710854/5b2e0178-3193-4c2c-bd33-da401e751739)
