### PR TITLE
[Gatekeep] Restructuring of word and user commands. New commands to manually add and remove user IDs from the watch list

### DIFF
--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -445,6 +445,9 @@ class Gatekeep(commands.Cog):
             if member:
                 text = f"{member.name}#{member.discriminator} ({member.id})"
                 display.append(text)
+            else:
+                text = f"Unknown User ({id})"
+                display.append(text)
 
         # Check if the display list is empty
         if not display:
@@ -481,6 +484,7 @@ class Gatekeep(commands.Cog):
         current = datetime.now(timezone.utc)
         for guild in guilds:
             watchList = await self.config.guild(guild).get_attr(KEY_WATCH_LIST)()
+            wl = await self.config.guild(guild).get_attr(KEY_WATCH_LIST)()
             nDays = await self.config.guild(guild).get_attr(KEY_NEW_USER_DAYS)()
             for id in watchList:
                 member = discord.utils.get(guild.members, id=id)
@@ -491,7 +495,7 @@ class Gatekeep(commands.Cog):
                         or member.guild_permissions.administrator
                         or await self.bot.is_automod_immune(member)
                     ):
-                        watchList.remove(int(id))
+                        wl.remove(int(id))
                         self.logger.info(
                             "%s#%s (%s) removed from the watch list. (Trusted user)",
                             member.name,
@@ -500,12 +504,12 @@ class Gatekeep(commands.Cog):
                         )
                 else:
                     # Remove member if they are no longer in the server (can't log because of it being an id)
-                    watchList.remove(int(id))
+                    wl.remove(int(id))
                     self.logger.info(
                         "Member with id (%s) removed from the watch list. (Not in server)", id
                     )
 
-            await self.config.guild(guild).get_attr(KEY_WATCH_LIST).set(watchList)
+            await self.config.guild(guild).get_attr(KEY_WATCH_LIST).set(wl)
             self.logger.info("Refreshed the watch list for %s", guild.name)
 
     # The async function that is triggered on new member join.

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -12,7 +12,6 @@ from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils.chat_formatting import pagify, warning, escape
 from redbot.core.bot import Red
 from .constants import *
-from typing import Optional
 import string
 
 
@@ -197,7 +196,7 @@ class Gatekeep(commands.Cog):
     @_gatekeep.command(name="test", aliases=["eval", "score"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
-    async def testMsg(self, ctx: Context, *, msg: Optional[str] = None):
+    async def testMsg(self, ctx: Context, *, msg: str):
         """Evaluate the score for a given message
 
         Parameters:
@@ -205,31 +204,28 @@ class Gatekeep(commands.Cog):
         msg: str
             The message to evaluate the score, given that the word weights are defined.
         """
-        if msg:
-            async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
-                # Break down into words
-                words = msg.strip().split(" ")
-                th = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
-                score = 0
-                # Begin scoring
-                for word in words:
-                    # Remove any punctuation leftover in each word and lowercase all letters
-                    w = word.translate(str.maketrans("", "", string.punctuation)).lower()
+        async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
+            # Break down into words
+            words = msg.strip().split(" ")
+            th = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
+            score = 0
+            # Begin scoring
+            for word in words:
+                # Remove any punctuation leftover in each word and lowercase all letters
+                w = word.translate(str.maketrans("", "", string.punctuation)).lower()
 
-                    # If word is found, add to the message score
-                    if w in wordDict:
-                        score += wordDict[w]
+                # If word is found, add to the message score
+                if w in wordDict:
+                    score += wordDict[w]
 
-                if score >= th:
-                    judge = "this message would warrant a ban."
-                else:
-                    judge = "this message would not warrant a ban."
+            if score >= th:
+                judge = "this message would warrant a ban."
+            else:
+                judge = "this message would not warrant a ban."
 
-                await ctx.send(
-                    f"This message scored {score} points. With a threshold of {th}, {judge}"
-                )
-        else:
-            await ctx.send("No message to test!")
+            await ctx.send(
+                f"This message scored {score} points. With a threshold of {th}, {judge}"
+            )
 
     @word.command(name="add")
     @commands.guild_only()
@@ -413,25 +409,22 @@ class Gatekeep(commands.Cog):
             The user to be added to the watch list. This can be their username or ID.
         """
 
-        if user.id > 0:
-            watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
-            if user.id not in watchList:
-                watchList.append(int(user.id))
-                await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-                await ctx.send(f"Added user ID `{user.id}` to the watch list.")
+        watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
+        if user.id not in watchList:
+            watchList.append(int(user.id))
+            await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+            await ctx.send(f"Added user ID `{user.id}` to the watch list.")
 
-                self.logger.info(
-                    "%s#%s (%s) added user ID %s to the watch list for %s.",
-                    ctx.author.name,
-                    ctx.author.discriminator,
-                    ctx.author.id,
-                    user.id,
-                    ctx.guild.name,
+            self.logger.info(
+                "%s#%s (%s) added user ID %s to the watch list for %s.",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                user.id,
+                ctx.guild.name,
                 )
-            else:
-                await ctx.send(f"User ID `{user.id}` is already in the watch list.")
         else:
-            await ctx.send("Invalid user!")
+            await ctx.send(f"User ID `{user.id}` is already in the watch list.")
 
     @user.command(name="remove", aliases=["delete", "del", "rm"])
     @commands.guild_only()
@@ -445,25 +438,22 @@ class Gatekeep(commands.Cog):
             The user to be removed from the watch list. This can be their username or ID.
         """
 
-        if user.id > 0:
-            watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
-            if user.id in watchList:
-                watchList.remove(user.id)
-                await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-                await ctx.send(f"Removed user ID `{user.id}` to the watch list.")
+        watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
+        if user.id in watchList:
+            watchList.remove(user.id)
+            await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+            await ctx.send(f"Removed user ID `{user.id}` to the watch list.")
 
-                self.logger.info(
-                    "%s#%s (%s) removed user ID %s from the watch list for %s.",
-                    ctx.author.name,
-                    ctx.author.discriminator,
-                    ctx.author.id,
-                    user.id,
-                    ctx.guild.name,
-                )
-            else:
-                await ctx.send(f"User ID `{user.id}` is not in the watch list.")
+            self.logger.info(
+                "%s#%s (%s) removed user ID %s from the watch list for %s.",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                user.id,
+                ctx.guild.name,
+            )
         else:
-            await ctx.send("Invalid user!")
+            await ctx.send(f"User ID `{user.id}` is not in the watch list.")
 
     @user.command(name="list", aliases=["ls", "users"])
     @commands.guild_only()

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -60,11 +60,19 @@ class Gatekeep(commands.Cog):
     def cog_unload(self):
         self.__unload()
 
-    @commands.group(name="gatekeep")
+    @commands.group(name="gatekeep", aliases=["gk"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def _gatekeep(self, ctx: Context):
         """Automatically gatekeep accounts that post spam messages."""
+
+    @_gatekeep.group(name="word", aliases=["w"])
+    async def word(self, ctx):
+        """Commands relating to words to gatekeep."""
+
+    @_gatekeep.group(name="user", aliases=["u"])
+    async def user(self, ctx):
+        """Commands relating to users and the watch list."""
 
     @_gatekeep.command(name="channel", aliases=["ch"])
     @commands.guild_only()
@@ -151,53 +159,6 @@ class Gatekeep(commands.Cog):
         else:
             await ctx.send("The value for the days should be greater than 0!")
 
-    @_gatekeep.command(name="initialize", aliases=["init"])
-    @commands.guild_only()
-    @checks.mod_or_permissions(administrator=True)
-    async def initWatchList(self, ctx: Context):
-        """Initialize the list of user IDs to place on the watchlist.
-        Users that joined the server for less than X days will be placed on the watchlist. (X is configurable)
-        """
-
-        def check(msg: discord.Message):
-            return msg.author == ctx.author and msg.channel == ctx.channel
-
-        # Get confirmation before initializing. It loops through every member in a server, so it could take a while
-        await ctx.send(warning("This operation may take a while. Type 'yes' to confirm."))
-        try:
-            response = await self.bot.wait_for("message", timeout=30.0, check=check)
-        except asyncio.TimeoutError:
-            await ctx.send("No response after 30 seconds, this operation will not be executed.")
-            return
-
-        if response.content.lower() != "yes":
-            await ctx.send("This operation will not be executed.")
-            return
-
-        # Confirmed, so initialization process begins
-        start = time.time()
-        current = datetime.now(timezone.utc)
-        nDays = await self.config.guild(ctx.guild).get_attr(KEY_NEW_USER_DAYS)()
-        watchList = []
-        for member in ctx.guild.members:
-            # If a member has been in the server for less than X days, then they get added to the watch list (X is configurable)
-            if (
-                current - member.joined_at < timedelta(days=nDays)
-                and not member.guild_permissions.administrator
-                and not await self.bot.is_automod_immune(member)
-            ):
-                watchList.append(int(member.id))
-                self.logger.info(
-                    "%s#%s (%s) added to the watch list.",
-                    member.name,
-                    member.discriminator,
-                    member.id,
-                )
-        await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-
-        end = time.time() - start
-        await ctx.send(f"Operation took {end:.3f} seconds.")
-
     @_gatekeep.command(name="activate", aliases=["enable", "on"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
@@ -232,7 +193,7 @@ class Gatekeep(commands.Cog):
             f"- Threshold: {threshold}\n- Days to watch: {nDays}"
         )
 
-    @_gatekeep.command(name="add")
+    @word.command(name="add")
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def addWord(self, ctx: Context, word: str, weight: int):
@@ -286,7 +247,7 @@ class Gatekeep(commands.Cog):
                 "The word should be non-empty and/or the value for the weight should be greater than 0!"
             )
 
-    @_gatekeep.command(name="remove", aliases=["delete", "del"])
+    @word.command(name="remove", aliases=["delete", "del", "rm"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def removeWord(self, ctx: Context, word: str):
@@ -322,7 +283,7 @@ class Gatekeep(commands.Cog):
             # Empty string "" passed
             await ctx.send("The word should be a non-empty string!")
 
-    @_gatekeep.command(name="list", aliases=["ls", "words"])
+    @word.command(name="list", aliases=["ls", "words"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def listWords(self, ctx: Context):
@@ -355,7 +316,118 @@ class Gatekeep(commands.Cog):
             pageList.append(embed)
         await menu(ctx, pageList, DEFAULT_CONTROLS)
 
-    @_gatekeep.command(name="watchlist", aliases=["wl", "users"])
+    @user.command(name="initialize", aliases=["init"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def initWatchList(self, ctx: Context):
+        """Initialize the list of user IDs to place on the watchlist.
+        Users that joined the server for less than X days will be placed on the watchlist. (X is configurable)
+        """
+
+        def check(msg: discord.Message):
+            return msg.author == ctx.author and msg.channel == ctx.channel
+
+        # Get confirmation before initializing. It loops through every member in a server, so it could take a while
+        await ctx.send(warning("This operation may take a while. Type 'yes' to confirm."))
+        try:
+            response = await self.bot.wait_for("message", timeout=30.0, check=check)
+        except asyncio.TimeoutError:
+            await ctx.send("No response after 30 seconds, this operation will not be executed.")
+            return
+
+        if response.content.lower() != "yes":
+            await ctx.send("This operation will not be executed.")
+            return
+
+        # Confirmed, so initialization process begins
+        start = time.time()
+        current = datetime.now(timezone.utc)
+        nDays = await self.config.guild(ctx.guild).get_attr(KEY_NEW_USER_DAYS)()
+        watchList = []
+        for member in ctx.guild.members:
+            # If a member has been in the server for less than X days, then they get added to the watch list (X is configurable)
+            if (
+                current - member.joined_at < timedelta(days=nDays)
+                and not member.guild_permissions.administrator
+                and not await self.bot.is_automod_immune(member)
+            ):
+                watchList.append(int(member.id))
+                self.logger.info(
+                    "%s#%s (%s) added to the watch list.",
+                    member.name,
+                    member.discriminator,
+                    member.id,
+                )
+        await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+
+        end = time.time() - start
+        await ctx.send(f"Operation took {end:.3f} seconds.")
+
+    @user.command(name="add")
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def addUser(self, ctx: Context, id: int):
+        """Add a user to the watch list.
+
+        Parameters:
+        -----------
+        id: int
+            The user ID to be added to the watch list.
+        """
+
+        if id > 0:
+            watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
+            if id not in watchList:
+                watchList.append(int(id))
+                await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+                await ctx.send(f"Added user ID `{id}` to the watch list.")
+
+                self.logger.info(
+                    "%s#%s (%s) added user ID %s to the watch list for %s.",
+                    ctx.author.name,
+                    ctx.author.discriminator,
+                    ctx.author.id,
+                    id,
+                    ctx.guild.name,
+                )
+            else:
+                await ctx.send(f"User ID `{id}` is already in the watch list.")
+        else:
+            await ctx.send("The value for the user ID should be greater than 0!")
+
+    @user.command(name="remove", aliases=["delete", "del", "rm"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def removeUser(self, ctx: Context, id: int):
+        """Remove a user from the watch list.
+
+        Parameters:
+        -----------
+        id: int
+            The user ID to be removed from the watch list.
+        """
+
+        if id > 0:
+            watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
+            if id in watchList:
+                watchList.remove(int(id))
+                await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+                await ctx.send(f"Removed user ID `{id}` to the watch list.")
+
+                self.logger.info(
+                    "%s#%s (%s) removed user ID %s from the watch list for %s.",
+                    ctx.author.name,
+                    ctx.author.discriminator,
+                    ctx.author.id,
+                    id,
+                    ctx.guild.name,
+                )
+            else:
+                await ctx.send(f"User ID `{id}` is not in the watch list.")
+        else:
+            await ctx.send("The value for the user ID should be greater than 0!")
+
+    @user.command(name="list", aliases=["ls", "users"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def listWatch(self, ctx: Context):

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -415,7 +415,7 @@ class Gatekeep(commands.Cog):
 
         if user.id > 0:
             watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
-            if id not in watchList:
+            if user.id not in watchList:
                 watchList.append(int(user.id))
                 await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
                 await ctx.send(f"Added user ID `{user.id}` to the watch list.")

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -223,9 +223,7 @@ class Gatekeep(commands.Cog):
         else:
             judge = "this message would not warrant a ban."
 
-        await ctx.send(
-            f"This message scored {score} points. With a threshold of {th}, {judge}"
-        )
+        await ctx.send(f"This message scored {score} points. With a threshold of {th}, {judge}")
 
     @word.command(name="add")
     @commands.guild_only()

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -12,6 +12,7 @@ from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils.chat_formatting import pagify, warning, escape
 from redbot.core.bot import Red
 from .constants import *
+from typing import Optional
 import string
 
 
@@ -193,6 +194,41 @@ class Gatekeep(commands.Cog):
             f"- Threshold: {threshold}\n- Days to watch: {nDays}"
         )
 
+    @_gatekeep.command(name="test", aliases=["eval", "score"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def testMsg(self, ctx: Context, *, msg: Optional[str] = None):
+        """Evaluate the score for a given message
+
+        Parameters:
+        -----------
+        msg: str
+            The message to evaluate the score, given that the word weights are defined.
+        """
+        if msg:
+            async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
+                # Break down into words
+                words = msg.strip().split(" ")
+                th = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
+                score = 0
+                # Begin scoring
+                for word in words:
+                    # Remove any punctuation leftover in each word and lowercase all letters
+                    w = word.translate(str.maketrans("", "", string.punctuation)).lower()
+
+                    # If word is found, add to the message score
+                    if w in wordDict:
+                        score += wordDict[w]
+
+                if score >= th:
+                    judge = "this message would warrant a ban."
+                else:
+                    judge = "this message would not warrant a ban."
+
+                await ctx.send(f"This message scored {score} points. With a threhold of {th}, {judge}")
+        else:
+            await ctx.send("No message to test!")
+
     @word.command(name="add")
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
@@ -216,8 +252,8 @@ class Gatekeep(commands.Cog):
         # Sanitize word by removing all punctuation
         w = word.translate(str.maketrans("", "", string.punctuation)).lower()
 
-        # Ensure both the word is non-empty and the weight is greater than 0
-        if w and weight > 0:
+        # Ensure both the word is valid and the weight is greater than 0
+        if len(w.split()) == 1 and weight > 0:
             async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
                 update = False
                 prev = 0
@@ -242,9 +278,9 @@ class Gatekeep(commands.Cog):
                 )
 
         else:
-            # Empty string "" passed or the integer passed was not a positive value
+            # Invalid string or the integer passed was not a positive value
             await ctx.send(
-                "The word should be non-empty and/or the value for the weight should be greater than 0!"
+                "The word is invalid and/or the value for the weight should be greater than 0!"
             )
 
     @word.command(name="remove", aliases=["delete", "del", "rm"])
@@ -263,8 +299,8 @@ class Gatekeep(commands.Cog):
         # Sanitize word by removing all punctuation
         w = word.translate(str.maketrans("", "", string.punctuation)).lower()
 
-        # Ensure the word is non-empty
-        if w:
+        # Ensure the word is valid
+        if len(w.split()) == 1:
             async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
                 # Pop removes the item with key 'w' from the dictionary if it exists. Othewise it returns None
                 if wordDict.pop(w, None):
@@ -280,7 +316,7 @@ class Gatekeep(commands.Cog):
                     await ctx.send(f"`{w}` is not in the list.")
 
         else:
-            # Empty string "" passed
+            # Invalid string passed
             await ctx.send("The word should be a non-empty string!")
 
     @word.command(name="list", aliases=["ls", "words"])
@@ -305,7 +341,7 @@ class Gatekeep(commands.Cog):
 
         pageList = []
         msg = "\n".join(display)
-        pages = list(pagify(msg, page_length=300))
+        pages = list(pagify(msg, page_length=200))
         totalPages = len(pages)
         async for pageNumber, page in AsyncIter(pages).enumerate(start=1):
             embed = discord.Embed(
@@ -366,66 +402,66 @@ class Gatekeep(commands.Cog):
     @user.command(name="add")
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
-    async def addUser(self, ctx: Context, id: int):
+    async def addUser(self, ctx: Context, user: discord.User):
         """Add a user to the watch list.
 
         Parameters:
         -----------
-        id: int
-            The user ID to be added to the watch list.
+        user: User
+            The user to be added to the watch list. This can be their username or ID.
         """
 
-        if id > 0:
+        if user.id > 0:
             watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
             if id not in watchList:
-                watchList.append(int(id))
+                watchList.append(int(user.id))
                 await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-                await ctx.send(f"Added user ID `{id}` to the watch list.")
+                await ctx.send(f"Added user ID `{user.id}` to the watch list.")
 
                 self.logger.info(
                     "%s#%s (%s) added user ID %s to the watch list for %s.",
                     ctx.author.name,
                     ctx.author.discriminator,
                     ctx.author.id,
-                    id,
+                    user.id,
                     ctx.guild.name,
                 )
             else:
-                await ctx.send(f"User ID `{id}` is already in the watch list.")
+                await ctx.send(f"User ID `{user.id}` is already in the watch list.")
         else:
-            await ctx.send("The value for the user ID should be greater than 0!")
+            await ctx.send("Invalid user!")
 
     @user.command(name="remove", aliases=["delete", "del", "rm"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
-    async def removeUser(self, ctx: Context, id: int):
+    async def removeUser(self, ctx: Context, user: discord.User):
         """Remove a user from the watch list.
 
         Parameters:
         -----------
-        id: int
-            The user ID to be removed from the watch list.
+        user: User
+            The user to be removed from the watch list. This can be their username or ID.
         """
 
-        if id > 0:
+        if user.id > 0:
             watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
-            if id in watchList:
-                watchList.remove(int(id))
+            if user.id in watchList:
+                watchList.remove(user.id)
                 await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-                await ctx.send(f"Removed user ID `{id}` to the watch list.")
+                await ctx.send(f"Removed user ID `{user.id}` to the watch list.")
 
                 self.logger.info(
                     "%s#%s (%s) removed user ID %s from the watch list for %s.",
                     ctx.author.name,
                     ctx.author.discriminator,
                     ctx.author.id,
-                    id,
+                    user.id,
                     ctx.guild.name,
                 )
             else:
-                await ctx.send(f"User ID `{id}` is not in the watch list.")
+                await ctx.send(f"User ID `{user.id}` is not in the watch list.")
         else:
-            await ctx.send("The value for the user ID should be greater than 0!")
+            await ctx.send("Invalid user!")
 
     @user.command(name="list", aliases=["ls", "users"])
     @commands.guild_only()

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -204,28 +204,28 @@ class Gatekeep(commands.Cog):
         msg: str
             The message to evaluate the score, given that the word weights are defined.
         """
-        async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
-            # Break down into words
-            words = msg.strip().split(" ")
-            th = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
-            score = 0
-            # Begin scoring
-            for word in words:
-                # Remove any punctuation leftover in each word and lowercase all letters
-                w = word.translate(str.maketrans("", "", string.punctuation)).lower()
+        wordDict = await self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)()
+        # Break down into words
+        words = msg.strip().split(" ")
+        th = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
+        score = 0
+        # Begin scoring
+        for word in words:
+            # Remove any punctuation leftover in each word and lowercase all letters
+            w = word.translate(str.maketrans("", "", string.punctuation)).lower()
 
-                # If word is found, add to the message score
-                if w in wordDict:
-                    score += wordDict[w]
+            # If word is found, add to the message score
+            if w in wordDict:
+                score += wordDict[w]
 
-            if score >= th:
-                judge = "this message would warrant a ban."
-            else:
-                judge = "this message would not warrant a ban."
+        if score >= th:
+            judge = "this message would warrant a ban."
+        else:
+            judge = "this message would not warrant a ban."
 
-            await ctx.send(
-                f"This message scored {score} points. With a threshold of {th}, {judge}"
-            )
+        await ctx.send(
+            f"This message scored {score} points. With a threshold of {th}, {judge}"
+        )
 
     @word.command(name="add")
     @commands.guild_only()
@@ -409,22 +409,21 @@ class Gatekeep(commands.Cog):
             The user to be added to the watch list. This can be their username or ID.
         """
 
-        watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
-        if user.id not in watchList:
-            watchList.append(int(user.id))
-            await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-            await ctx.send(f"Added user ID `{user.id}` to the watch list.")
+        async with self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)() as watchList:
+            if user.id not in watchList:
+                watchList.append(int(user.id))
+                await ctx.send(f"Added user ID `{user.id}` to the watch list.")
 
-            self.logger.info(
-                "%s#%s (%s) added user ID %s to the watch list for %s.",
-                ctx.author.name,
-                ctx.author.discriminator,
-                ctx.author.id,
-                user.id,
-                ctx.guild.name,
-            )
-        else:
-            await ctx.send(f"User ID `{user.id}` is already in the watch list.")
+                self.logger.info(
+                    "%s#%s (%s) added user ID %s to the watch list for %s.",
+                    ctx.author.name,
+                    ctx.author.discriminator,
+                    ctx.author.id,
+                    user.id,
+                    ctx.guild.name,
+                )
+            else:
+                await ctx.send(f"User ID `{user.id}` is already in the watch list.")
 
     @user.command(name="remove", aliases=["delete", "del", "rm"])
     @commands.guild_only()
@@ -438,22 +437,21 @@ class Gatekeep(commands.Cog):
             The user to be removed from the watch list. This can be their username or ID.
         """
 
-        watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
-        if user.id in watchList:
-            watchList.remove(user.id)
-            await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-            await ctx.send(f"Removed user ID `{user.id}` to the watch list.")
+        async with self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)() as watchList:
+            if user.id in watchList:
+                watchList.remove(user.id)
+                await ctx.send(f"Removed user ID `{user.id}` to the watch list.")
 
-            self.logger.info(
-                "%s#%s (%s) removed user ID %s from the watch list for %s.",
-                ctx.author.name,
-                ctx.author.discriminator,
-                ctx.author.id,
-                user.id,
-                ctx.guild.name,
-            )
-        else:
-            await ctx.send(f"User ID `{user.id}` is not in the watch list.")
+                self.logger.info(
+                    "%s#%s (%s) removed user ID %s from the watch list for %s.",
+                    ctx.author.name,
+                    ctx.author.discriminator,
+                    ctx.author.id,
+                    user.id,
+                    ctx.guild.name,
+                )
+            else:
+                await ctx.send(f"User ID `{user.id}` is not in the watch list.")
 
     @user.command(name="list", aliases=["ls", "users"])
     @commands.guild_only()
@@ -511,49 +509,47 @@ class Gatekeep(commands.Cog):
         guilds = self.bot.guilds
         current = datetime.now(timezone.utc)
         for guild in guilds:
-            watchList = await self.config.guild(guild).get_attr(KEY_WATCH_LIST)()
-            wl = await self.config.guild(guild).get_attr(KEY_WATCH_LIST)()
-            nDays = await self.config.guild(guild).get_attr(KEY_NEW_USER_DAYS)()
-            for id in watchList:
-                member = discord.utils.get(guild.members, id=id)
-                if member:
-                    # Remove member from watch list if they have been in the server for over the required amount of days
-                    if (
-                        current - member.joined_at > timedelta(days=nDays)
-                        or member.guild_permissions.administrator
-                        or await self.bot.is_automod_immune(member)
-                    ):
-                        wl.remove(int(id))
+            watchListIterator = await self.config.guild(guild).get_attr(KEY_WATCH_LIST)()
+            async with self.config.guild(guild).get_attr(KEY_WATCH_LIST)() as watchList:
+                nDays = await self.config.guild(guild).get_attr(KEY_NEW_USER_DAYS)()
+                for id in watchListIterator:
+                    member = discord.utils.get(guild.members, id=id)
+                    if member:
+                        # Remove member from watch list if they have been in the server for over the required amount of days
+                        if (
+                            current - member.joined_at > timedelta(days=nDays)
+                            or member.guild_permissions.administrator
+                            or await self.bot.is_automod_immune(member)
+                        ):
+                            watchList.remove(int(id))
+                            self.logger.info(
+                                "%s#%s (%s) removed from the watch list. (Trusted user)",
+                                member.name,
+                                member.discriminator,
+                                member.id,
+                            )
+                    else:
+                        # Remove member if they are no longer in the server (can't log because of it being an id)
+                        watchList.remove(int(id))
                         self.logger.info(
-                            "%s#%s (%s) removed from the watch list. (Trusted user)",
-                            member.name,
-                            member.discriminator,
-                            member.id,
+                            "Member with id (%s) removed from the watch list. (Not in server)", id
                         )
-                else:
-                    # Remove member if they are no longer in the server (can't log because of it being an id)
-                    wl.remove(int(id))
-                    self.logger.info(
-                        "Member with id (%s) removed from the watch list. (Not in server)", id
-                    )
 
-            await self.config.guild(guild).get_attr(KEY_WATCH_LIST).set(wl)
-            self.logger.info("Refreshed the watch list for %s", guild.name)
+                self.logger.info("Refreshed the watch list for %s", guild.name)
 
     # The async function that is triggered on new member join.
     @commands.Cog.listener()
     async def on_member_join(self, newMember: discord.Member):
         # Add member to list, if they joined and aren't already on the list
-        watchList = await self.config.guild(newMember.guild).get_attr(KEY_WATCH_LIST)()
-        if int(newMember.id) not in watchList:
-            watchList.append(int(newMember.id))
-            self.logger.info(
-                "%s#%s (%s) added to the watch list.",
-                newMember.name,
-                newMember.discriminator,
-                newMember.id,
-            )
-            await self.config.guild(newMember.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+        async with self.config.guild(newMember.guild).get_attr(KEY_WATCH_LIST)() as watchList:
+            if int(newMember.id) not in watchList:
+                watchList.append(int(newMember.id))
+                self.logger.info(
+                    "%s#%s (%s) added to the watch list.",
+                    newMember.name,
+                    newMember.discriminator,
+                    newMember.id,
+                )
 
     # The async function that is triggered on any message being sent.
     @commands.Cog.listener()
@@ -583,13 +579,13 @@ class Gatekeep(commands.Cog):
             return
 
         # Check the list
-        watchList = await self.config.guild(message.guild).get_attr(KEY_WATCH_LIST)()
-        # Do nothing if the message author is not on the watch list to begin with
-        if int(author.id) not in watchList:
-            return
+        async with self.config.guild(message.guild).get_attr(KEY_WATCH_LIST)() as watchList:
+            # Do nothing if the message author is not on the watch list to begin with
+            if int(author.id) not in watchList:
+                return
 
-        # Evaluation of the message contents happen here
-        async with self.config.guild(message.guild).get_attr(KEY_WORD_DICT)() as wordDict:
+            # Evaluation of the message contents happen here
+            wordDict = await self.config.guild(message.guild).get_attr(KEY_WORD_DICT)()
             # Break down into words
             words = message.content.strip().split(" ")
             th = await self.config.guild(message.guild).get_attr(KEY_THRESHOLD)()
@@ -635,4 +631,9 @@ class Gatekeep(commands.Cog):
 
             # Remove the author from the watch list. Ban = gone from server, no ban = they're probably not a bot
             watchList.remove(int(author.id))
-            await self.config.guild(author.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+            self.logger.info(
+                "%s#%s (%s) removed from the watch list.",
+                author.name,
+                author.discriminator,
+                author.id,
+            )

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -225,7 +225,9 @@ class Gatekeep(commands.Cog):
                 else:
                     judge = "this message would not warrant a ban."
 
-                await ctx.send(f"This message scored {score} points. With a threhold of {th}, {judge}")
+                await ctx.send(
+                    f"This message scored {score} points. With a threshold of {th}, {judge}"
+                )
         else:
             await ctx.send("No message to test!")
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -12,7 +12,6 @@ from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils.chat_formatting import pagify, warning, escape
 from redbot.core.bot import Red
 from .constants import *
-from typing import Optional
 import string
 
 
@@ -197,7 +196,7 @@ class Gatekeep(commands.Cog):
     @_gatekeep.command(name="test", aliases=["eval", "score"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
-    async def testMsg(self, ctx: Context, *, msg: Optional[str] = None):
+    async def testMsg(self, ctx: Context, *, msg: str):
         """Evaluate the score for a given message
 
         Parameters:
@@ -205,31 +204,28 @@ class Gatekeep(commands.Cog):
         msg: str
             The message to evaluate the score, given that the word weights are defined.
         """
-        if msg:
-            async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
-                # Break down into words
-                words = msg.strip().split(" ")
-                th = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
-                score = 0
-                # Begin scoring
-                for word in words:
-                    # Remove any punctuation leftover in each word and lowercase all letters
-                    w = word.translate(str.maketrans("", "", string.punctuation)).lower()
+        async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
+            # Break down into words
+            words = msg.strip().split(" ")
+            th = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
+            score = 0
+            # Begin scoring
+            for word in words:
+                # Remove any punctuation leftover in each word and lowercase all letters
+                w = word.translate(str.maketrans("", "", string.punctuation)).lower()
 
-                    # If word is found, add to the message score
-                    if w in wordDict:
-                        score += wordDict[w]
+                # If word is found, add to the message score
+                if w in wordDict:
+                    score += wordDict[w]
 
-                if score >= th:
-                    judge = "this message would warrant a ban."
-                else:
-                    judge = "this message would not warrant a ban."
+            if score >= th:
+                judge = "this message would warrant a ban."
+            else:
+                judge = "this message would not warrant a ban."
 
-                await ctx.send(
-                    f"This message scored {score} points. With a threshold of {th}, {judge}"
-                )
-        else:
-            await ctx.send("No message to test!")
+            await ctx.send(
+                f"This message scored {score} points. With a threshold of {th}, {judge}"
+            )
 
     @word.command(name="add")
     @commands.guild_only()
@@ -413,25 +409,22 @@ class Gatekeep(commands.Cog):
             The user to be added to the watch list. This can be their username or ID.
         """
 
-        if user.id > 0:
-            watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
-            if id not in watchList:
-                watchList.append(int(user.id))
-                await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-                await ctx.send(f"Added user ID `{user.id}` to the watch list.")
+        watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
+        if user.id not in watchList:
+            watchList.append(int(user.id))
+            await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+            await ctx.send(f"Added user ID `{user.id}` to the watch list.")
 
-                self.logger.info(
-                    "%s#%s (%s) added user ID %s to the watch list for %s.",
-                    ctx.author.name,
-                    ctx.author.discriminator,
-                    ctx.author.id,
-                    user.id,
-                    ctx.guild.name,
-                )
-            else:
-                await ctx.send(f"User ID `{user.id}` is already in the watch list.")
+            self.logger.info(
+                "%s#%s (%s) added user ID %s to the watch list for %s.",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                user.id,
+                ctx.guild.name,
+            )
         else:
-            await ctx.send("Invalid user!")
+            await ctx.send(f"User ID `{user.id}` is already in the watch list.")
 
     @user.command(name="remove", aliases=["delete", "del", "rm"])
     @commands.guild_only()
@@ -445,25 +438,22 @@ class Gatekeep(commands.Cog):
             The user to be removed from the watch list. This can be their username or ID.
         """
 
-        if user.id > 0:
-            watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
-            if user.id in watchList:
-                watchList.remove(user.id)
-                await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
-                await ctx.send(f"Removed user ID `{user.id}` to the watch list.")
+        watchList = await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)()
+        if user.id in watchList:
+            watchList.remove(user.id)
+            await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set(watchList)
+            await ctx.send(f"Removed user ID `{user.id}` to the watch list.")
 
-                self.logger.info(
-                    "%s#%s (%s) removed user ID %s from the watch list for %s.",
-                    ctx.author.name,
-                    ctx.author.discriminator,
-                    ctx.author.id,
-                    user.id,
-                    ctx.guild.name,
-                )
-            else:
-                await ctx.send(f"User ID `{user.id}` is not in the watch list.")
+            self.logger.info(
+                "%s#%s (%s) removed user ID %s from the watch list for %s.",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                user.id,
+                ctx.guild.name,
+            )
         else:
-            await ctx.send("Invalid user!")
+            await ctx.send(f"User ID `{user.id}` is not in the watch list.")
 
     @user.command(name="list", aliases=["ls", "users"])
     @commands.guild_only()


### PR DESCRIPTION
### Changes
- Restructured commands relating to words and users. These have their own sub-command tree now.
- Added commands to manually add and remove user IDs to the watch list.
  - With this change, IDs on the watch list belonging to users not in the server are now shown in the watch list display command.
- Added an alias for gatekeep. You can now use either `[p]gatekeep` or `[p]gk`.

### Bug Fixes
- Fixed a bug in the daily refresh where every other user ID would be skipped over, due to the way the loop removed IDs in the list it was iterating.