### PR TITLE
[SFU] Handle ConnectionError exception instead of MaxRetryError

### DIFF
--- a/cogs/sfu/roads.py
+++ b/cogs/sfu/roads.py
@@ -131,11 +131,14 @@ class SFURoads(SFUBase):
             fetchedData = self.httpRetrySession.get(camera, headers=self.headers)
             fetchedData.raise_for_status()
         except requests.exceptions.HTTPError:
-            await ctx.send(":warning: This webcam is currently unavailable!")
+            await ctx.send(
+                ":warning: This webcam is currently unavailable! Please try again later"
+            )
             # self.logger.error(exc_info=True)
             return
-        except requests.adapters.MaxRetryError:
-            await ctx.send(":warning: Unable to retrieve webcam image. Please try again.")
+        except requests.adapters.ConnectionError:
+            await ctx.send(":warning: Unable to retrieve webcam image! Please try again later.")
+            return
 
         if not fetchedData.content:
             # Make sure we don't fetch a zero byte file

--- a/cogs/sfu/roads.py
+++ b/cogs/sfu/roads.py
@@ -134,7 +134,6 @@ class SFURoads(SFUBase):
             await ctx.send(
                 ":warning: This webcam is currently unavailable! Please try again later."
             )
-            # self.logger.error(exc_info=True)
             return
         except requests.adapters.ConnectionError:
             await ctx.send(":warning: Unable to retrieve webcam image! Please try again later.")

--- a/cogs/sfu/roads.py
+++ b/cogs/sfu/roads.py
@@ -132,7 +132,7 @@ class SFURoads(SFUBase):
             fetchedData.raise_for_status()
         except requests.exceptions.HTTPError:
             await ctx.send(
-                ":warning: This webcam is currently unavailable! Please try again later"
+                ":warning: This webcam is currently unavailable! Please try again later."
             )
             # self.logger.error(exc_info=True)
             return


### PR DESCRIPTION
When we introduced retries in SFUAnime/Ren#591, we expected to handle the MaxRetryError exception. Instead, what appears to happen is the MaxRetryError exception block isn't hit, and instead, we get a chain of Exceptions that results in the underlying Exception being raised, which is a ConnectionError.

As such, this commit changes the MaxRetryError block to a ConnectionError block, thus returning a more descriptive message to the end user. An early return is also added to avoid a UnboundLocalError when trying to use fetchedData after the Exception was handled.

This addresses SFUAnime/Ren#663.