### PR TITLE
[Gatekeep] Improve command QoL

### DIFF
--- a/cogs/gatekeep/constants.py
+++ b/cogs/gatekeep/constants.py
@@ -4,6 +4,7 @@ KEY_NEW_USER_DAYS = "newUserDays"
 KEY_ACTIVE = "active"
 KEY_WORD_DICT = "wordDict"
 KEY_WATCH_LIST = "watchList"
+KEY_BAN_COUNT = "banCount"
 
 BASE_GUILD = {
     KEY_LOG_CHANNEL: None,
@@ -12,4 +13,5 @@ BASE_GUILD = {
     KEY_ACTIVE: False,
     KEY_WORD_DICT: {},
     KEY_WATCH_LIST: [],
+    KEY_BAN_COUNT: 0,
 }

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -12,7 +12,6 @@ from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils.chat_formatting import pagify, warning, escape
 from redbot.core.bot import Red
 from .constants import *
-from typing import Optional
 import string
 
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -363,8 +363,9 @@ class Gatekeep(commands.Cog):
 
             numWords = len(wordDict)
 
-            if numWords < 1:
+            if not numWords:
                 await ctx.send("The word list is empty.")
+                return
             else:
                 # Get confirmation before clearing the word list
                 await ctx.send(
@@ -549,8 +550,9 @@ class Gatekeep(commands.Cog):
 
             numUsers = len(watchList)
 
-            if numUsers < 1:
+            if not numUsers:
                 await ctx.send("The watch list is empty.")
+                return
             else:
                 # Get confirmation before clearing the watch list
                 await ctx.send(

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -412,14 +412,14 @@ class Gatekeep(commands.Cog):
                 watchList.append(int(user.id))
                 await ctx.send(f"Added user ID `{user.id}` to the watch list.")
 
-            self.logger.info(
-                "%s#%s (%s) added user ID %s to the watch list for %s.",
-                ctx.author.name,
-                ctx.author.discriminator,
-                ctx.author.id,
-                user.id,
-                ctx.guild.name,
-            )
+                self.logger.info(
+                    "%s#%s (%s) added user ID %s to the watch list for %s.",
+                    ctx.author.name,
+                    ctx.author.discriminator,
+                    ctx.author.id,
+                    user.id,
+                    ctx.guild.name,
+                )
             else:
                 await ctx.send(f"User ID `{user.id}` is already in the watch list.")
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -412,14 +412,14 @@ class Gatekeep(commands.Cog):
                 watchList.append(int(user.id))
                 await ctx.send(f"Added user ID `{user.id}` to the watch list.")
 
-                self.logger.info(
-                    "%s#%s (%s) added user ID %s to the watch list for %s.",
-                    ctx.author.name,
-                    ctx.author.discriminator,
-                    ctx.author.id,
-                    user.id,
-                    ctx.guild.name,
-                )
+            self.logger.info(
+                "%s#%s (%s) added user ID %s to the watch list for %s.",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                user.id,
+                ctx.guild.name,
+            )
             else:
                 await ctx.send(f"User ID `{user.id}` is already in the watch list.")
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -357,20 +357,25 @@ class Gatekeep(commands.Cog):
         """Clears the entire word list for the server."""
 
         async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
+
             def check(msg: discord.Message):
                 return msg.author == ctx.author and msg.channel == ctx.channel
-            
+
             numWords = len(wordDict)
-            
+
             if numWords < 1:
                 await ctx.send("The word list is empty.")
             else:
                 # Get confirmation before clearing the word list
-                await ctx.send(warning(f"This will remove {numWords} word(s). Type 'yes' to confirm."))
+                await ctx.send(
+                    warning(f"This will remove {numWords} word(s). Type 'yes' to confirm.")
+                )
                 try:
                     response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
-                    await ctx.send("No response after 30 seconds, this operation will not be executed.")
+                    await ctx.send(
+                        "No response after 30 seconds, this operation will not be executed."
+                    )
                     return
 
                 if response.content.lower() != "yes":
@@ -538,20 +543,25 @@ class Gatekeep(commands.Cog):
         """Clears the entire user list for the server."""
 
         async with self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)() as watchList:
+
             def check(msg: discord.Message):
                 return msg.author == ctx.author and msg.channel == ctx.channel
-            
+
             numUsers = len(watchList)
-            
+
             if numUsers < 1:
                 await ctx.send("The watch list is empty.")
             else:
                 # Get confirmation before clearing the watch list
-                await ctx.send(warning(f"This will remove {numUsers} user(s). Type 'yes' to confirm."))
+                await ctx.send(
+                    warning(f"This will remove {numUsers} user(s). Type 'yes' to confirm.")
+                )
                 try:
                     response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
-                    await ctx.send("No response after 30 seconds, this operation will not be executed.")
+                    await ctx.send(
+                        "No response after 30 seconds, this operation will not be executed."
+                    )
                     return
 
                 if response.content.lower() != "yes":

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -12,6 +12,7 @@ from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils.chat_formatting import pagify, warning, escape
 from redbot.core.bot import Red
 from .constants import *
+from typing import Optional
 import string
 
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -187,10 +187,12 @@ class Gatekeep(commands.Cog):
         active = await self.config.guild(ctx.guild).get_attr(KEY_ACTIVE)()
         threshold = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
         nDays = await self.config.guild(ctx.guild).get_attr(KEY_NEW_USER_DAYS)()
+        banCount = await self.config.guild(ctx.guild).get_attr(KEY_BAN_COUNT)()
         await ctx.send(
             ":information_source: Current Status :information_source:\n"
             f"- Log Channel: <#{log}>\n- Gatekeeping: {active}\n"
-            f"- Threshold: {threshold}\n- Days to watch: {nDays}"
+            f"- Threshold: {threshold}\n- Days to watch: {nDays}\n"
+            f"- Total Users Banned: {banCount}"
         )
 
     @_gatekeep.command(name="test", aliases=["eval", "score"])
@@ -312,8 +314,8 @@ class Gatekeep(commands.Cog):
                     await ctx.send(f"`{w}` is not in the list.")
 
         else:
-            # Invalid string passed
-            await ctx.send("The word should be a non-empty string!")
+            # Invalid string passed (ie: "" or "a b")
+            await ctx.send("The word is invalid!")
 
     @word.command(name="list", aliases=["ls", "words"])
     @commands.guild_only()
@@ -323,11 +325,11 @@ class Gatekeep(commands.Cog):
 
         display = []  # List of text for paginator to use.  Will be constructed from KEY_WORD_DICT.
 
-        # Loop through the word dictionary object
+        # Loop through the word dictionary object in alphabetical order
         wordDict = await self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)()
-        for word, weight in wordDict.items():
+        for word in sorted(wordDict):
             # Construct the display list
-            text = f"{word}: {weight}"
+            text = f"{word}: {wordDict[word]}"
             display.append(text)
 
         # Check if the display list is empty
@@ -347,6 +349,44 @@ class Gatekeep(commands.Cog):
             embed.colour = discord.Colour.red()
             pageList.append(embed)
         await menu(ctx, pageList, DEFAULT_CONTROLS)
+
+    @word.command(name="clear", aliases=["reset"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def clearWords(self, ctx: Context):
+        """Clears the entire word list for the server."""
+
+        async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
+            def check(msg: discord.Message):
+                return msg.author == ctx.author and msg.channel == ctx.channel
+            
+            numWords = len(wordDict)
+            
+            if numWords < 1:
+                await ctx.send("The word list is empty.")
+            else:
+                # Get confirmation before clearing the word list
+                await ctx.send(warning(f"This will remove {numWords} word(s). Type 'yes' to confirm."))
+                try:
+                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
+                except asyncio.TimeoutError:
+                    await ctx.send("No response after 30 seconds, this operation will not be executed.")
+                    return
+
+                if response.content.lower() != "yes":
+                    await ctx.send("This operation will not be executed.")
+                    return
+
+        # Confirmed, clear the word list
+        await self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT).set({})
+        await ctx.send(":white_check_mark: Cleared the word list.")
+        self.logger.info(
+            "%s#%s (%s) cleared the word list for %s.",
+            ctx.author.name,
+            ctx.author.discriminator,
+            ctx.author.id,
+            ctx.guild.name,
+        )
 
     @user.command(name="initialize", aliases=["init"])
     @commands.guild_only()
@@ -491,6 +531,44 @@ class Gatekeep(commands.Cog):
             pageList.append(embed)
         await menu(ctx, pageList, DEFAULT_CONTROLS)
 
+    @user.command(name="clear", aliases=["reset"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def clearUsers(self, ctx: Context):
+        """Clears the entire user list for the server."""
+
+        async with self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)() as watchList:
+            def check(msg: discord.Message):
+                return msg.author == ctx.author and msg.channel == ctx.channel
+            
+            numUsers = len(watchList)
+            
+            if numUsers < 1:
+                await ctx.send("The watch list is empty.")
+            else:
+                # Get confirmation before clearing the watch list
+                await ctx.send(warning(f"This will remove {numUsers} user(s). Type 'yes' to confirm."))
+                try:
+                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
+                except asyncio.TimeoutError:
+                    await ctx.send("No response after 30 seconds, this operation will not be executed.")
+                    return
+
+                if response.content.lower() != "yes":
+                    await ctx.send("This operation will not be executed.")
+                    return
+
+        # Confirmed, clear the watch list
+        await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set([])
+        await ctx.send(":white_check_mark: Cleared the watch list.")
+        self.logger.info(
+            "%s#%s (%s) cleared the watch list for %s.",
+            ctx.author.name,
+            ctx.author.discriminator,
+            ctx.author.id,
+            ctx.guild.name,
+        )
+
     async def watchlistLoop(self):
         """Daily update loop to keep the watchlist small."""
         self.logger.info("Waiting for bot to be ready")
@@ -626,6 +704,9 @@ class Gatekeep(commands.Cog):
                     str(score),
                     str(th),
                 )
+
+                banCount = await self.config.guild(message.guild).get_attr(KEY_BAN_COUNT)()
+                await self.config.guild(message.guild).get_attr(KEY_BAN_COUNT).set(banCount + 1)
 
             # Remove the author from the watch list. Ban = gone from server, no ban = they're probably not a bot
             watchList.remove(int(author.id))


### PR DESCRIPTION
# Quality of Life Changes
### Word list display from _listWords_ now displays the words in alphabetical order
Currently, the word list is displayed by insertion order. As the word list grows, it will become more confusing to find a specific word in the list. So I changed the behaviour such that it will now display the words alphabetically.
Before:
![Screenshot_20250222_174704](https://github.com/user-attachments/assets/41e20c35-8f32-4478-b321-a93142babe95)
After:
![Screenshot_20250222_174725](https://github.com/user-attachments/assets/ef53987e-e048-4ebe-bda7-40674ea633ba)

### New commands to clear the word list and user watch list
- `[p]gatekeep word clear` or `[p]gatekeep word reset`
- `[p]gatekeep user clear` or `[p]gatekeep user reset`

These commands will require confirmation to use, just like _initWatchList_.

### New counter for the total number of users banned from the server
I wanted to keep track this stat. This counter will show up in the `[p]gatekeep status` command.

### Rewording of the message for invalid strings in _removeWord_
Currently, this would tell the user that the string cannot be empty, i.e. `""`. However, the command also rejects strings consisting of multiple words, i.e. `two words`. The message for invalid strings was updated to reflect this behaviour.