### PR TITLE
[Gatekeep] Added scoring for attachments in messages. Restructured setting commands into separate subcommand branch

### DIFF
--- a/cogs/gatekeep/constants.py
+++ b/cogs/gatekeep/constants.py
@@ -1,5 +1,6 @@
 KEY_LOG_CHANNEL = "logChannel"
 KEY_THRESHOLD = "threshold"
+KEY_ATTACHMENT_WEIGHT = "attachmentWeight"
 KEY_NEW_USER_DAYS = "newUserDays"
 KEY_ACTIVE = "active"
 KEY_WORD_DICT = "wordDict"
@@ -9,6 +10,7 @@ KEY_BAN_COUNT = "banCount"
 BASE_GUILD = {
     KEY_LOG_CHANNEL: None,
     KEY_THRESHOLD: 1000000,
+    KEY_ATTACHMENT_WEIGHT: 0,
     KEY_NEW_USER_DAYS: 14,
     KEY_ACTIVE: False,
     KEY_WORD_DICT: {},

--- a/cogs/gatekeep/constants.py
+++ b/cogs/gatekeep/constants.py
@@ -4,6 +4,7 @@ KEY_NEW_USER_DAYS = "newUserDays"
 KEY_ACTIVE = "active"
 KEY_WORD_DICT = "wordDict"
 KEY_WATCH_LIST = "watchList"
+KEY_BAN_COUNT = "banCount"
 
 BASE_GUILD = {
     KEY_LOG_CHANNEL: None,
@@ -12,4 +13,5 @@ BASE_GUILD = {
     KEY_ACTIVE: False,
     KEY_WORD_DICT: {},
     KEY_WATCH_LIST: [],
+    KEY_BAN_COUNT: 0,
 }

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -12,7 +12,6 @@ from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils.chat_formatting import pagify, warning, escape
 from redbot.core.bot import Red
 from .constants import *
-from typing import Optional
 import string
 
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -716,7 +716,9 @@ class Gatekeep(commands.Cog):
             # Break down into words
             words = message.content.strip().split(" ")
             th = await self.config.guild(message.guild).get_attr(KEY_THRESHOLD)()
-            attachmentWeight = await self.config.guild(message.guild).get_attr(KEY_ATTACHMENT_WEIGHT)()
+            attachmentWeight = await self.config.guild(message.guild).get_attr(
+                KEY_ATTACHMENT_WEIGHT
+            )()
 
             score = 0
             # Begin scoring

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -363,8 +363,9 @@ class Gatekeep(commands.Cog):
 
             numWords = len(wordDict)
 
-            if numWords < 1:
+            if not numWords:
                 await ctx.send("The word list is empty.")
+                return
             else:
                 # Get confirmation before clearing the word list
                 await ctx.send(
@@ -549,8 +550,9 @@ class Gatekeep(commands.Cog):
 
             numUsers = len(watchList)
 
-            if numUsers < 1:
+            if not numUsers:
                 await ctx.send("The watch list is empty.")
+                return
             else:
                 # Get confirmation before clearing the watch list
                 await ctx.send(

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -412,14 +412,14 @@ class Gatekeep(commands.Cog):
                 watchList.append(int(user.id))
                 await ctx.send(f"Added user ID `{user.id}` to the watch list.")
 
-            self.logger.info(
-                "%s#%s (%s) added user ID %s to the watch list for %s.",
-                ctx.author.name,
-                ctx.author.discriminator,
-                ctx.author.id,
-                user.id,
-                ctx.guild.name,
-            )
+                self.logger.info(
+                    "%s#%s (%s) added user ID %s to the watch list for %s.",
+                    ctx.author.name,
+                    ctx.author.discriminator,
+                    ctx.author.id,
+                    user.id,
+                    ctx.guild.name,
+                )
             else:
                 await ctx.send(f"User ID `{user.id}` is already in the watch list.")
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -66,6 +66,10 @@ class Gatekeep(commands.Cog):
     async def _gatekeep(self, ctx: Context):
         """Automatically gatekeep accounts that post spam messages."""
 
+    @_gatekeep.group(name="settings", aliases=["s", "set"])
+    async def settings(self, ctx):
+        """Commands relating to setting gatekeeping configurations."""
+
     @_gatekeep.group(name="word", aliases=["w"])
     async def word(self, ctx):
         """Commands relating to words to gatekeep."""
@@ -74,7 +78,7 @@ class Gatekeep(commands.Cog):
     async def user(self, ctx):
         """Commands relating to users and the watch list."""
 
-    @_gatekeep.command(name="channel", aliases=["ch"])
+    @settings.command(name="channel", aliases=["ch"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def setChannel(self, ctx: Context, channel: discord.TextChannel = None):
@@ -105,7 +109,7 @@ class Gatekeep(commands.Cog):
                 ":white_check_mark: **Gatekeep - Channel**: Moderation logs are now disabled."
             )
 
-    @_gatekeep.command(name="threshold", aliases=["th"])
+    @settings.command(name="threshold", aliases=["th"])
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def setThreshold(self, ctx: Context, threshold: int):
@@ -132,7 +136,36 @@ class Gatekeep(commands.Cog):
         else:
             await ctx.send("The value for the threshold should be greater than 0!")
 
-    @_gatekeep.command(name="days")
+    @settings.command(name="attachmentweight", aliases=["aw", "attachment", "attachments"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def setAttachmentWeight(self, ctx: Context, weight: int):
+        """Set the weight for how attachments in a message are scored.
+        Each attachment in a message will add this weight to the score when evaluating.
+
+        Parameters:
+        -----------
+        weight: int
+            Weight for which every attachment in a message will be scored.
+        """
+
+        if weight >= 0:
+            await self.config.guild(ctx.guild).get_attr(KEY_ATTACHMENT_WEIGHT).set(weight)
+            self.logger.info(
+                "%s#%s (%s) set the attachment weight to %s",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                str(weight),
+            )
+            await ctx.send(
+                f":white_check_mark: **Gatekeep - Attachment Weight**: "
+                f"The attachment weight has been updated to **{weight}**"
+            )
+        else:
+            await ctx.send("The value for the threshold should be greater than or equal to 0!")
+
+    @settings.command(name="days")
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def setDays(self, ctx: Context, days: int):
@@ -186,13 +219,14 @@ class Gatekeep(commands.Cog):
         log = await self.config.guild(ctx.guild).get_attr(KEY_LOG_CHANNEL)()
         active = await self.config.guild(ctx.guild).get_attr(KEY_ACTIVE)()
         threshold = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
+        attachmentWeight = await self.config.guild(ctx.guild).get_attr(KEY_ATTACHMENT_WEIGHT)()
         nDays = await self.config.guild(ctx.guild).get_attr(KEY_NEW_USER_DAYS)()
         banCount = await self.config.guild(ctx.guild).get_attr(KEY_BAN_COUNT)()
         await ctx.send(
             ":information_source: Current Status :information_source:\n"
             f"- Log Channel: <#{log}>\n- Gatekeeping: {active}\n"
-            f"- Threshold: {threshold}\n- Days to watch: {nDays}\n"
-            f"- Total Users Banned: {banCount}"
+            f"- Threshold: {threshold}\n- Attachment Weight: {attachmentWeight}\n"
+            f"- Days to Watch: {nDays}\n- Total Users Banned: {banCount}"
         )
 
     @_gatekeep.command(name="test", aliases=["eval", "score"])
@@ -210,6 +244,7 @@ class Gatekeep(commands.Cog):
         # Break down into words
         words = msg.strip().split(" ")
         th = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
+        attachmentWeight = await self.config.guild(ctx.guild).get_attr(KEY_ATTACHMENT_WEIGHT)()
         score = 0
         # Begin scoring
         for word in words:
@@ -219,6 +254,10 @@ class Gatekeep(commands.Cog):
             # If word is found, add to the message score
             if w in wordDict:
                 score += wordDict[w]
+
+        # Add the weight for each attachment in the message, if any.
+        nAttachments = len(ctx.message.attachments)
+        score += nAttachments * attachmentWeight
 
         if score >= th:
             judge = "this message would warrant a ban."
@@ -232,7 +271,7 @@ class Gatekeep(commands.Cog):
     @checks.mod_or_permissions(administrator=True)
     async def addWord(self, ctx: Context, word: str, weight: int):
         """Add a word to the gatekeeping list.
-        If the word already exists on the list,
+        If the word already exists in the list,
         then update the word weight to the new weight.
 
         Parameters:
@@ -321,7 +360,7 @@ class Gatekeep(commands.Cog):
     @commands.guild_only()
     @checks.mod_or_permissions(administrator=True)
     async def listWords(self, ctx: Context):
-        """Lists the words on the word list for the server."""
+        """Lists the words in the word list for the server."""
 
         display = []  # List of text for paginator to use.  Will be constructed from KEY_WORD_DICT.
 
@@ -677,6 +716,7 @@ class Gatekeep(commands.Cog):
             # Break down into words
             words = message.content.strip().split(" ")
             th = await self.config.guild(message.guild).get_attr(KEY_THRESHOLD)()
+            attachmentWeight = await self.config.guild(message.guild).get_attr(KEY_ATTACHMENT_WEIGHT)()
 
             score = 0
             # Begin scoring
@@ -687,6 +727,10 @@ class Gatekeep(commands.Cog):
                 # If word is found, add to the message score
                 if w in wordDict:
                     score += wordDict[w]
+
+            # Add the weight for each attachment in the message, if any.
+            nAttachments = len(message.attachments)
+            score += nAttachments * attachmentWeight
 
             # Determine if spam
             if score >= th:
@@ -705,6 +749,7 @@ class Gatekeep(commands.Cog):
                 await self.bot.get_channel(ch).send(
                     f"Banned {author.mention} `{author.id}` for posting spam. The message score was {score}, "
                     f"which exceeded the threshold of {th}. Their message was:```\n{escape(m, formatting=True)}\n```"
+                    f"This message contained {nAttachments} attachment(s).\n"
                 )
 
                 self.logger.info(

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -412,14 +412,14 @@ class Gatekeep(commands.Cog):
                 watchList.append(int(user.id))
                 await ctx.send(f"Added user ID `{user.id}` to the watch list.")
 
-                self.logger.info(
-                    "%s#%s (%s) added user ID %s to the watch list for %s.",
-                    ctx.author.name,
-                    ctx.author.discriminator,
-                    ctx.author.id,
-                    user.id,
-                    ctx.guild.name,
-                )
+            self.logger.info(
+                "%s#%s (%s) added user ID %s to the watch list for %s.",
+                ctx.author.name,
+                ctx.author.discriminator,
+                ctx.author.id,
+                user.id,
+                ctx.guild.name,
+            )
             else:
                 await ctx.send(f"User ID `{user.id}` is already in the watch list.")
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -357,20 +357,25 @@ class Gatekeep(commands.Cog):
         """Clears the entire word list for the server."""
 
         async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
+
             def check(msg: discord.Message):
                 return msg.author == ctx.author and msg.channel == ctx.channel
-            
+
             numWords = len(wordDict)
-            
+
             if numWords < 1:
                 await ctx.send("The word list is empty.")
             else:
                 # Get confirmation before clearing the word list
-                await ctx.send(warning(f"This will remove {numWords} word(s). Type 'yes' to confirm."))
+                await ctx.send(
+                    warning(f"This will remove {numWords} word(s). Type 'yes' to confirm.")
+                )
                 try:
                     response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
-                    await ctx.send("No response after 30 seconds, this operation will not be executed.")
+                    await ctx.send(
+                        "No response after 30 seconds, this operation will not be executed."
+                    )
                     return
 
                 if response.content.lower() != "yes":
@@ -538,20 +543,25 @@ class Gatekeep(commands.Cog):
         """Clears the entire user list for the server."""
 
         async with self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)() as watchList:
+
             def check(msg: discord.Message):
                 return msg.author == ctx.author and msg.channel == ctx.channel
-            
+
             numUsers = len(watchList)
-            
+
             if numUsers < 1:
                 await ctx.send("The watch list is empty.")
             else:
                 # Get confirmation before clearing the watch list
-                await ctx.send(warning(f"This will remove {numUsers} user(s). Type 'yes' to confirm."))
+                await ctx.send(
+                    warning(f"This will remove {numUsers} user(s). Type 'yes' to confirm.")
+                )
                 try:
                     response = await self.bot.wait_for("message", timeout=30.0, check=check)
                 except asyncio.TimeoutError:
-                    await ctx.send("No response after 30 seconds, this operation will not be executed.")
+                    await ctx.send(
+                        "No response after 30 seconds, this operation will not be executed."
+                    )
                     return
 
                 if response.content.lower() != "yes":

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -12,6 +12,7 @@ from redbot.core.utils.menus import DEFAULT_CONTROLS, menu
 from redbot.core.utils.chat_formatting import pagify, warning, escape
 from redbot.core.bot import Red
 from .constants import *
+from typing import Optional
 import string
 
 

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -93,7 +93,7 @@ class Gatekeep(commands.Cog):
         if channel:
             await self.config.guild(ctx.guild).get_attr(KEY_LOG_CHANNEL).set(channel.id)
             self.logger.info(
-                "%s#%s (%s) set the gatekeep logging channel to %s",
+                "%s#%s (%s) set the gatekeep logging channel to %s.",
                 ctx.author.name,
                 ctx.author.discriminator,
                 ctx.author.id,
@@ -124,14 +124,14 @@ class Gatekeep(commands.Cog):
         if threshold > 0:
             await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD).set(threshold)
             self.logger.info(
-                "%s#%s (%s) set the threshold to %s",
+                "%s#%s (%s) set the threshold to %d.",
                 ctx.author.name,
                 ctx.author.discriminator,
                 ctx.author.id,
-                str(threshold),
+                threshold,
             )
             await ctx.send(
-                f":white_check_mark: **Gatekeep - Threshold**: The threshold has been updated to **{threshold}**"
+                f":white_check_mark: **Gatekeep - Threshold**: The threshold has been updated to **{threshold}**."
             )
         else:
             await ctx.send("The value for the threshold should be greater than 0!")
@@ -152,15 +152,15 @@ class Gatekeep(commands.Cog):
         if weight >= 0:
             await self.config.guild(ctx.guild).get_attr(KEY_ATTACHMENT_WEIGHT).set(weight)
             self.logger.info(
-                "%s#%s (%s) set the attachment weight to %s",
+                "%s#%s (%s) set the attachment weight to %d.",
                 ctx.author.name,
                 ctx.author.discriminator,
                 ctx.author.id,
-                str(weight),
+                weight,
             )
             await ctx.send(
                 f":white_check_mark: **Gatekeep - Attachment Weight**: "
-                f"The attachment weight has been updated to **{weight}**"
+                f"The attachment weight has been updated to **{weight}**."
             )
         else:
             await ctx.send("The value for the threshold should be greater than or equal to 0!")
@@ -180,14 +180,14 @@ class Gatekeep(commands.Cog):
         if days > 0:
             await self.config.guild(ctx.guild).get_attr(KEY_NEW_USER_DAYS).set(days)
             self.logger.info(
-                "%s#%s (%s) set the number of days to %s",
+                "%s#%s (%s) set the number of days to %d.",
                 ctx.author.name,
                 ctx.author.discriminator,
                 ctx.author.id,
-                str(days),
+                days,
             )
             await ctx.send(
-                f":white_check_mark: **Gatekeep - Days**: The number of days has been updated to **{days}**"
+                f":white_check_mark: **Gatekeep - Days**: The number of days has been updated to **{days}**."
             )
         else:
             await ctx.send("The value for the days should be greater than 0!")
@@ -306,12 +306,12 @@ class Gatekeep(commands.Cog):
                     await ctx.send(f"Added the word `{w}` with a weight of **{weight}**.")
 
                 self.logger.info(
-                    "%s#%s (%s) added/updated %s with weight %s.",
+                    "%s#%s (%s) added/updated %s with weight %d.",
                     ctx.author.name,
                     ctx.author.discriminator,
                     ctx.author.id,
                     w,
-                    str(weight),
+                    weight,
                 )
 
         else:
@@ -622,9 +622,9 @@ class Gatekeep(commands.Cog):
 
     async def watchlistLoop(self):
         """Daily update loop to keep the watchlist small."""
-        self.logger.info("Waiting for bot to be ready")
+        self.logger.info("Waiting for bot to be ready...")
         await self.bot.wait_until_red_ready()
-        self.logger.info("Bot is ready")
+        self.logger.info("Bot is ready.")
         while self == self.bot.get_cog("Gatekeep"):
             if self.lastChecked.day != datetime.now().day:
                 self.lastChecked = datetime.now()
@@ -662,7 +662,7 @@ class Gatekeep(commands.Cog):
                             "Member with id (%s) removed from the watch list. (Not in server)", id
                         )
 
-                self.logger.info("Refreshed the watch list for %s", guild.name)
+                self.logger.info("Refreshed the watch list for %s.", guild.name)
 
     # The async function that is triggered on new member join.
     @commands.Cog.listener()
@@ -755,13 +755,13 @@ class Gatekeep(commands.Cog):
                 )
 
                 self.logger.info(
-                    "%s#%s (%s) was banned from %s for spam. Message score was %s, which exceed threshold of %s.",
+                    "%s#%s (%s) was banned from %s for spam. Message score was %d, which exceed threshold of %d.",
                     author.name,
                     author.discriminator,
                     author.id,
                     message.guild.name,
-                    str(score),
-                    str(th),
+                    score,
+                    th,
                 )
 
                 banCount = await self.config.guild(message.guild).get_attr(KEY_BAN_COUNT)()

--- a/cogs/gatekeep/gatekeep.py
+++ b/cogs/gatekeep/gatekeep.py
@@ -187,10 +187,12 @@ class Gatekeep(commands.Cog):
         active = await self.config.guild(ctx.guild).get_attr(KEY_ACTIVE)()
         threshold = await self.config.guild(ctx.guild).get_attr(KEY_THRESHOLD)()
         nDays = await self.config.guild(ctx.guild).get_attr(KEY_NEW_USER_DAYS)()
+        banCount = await self.config.guild(ctx.guild).get_attr(KEY_BAN_COUNT)()
         await ctx.send(
             ":information_source: Current Status :information_source:\n"
             f"- Log Channel: <#{log}>\n- Gatekeeping: {active}\n"
-            f"- Threshold: {threshold}\n- Days to watch: {nDays}"
+            f"- Threshold: {threshold}\n- Days to watch: {nDays}\n"
+            f"- Total Users Banned: {banCount}"
         )
 
     @_gatekeep.command(name="test", aliases=["eval", "score"])
@@ -312,8 +314,8 @@ class Gatekeep(commands.Cog):
                     await ctx.send(f"`{w}` is not in the list.")
 
         else:
-            # Invalid string passed
-            await ctx.send("The word should be a non-empty string!")
+            # Invalid string passed (ie: "" or "a b")
+            await ctx.send("The word is invalid!")
 
     @word.command(name="list", aliases=["ls", "words"])
     @commands.guild_only()
@@ -323,11 +325,11 @@ class Gatekeep(commands.Cog):
 
         display = []  # List of text for paginator to use.  Will be constructed from KEY_WORD_DICT.
 
-        # Loop through the word dictionary object
+        # Loop through the word dictionary object in alphabetical order
         wordDict = await self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)()
-        for word, weight in wordDict.items():
+        for word in sorted(wordDict):
             # Construct the display list
-            text = f"{word}: {weight}"
+            text = f"{word}: {wordDict[word]}"
             display.append(text)
 
         # Check if the display list is empty
@@ -347,6 +349,44 @@ class Gatekeep(commands.Cog):
             embed.colour = discord.Colour.red()
             pageList.append(embed)
         await menu(ctx, pageList, DEFAULT_CONTROLS)
+
+    @word.command(name="clear", aliases=["reset"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def clearWords(self, ctx: Context):
+        """Clears the entire word list for the server."""
+
+        async with self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT)() as wordDict:
+            def check(msg: discord.Message):
+                return msg.author == ctx.author and msg.channel == ctx.channel
+            
+            numWords = len(wordDict)
+            
+            if numWords < 1:
+                await ctx.send("The word list is empty.")
+            else:
+                # Get confirmation before clearing the word list
+                await ctx.send(warning(f"This will remove {numWords} word(s). Type 'yes' to confirm."))
+                try:
+                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
+                except asyncio.TimeoutError:
+                    await ctx.send("No response after 30 seconds, this operation will not be executed.")
+                    return
+
+                if response.content.lower() != "yes":
+                    await ctx.send("This operation will not be executed.")
+                    return
+
+        # Confirmed, clear the word list
+        await self.config.guild(ctx.guild).get_attr(KEY_WORD_DICT).set({})
+        await ctx.send(":white_check_mark: Cleared the word list.")
+        self.logger.info(
+            "%s#%s (%s) cleared the word list for %s.",
+            ctx.author.name,
+            ctx.author.discriminator,
+            ctx.author.id,
+            ctx.guild.name,
+        )
 
     @user.command(name="initialize", aliases=["init"])
     @commands.guild_only()
@@ -491,6 +531,44 @@ class Gatekeep(commands.Cog):
             pageList.append(embed)
         await menu(ctx, pageList, DEFAULT_CONTROLS)
 
+    @user.command(name="clear", aliases=["reset"])
+    @commands.guild_only()
+    @checks.mod_or_permissions(administrator=True)
+    async def clearUsers(self, ctx: Context):
+        """Clears the entire user list for the server."""
+
+        async with self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST)() as watchList:
+            def check(msg: discord.Message):
+                return msg.author == ctx.author and msg.channel == ctx.channel
+            
+            numUsers = len(watchList)
+            
+            if numUsers < 1:
+                await ctx.send("The watch list is empty.")
+            else:
+                # Get confirmation before clearing the watch list
+                await ctx.send(warning(f"This will remove {numUsers} user(s). Type 'yes' to confirm."))
+                try:
+                    response = await self.bot.wait_for("message", timeout=30.0, check=check)
+                except asyncio.TimeoutError:
+                    await ctx.send("No response after 30 seconds, this operation will not be executed.")
+                    return
+
+                if response.content.lower() != "yes":
+                    await ctx.send("This operation will not be executed.")
+                    return
+
+        # Confirmed, clear the watch list
+        await self.config.guild(ctx.guild).get_attr(KEY_WATCH_LIST).set([])
+        await ctx.send(":white_check_mark: Cleared the watch list.")
+        self.logger.info(
+            "%s#%s (%s) cleared the watch list for %s.",
+            ctx.author.name,
+            ctx.author.discriminator,
+            ctx.author.id,
+            ctx.guild.name,
+        )
+
     async def watchlistLoop(self):
         """Daily update loop to keep the watchlist small."""
         self.logger.info("Waiting for bot to be ready")
@@ -626,6 +704,9 @@ class Gatekeep(commands.Cog):
                     str(score),
                     str(th),
                 )
+
+                banCount = await self.config.guild(message.guild).get_attr(KEY_BAN_COUNT)()
+                await self.config.guild(message.guild).get_attr(KEY_BAN_COUNT).set(banCount + 1)
 
             # Remove the author from the watch list. Ban = gone from server, no ban = they're probably not a bot
             watchList.remove(int(author.id))


### PR DESCRIPTION
# Message Attachment Scoring and Settings Commands Restructuring
### Scoring for attachments in messages
From observing the behaviour of recent spam messages, I decided to add the option to score attachments in messages. There is a new configurable weight for attachments, called `attachmentweight`. For each attachment in the message, the score of the message increases by `attachmentweight`. By default, this is set to **0**.

To change the weight for attachments, use the following command or any of its aliases:
- `[p]gatekeep settings attachmentweight <weight>`
- `[p]gatekeep settings attachments <weight>`
- `[p]gatekeep settings attachment <weight>`
- `[p]gatekeep settings aw <weight>`

Below I have provided 3 ban examples, where the words "kitasan" and "black" both had weights of **12** and attachments had a weight of **6**:
<img width="1150" height="300" alt="attachment_test_1" src="https://github.com/user-attachments/assets/97f136b2-7519-4766-b7d8-d4ae0651d62b" />

I updated `[p]gatekeep test <message>` to support testing messages with attachments.
<img width="750" height="570" alt="attachment_test_2" src="https://github.com/user-attachments/assets/20c1fd6e-b14f-4f2c-b42e-36200cf1dfdc" />

### New subcommand tree for changing the settings
The base `[p]gatekeep <subcommand>` tree was getting cluttered, especially with the newly added `attachmentweight` setting. I moved 4 commands from the base subcommand tree into their own separate subcommand tree for a more organized subcommand structure.

This new subcommand tree is aptly named `settings`, with a few aliases for convenience:
- `[p]gatekeep settings <subcommand>`
- `[p]gatekeep set <subcommand>`
- `[p]gatekeep s <subcommand>`

The 4 commands that have been moved to this subcommand tree are: `attachmentweight`, `channel`, `days`, `threshold`, 

Before:
<img width="599" height="531" alt="settings_1" src="https://github.com/user-attachments/assets/3acc90ef-5002-4f7f-addd-4a616defe281" />

After:
<img width="640" height="517" alt="settings_2" src="https://github.com/user-attachments/assets/027bb69c-6ea3-4ea2-832e-4aad8120a2bc" />
<img width="614" height="474" alt="settings_3" src="https://github.com/user-attachments/assets/fa824a1c-4f33-4682-8bce-0aeee7ea6e70" />
